### PR TITLE
feat: redesign job detail header into structured container

### DIFF
--- a/docs/superpowers/plans/2026-04-08-job-detail-header-redesign.md
+++ b/docs/superpowers/plans/2026-04-08-job-detail-header-redesign.md
@@ -1,0 +1,802 @@
+# Job Detail Header Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize the job detail page header into a single structured container with title bar, poster, bordered metadata grid, panel toggle bar, and expanded panel content.
+
+**Architecture:** Replace the current loose layout (poster + title line + action bar + flat dl grid + separate toggle buttons) with one unified container. The container has 4 sections: title bar (title/badges/actions), poster+grid body, panel toggle bar, and expandable panel content. The metadata grid uses 4 columns with full cell borders, auto-padding empty cells.
+
+**Tech Stack:** Svelte 5, Tailwind CSS 4, existing component library (StatusBadge, JobActions, TitleSearch, etc.)
+
+**Spec:** `docs/superpowers/specs/2026-04-08-job-detail-header-redesign.md`
+
+---
+
+### Task 1: Create feature branch
+
+**Files:**
+- None (git only)
+
+- [ ] **Step 1: Create and switch to feature branch**
+
+```bash
+git checkout main
+git pull
+git checkout -b feat/job-detail-header-redesign
+```
+
+- [ ] **Step 2: Verify branch**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/job-detail-header-redesign`
+
+---
+
+### Task 2: Build the metadata field list helper
+
+**Files:**
+- Create: `frontend/src/lib/utils/job-fields.ts`
+- Test: `frontend/src/lib/__tests__/job-fields.test.ts`
+
+This helper computes the ordered list of metadata fields to display for any given job, based on type and state. Each field is a `{ label: string; value: string; mono?: boolean; link?: string; isSelect?: boolean }` object.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/lib/__tests__/job-fields.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { buildMetadataFields } from '$lib/utils/job-fields';
+import type { JobDetail } from '$lib/types/arm';
+
+function makeJob(overrides: Partial<JobDetail> = {}): JobDetail {
+	return {
+		job_id: 1, title: 'The Matrix', year: '1999', status: 'success',
+		video_type: 'movie', disctype: 'bluray', label: 'THE_MATRIX',
+		devpath: '/dev/sr0', source_type: 'disc', no_of_titles: 24,
+		start_time: '2026-04-07T22:26:00Z', stop_time: '2026-04-08T00:06:00Z',
+		job_length: '1:40:12', multi_title: false, crc_id: null, imdb_id: 'tt0133093',
+		path: '/home/arm/media/movies/The Matrix (1999)', raw_path: null,
+		transcode_path: null, disc_number: null, disc_total: null,
+		season: null, season_auto: null, tvdb_id: null,
+		artist: null, artist_auto: null, album: null, album_auto: null,
+		source_path: null, tracks: [], config: {},
+		arm_version: null, logfile: null, stage: null, errors: null,
+		mountpoint: null, hasnicetitle: null, poster_url: null,
+		poster_url_auto: null, poster_url_manual: null,
+		title_auto: null, title_manual: null, year_auto: null, year_manual: null,
+		video_type_auto: null, video_type_manual: null,
+		imdb_id_auto: null, imdb_id_manual: null,
+		artist_manual: null, album_manual: null,
+		season_manual: null, episode: null, episode_auto: null, episode_manual: null,
+		transcode_overrides: null, title_pattern_override: null, folder_pattern_override: null,
+		ejected: null, pid: null, manual_pause: null, wait_start_time: null,
+		tracks_total: null, tracks_ripped: null,
+	} as unknown as JobDetail;
+}
+
+describe('buildMetadataFields', () => {
+	it('returns correct fields for a completed movie', () => {
+		const fields = buildMetadataFields(makeJob());
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('Type');
+		expect(labels).toContain('Disc Type');
+		expect(labels).toContain('Title Mode');
+		expect(labels).toContain('Titles');
+		expect(labels).toContain('Label');
+		expect(labels).toContain('Device');
+		expect(labels).toContain('Source');
+		expect(labels).toContain('IMDb');
+		expect(labels).toContain('Started');
+		expect(labels).toContain('Finished');
+		expect(labels).toContain('Duration');
+		expect(labels).toContain('Output');
+		expect(labels).not.toContain('CRC');
+		expect(labels).not.toContain('Season');
+		expect(labels).not.toContain('Artist');
+	});
+
+	it('includes CRC only for DVD with crc_id', () => {
+		const fields = buildMetadataFields(makeJob({ disctype: 'dvd', crc_id: 'abc123' }));
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('CRC');
+	});
+
+	it('excludes CRC for bluray even with crc_id', () => {
+		const fields = buildMetadataFields(makeJob({ crc_id: 'abc123' }));
+		const labels = fields.map(f => f.label);
+		expect(labels).not.toContain('CRC');
+	});
+
+	it('includes Season and TVDB for series', () => {
+		const fields = buildMetadataFields(makeJob({ video_type: 'series', season: '1', tvdb_id: 81189 }));
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('Season');
+		expect(labels).toContain('TVDB');
+	});
+
+	it('includes Artist and Album for music, excludes Title Mode', () => {
+		const fields = buildMetadataFields(makeJob({
+			disctype: 'music', video_type: 'music',
+			artist: 'The Beatles', album: 'Abbey Road',
+		}));
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('Artist');
+		expect(labels).toContain('Album');
+		expect(labels).not.toContain('Title Mode');
+		expect(labels).not.toContain('IMDb');
+	});
+
+	it('shows Elapsed instead of Finished/Duration for active jobs', () => {
+		const fields = buildMetadataFields(makeJob({ status: 'ripping', stop_time: null, job_length: null }));
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('Elapsed');
+		expect(labels).not.toContain('Finished');
+		expect(labels).not.toContain('Duration');
+	});
+
+	it('includes disc number when present', () => {
+		const fields = buildMetadataFields(makeJob({ disc_number: 2, disc_total: 4 }));
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('Disc #');
+		const discField = fields.find(f => f.label === 'Disc #');
+		expect(discField?.value).toBe('2 of 4');
+	});
+
+	it('includes source path for folder imports', () => {
+		const fields = buildMetadataFields(makeJob({ source_type: 'folder', source_path: '/mnt/ingress/movies' }));
+		const labels = fields.map(f => f.label);
+		expect(labels).toContain('Source Path');
+	});
+
+	it('marks mono fields correctly', () => {
+		const fields = buildMetadataFields(makeJob());
+		const labelField = fields.find(f => f.label === 'Label');
+		expect(labelField?.mono).toBe(true);
+	});
+
+	it('marks IMDb as linked', () => {
+		const fields = buildMetadataFields(makeJob());
+		const imdbField = fields.find(f => f.label === 'IMDb');
+		expect(imdbField?.link).toContain('imdb.com');
+	});
+
+	it('pads fields to multiple of 4', () => {
+		const fields = buildMetadataFields(makeJob());
+		expect(fields.length % 4).toBe(0);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/lib/__tests__/job-fields.test.ts`
+Expected: FAIL - module not found
+
+- [ ] **Step 3: Write the implementation**
+
+Create `frontend/src/lib/utils/job-fields.ts`:
+
+```typescript
+import type { JobDetail } from '$lib/types/arm';
+import { formatDateTime, timeAgo } from '$lib/utils/format';
+import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
+
+export interface MetadataField {
+	label: string;
+	value: string;
+	mono?: boolean;
+	link?: string;
+	/** When true, this cell renders the Title Mode <select> instead of a text value */
+	isSelect?: boolean;
+	/** Empty placeholder cell for grid padding */
+	empty?: boolean;
+}
+
+export function buildMetadataFields(job: JobDetail): MetadataField[] {
+	const fields: MetadataField[] = [];
+	const active = isJobActive(job.status);
+	const isMusic = job.disctype === 'music' || job.video_type === 'music';
+	const isVideo = job.disctype === 'dvd' || job.disctype === 'bluray' || job.disctype === 'bluray4k';
+
+	// Type
+	if (!isMusic) {
+		fields.push({ label: 'Type', value: job.video_type ?? 'N/A' });
+	} else {
+		fields.push({ label: 'Type', value: 'Music' });
+	}
+
+	// Disc Type
+	fields.push({ label: 'Disc Type', value: discTypeLabel(job.disctype) });
+
+	// Title Mode (video only)
+	if (isVideo) {
+		fields.push({ label: 'Title Mode', value: job.multi_title ? 'multi' : 'single', isSelect: true });
+	}
+
+	// Titles
+	fields.push({ label: 'Titles', value: String(job.no_of_titles ?? 'N/A') });
+
+	// Season (series only)
+	const season = job.season || job.season_auto;
+	if (season && !isMusic) {
+		fields.push({ label: 'Season', value: String(season) });
+	}
+
+	// Disc # (multi-disc)
+	if (job.disc_number) {
+		const val = job.disc_total ? `${job.disc_number} of ${job.disc_total}` : String(job.disc_number);
+		fields.push({ label: 'Disc #', value: val });
+	}
+
+	// Artist / Album (music)
+	const artist = job.artist || job.artist_auto;
+	if (artist && isMusic) {
+		fields.push({ label: 'Artist', value: artist });
+	}
+	const album = job.album || job.album_auto;
+	if (album && isMusic) {
+		fields.push({ label: 'Album', value: album });
+	}
+
+	// Label
+	if (job.label) {
+		fields.push({ label: 'Label', value: job.label, mono: true });
+	}
+
+	// Device
+	if (job.devpath) {
+		fields.push({ label: 'Device', value: job.devpath });
+	}
+
+	// Source
+	fields.push({ label: 'Source', value: job.source_type === 'folder' ? 'Folder' : 'Disc' });
+
+	// Source Path (folder imports)
+	if (job.source_type === 'folder' && job.source_path) {
+		fields.push({ label: 'Source Path', value: job.source_path, mono: true });
+	}
+
+	// CRC (DVD only, when present)
+	if (job.crc_id && job.disctype === 'dvd') {
+		fields.push({ label: 'CRC', value: job.crc_id, mono: true });
+	}
+
+	// IMDb (video only, when present)
+	if (job.imdb_id && !isMusic) {
+		fields.push({ label: 'IMDb', value: job.imdb_id, link: `https://www.imdb.com/title/${job.imdb_id}/` });
+	}
+
+	// TVDB (series, when present)
+	if (job.tvdb_id && !isMusic) {
+		fields.push({ label: 'TVDB', value: String(job.tvdb_id), link: `https://thetvdb.com/?id=${job.tvdb_id}&tab=series` });
+	}
+
+	// Timing
+	fields.push({ label: 'Started', value: formatDateTime(job.start_time) });
+
+	if (active) {
+		fields.push({ label: 'Elapsed', value: job.start_time ? timeAgo(job.start_time) : 'N/A' });
+	} else {
+		if (job.stop_time) {
+			fields.push({ label: 'Finished', value: formatDateTime(job.stop_time) });
+		}
+		if (job.job_length) {
+			fields.push({ label: 'Duration', value: job.job_length });
+		}
+	}
+
+	// Paths
+	if (job.path) {
+		fields.push({ label: 'Output', value: job.path, mono: true });
+	}
+	if (job.raw_path) {
+		fields.push({ label: 'Raw', value: job.raw_path, mono: true });
+	}
+	if (job.transcode_path) {
+		fields.push({ label: 'Transcode', value: job.transcode_path, mono: true });
+	}
+
+	// Pad to multiple of 4
+	while (fields.length % 4 !== 0) {
+		fields.push({ label: '', value: '', empty: true });
+	}
+
+	return fields;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/lib/__tests__/job-fields.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/utils/job-fields.ts frontend/src/lib/__tests__/job-fields.test.ts
+git commit -m "feat: add buildMetadataFields helper for job detail header grid
+
+Computes ordered metadata field list based on job type and state.
+Handles video/music/series/folder variants, pads to 4-column grid.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Rewrite the header template
+
+**Files:**
+- Modify: `frontend/src/routes/jobs/[id]/+page.svelte` (lines 249-497)
+
+This is the main task. Replace everything from the back link through the panel content (but NOT the tracks table or debug section) with the new container structure.
+
+- [ ] **Step 1: Add the import for buildMetadataFields**
+
+At the top of the `<script>` section, add:
+
+```typescript
+import { buildMetadataFields } from '$lib/utils/job-fields';
+```
+
+And add a derived value after the existing derived values (around line 128):
+
+```typescript
+let metadataFields = $derived(job ? buildMetadataFields(job) : []);
+```
+
+- [ ] **Step 2: Replace the header section**
+
+Replace from `<!-- Back link -->` (line 252) through the closing `{/if}` of the active panel content (line 497) with the new container structure. Keep the `<!-- Auto vs Manual title info -->` banner and inline log feeds - move them outside and below the container.
+
+The new template (replaces lines 252-497):
+
+```svelte
+		<!-- Breadcrumb -->
+		<nav class="text-sm">
+			<a href="/" class="text-primary-text hover:underline dark:text-primary-text-dark">Dashboard</a>
+			<span class="mx-1.5 text-gray-400 dark:text-gray-500">&rsaquo;</span>
+			<span class="text-gray-500 dark:text-gray-400">{job.title || job.label || 'Untitled'}</span>
+		</nav>
+
+		<!-- Main header container -->
+		<div class="rounded-lg border border-primary/20 bg-surface shadow-xs dark:border-primary/20 dark:bg-surface-dark overflow-hidden">
+
+			<!-- Title bar -->
+			<div class="flex flex-wrap items-center gap-2 border-b border-primary/15 px-5 py-3 dark:border-primary/15">
+				<h1 class="text-xl font-bold text-gray-900 dark:text-white">
+					{job.title || job.label || 'Untitled'}
+				</h1>
+				{#if job.year && job.year !== '0000'}
+					<span class="text-base text-gray-400 dark:text-gray-500">({job.year})</span>
+				{/if}
+				<StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} />
+				{#if job.multi_title}
+					<span class="rounded-full bg-purple-100 px-2.5 py-0.5 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">Multi-Title</span>
+				{/if}
+				{#if job.imdb_id && !isMusicDisc}
+					<a
+						href="https://www.imdb.com/title/{job.imdb_id}"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="rounded-full bg-yellow-400 px-2.5 py-0.5 text-[10px] font-bold text-black"
+					>IMDb</a>
+				{/if}
+
+				<!-- Action buttons pushed right -->
+				<div class="flex flex-wrap items-center gap-2 ml-auto">
+					{#if isVideoDisc && (job.status === 'success' || job.status === 'fail')}
+						<button
+							onclick={handleRetranscode}
+							disabled={retranscoding}
+							class="rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400 dark:hover:bg-indigo-900/50"
+						>
+							{retranscoding ? 'Queuing...' : 'Re-transcode'}
+						</button>
+					{/if}
+					<JobActions {job} onaction={loadJob} ondelete={() => goto('/')} compact={false} />
+					{#if retranscodeFeedback}
+						<span class="text-xs {retranscodeFeedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
+							{retranscodeFeedback.message}
+						</span>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Poster + Metadata grid -->
+			<div class="flex items-start">
+				<!-- Poster -->
+				<div class="shrink-0 border-r border-primary/15 p-4 dark:border-primary/15">
+					{#if job.poster_url}
+						<img
+							src={posterSrc(job.poster_url)}
+							alt={job.title ?? 'Poster'}
+							class="rounded-md object-cover shadow-sm {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+							onerror={posterFallback}
+						/>
+					{:else}
+						<div
+							class="flex items-center justify-center rounded-md border border-dashed border-primary/20 bg-primary/5 dark:border-primary/15 dark:bg-primary/5 {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+						>
+							<svg class="h-8 w-8 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+								<circle cx="12" cy="12" r="10" />
+								<circle cx="12" cy="12" r="3" />
+							</svg>
+						</div>
+					{/if}
+				</div>
+
+				<!-- Metadata grid -->
+				<div class="flex-1 grid grid-cols-4">
+					{#each metadataFields as field, i}
+						{@const isLastRow = i >= metadataFields.length - 4}
+						{@const isRightEdge = (i + 1) % 4 === 0}
+						<div class="px-4 py-3 {!isLastRow ? 'border-b border-primary/15 dark:border-primary/15' : ''} {!isRightEdge ? 'border-r border-primary/15 dark:border-primary/15' : ''}">
+							{#if !field.empty}
+								<div class="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">{field.label}</div>
+								{#if field.isSelect}
+									<div class="mt-1">
+										<select
+											value={job.multi_title ? 'multi' : 'single'}
+											onchange={(e) => { const v = e.currentTarget.value; if ((v === 'multi') !== !!job?.multi_title) handleToggleMultiTitle(); }}
+											disabled={togglingMultiTitle}
+											class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+										>
+											<option value="single">Single Title</option>
+											<option value="multi">Multi-Title</option>
+										</select>
+									</div>
+								{:else if field.link}
+									<a href={field.link} target="_blank" rel="noopener noreferrer" class="mt-1 block text-sm font-medium text-primary hover:underline dark:text-primary {field.mono ? 'font-mono text-xs' : ''}">{field.value}</a>
+								{:else}
+									<div class="mt-1 text-sm font-medium text-gray-900 dark:text-white {field.mono ? 'font-mono text-xs truncate' : ''}" title={field.mono ? field.value : undefined}>{field.value}</div>
+								{/if}
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Panel toggle bar -->
+			<div class="flex border-t border-primary/15 bg-surface/50 dark:border-primary/15 dark:bg-surface-dark/50">
+				{#if isVideoDisc}
+					<button
+						onclick={() => (activePanel = activePanel === 'title' ? null : 'title')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'title' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Identify</button>
+				{/if}
+				{#if isMusicDisc}
+					<button
+						onclick={() => (activePanel = activePanel === 'music' ? null : 'music')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'music' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Search Music</button>
+				{/if}
+				{#if job.config}
+					<button
+						onclick={() => (activePanel = activePanel === 'rip' ? null : 'rip')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'rip' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Rip Settings</button>
+				{/if}
+				{#if isVideoDisc && (job.video_type === 'series' || job.imdb_id)}
+					<button
+						onclick={() => (activePanel = activePanel === 'tvdb' ? null : 'tvdb')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'tvdb' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Episodes</button>
+				{/if}
+				{#if isVideoDisc}
+					<button
+						onclick={() => (activePanel = activePanel === 'transcode' ? null : 'transcode')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'transcode' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Transcode Settings</button>
+				{/if}
+				{#if hasCrcData}
+					<button
+						onclick={() => (activePanel = activePanel === 'crc' ? null : 'crc')}
+						class="flex-1 px-4 py-2.5 text-center text-sm font-medium transition-colors {activePanel === 'crc' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>CRC Lookup</button>
+				{/if}
+			</div>
+
+			<!-- Active panel content -->
+			{#if activePanel === 'title'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<TitleSearch {job} onapply={handleTitleApply} />
+				</div>
+			{:else if activePanel === 'music'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<MusicSearch {job} onapply={handleTitleApply} />
+				</div>
+			{:else if activePanel === 'crc'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<CrcLookup {job} onapply={loadJob} />
+				</div>
+			{:else if activePanel === 'rip'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<RipSettings {job} config={job.config!} isMusic={isMusicDisc} multiTitle={!!job.multi_title} onsaved={handleConfigSaved} />
+				</div>
+			{:else if activePanel === 'tvdb'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<EpisodeMatch {job} onapply={loadJob} />
+				</div>
+			{:else if activePanel === 'transcode'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<TranscodeOverrides {job} onsaved={loadJob} />
+				</div>
+			{/if}
+		</div>
+
+		<!-- Auto vs Manual title info (outside container) -->
+		{#if hasAutoManualDiff}
+			<div class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm dark:border-amber-800 dark:bg-amber-900/20">
+				<svg class="h-4 w-4 shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+				</svg>
+				<span class="text-amber-800 dark:text-amber-300">
+					Auto-detected: <span class="font-medium">{job.title_auto}{#if job.year_auto} ({job.year_auto}){/if}</span>
+				</span>
+			</div>
+		{/if}
+
+		{#if job.errors}
+			<div class="rounded-lg border p-3 text-sm {job.status === 'success'
+				? 'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400'
+				: 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400'}">
+				<strong>{job.status === 'success' ? 'Warnings:' : 'Errors:'}</strong> {job.errors}
+			</div>
+		{/if}
+
+		{#if job.logfile}
+			<InlineLogFeed logfile={job.logfile} maxEntries={15} title="ARM Ripper Log" />
+		{/if}
+		{#if transcoderLogfile && !isMusicDisc && job?.disctype !== 'data' && job?.status !== 'ripping' && job?.status !== 'ready' && job?.status !== 'identifying' && job?.status !== 'waiting'}
+			<InlineLogFeed
+				logfile={transcoderLogfile}
+				maxEntries={15}
+				title="Transcoder Log"
+				fetchFn={fetchStructuredTranscoderLogContent}
+				logLinkBase="/logs/transcoder"
+			/>
+		{/if}
+```
+
+- [ ] **Step 3: Verify the dev server renders correctly**
+
+Run: Visit http://localhost:5174/jobs/1 in the browser
+Expected: The Matrix job shows the new container layout with title bar, poster, 4-col grid, and panel toggle bar
+
+- [ ] **Step 4: Check multiple job types render**
+
+Visit:
+- http://localhost:5174/jobs/4 (series - Breaking Bad)
+- http://localhost:5174/jobs/9 (music - Abbey Road)
+- http://localhost:5174/jobs/8 (waiting - Mystery Disc)
+- http://localhost:5174/jobs/11 (waiting with IMDb - Dark Knight)
+
+Expected: Each shows appropriate fields, no empty grids, panel bar adapts to job type
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/routes/jobs/[id]/+page.svelte
+git commit -m "feat: redesign job detail header into structured container
+
+Single container with title bar (badges + actions), poster + 4-col
+bordered metadata grid, and panel toggle bar. Fields adapt by job type.
+Replaces flat layout with settings-page styling patterns.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update the JobActions button styling to pill
+
+**Files:**
+- Modify: `frontend/src/lib/components/JobActions.svelte` (line 97-101)
+
+The action buttons need to use pill styling (`rounded-full`) to match the title bar context.
+
+- [ ] **Step 1: Update the btnBase derived value**
+
+In `JobActions.svelte`, change the `btnBase` derived value (line 97-101) from:
+
+```typescript
+let btnBase = $derived(
+	compact
+		? 'rounded px-2 py-0.5 text-xs font-medium disabled:opacity-50 transition-colors'
+		: 'rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 transition-colors'
+);
+```
+
+to:
+
+```typescript
+let btnBase = $derived(
+	compact
+		? 'rounded px-2 py-0.5 text-xs font-medium disabled:opacity-50 transition-colors'
+		: 'rounded-full px-3 py-1.5 text-xs font-medium disabled:opacity-50 transition-colors'
+);
+```
+
+Changes: `rounded-lg` to `rounded-full`, `text-sm` to `text-xs`.
+
+- [ ] **Step 2: Add outline borders to destructive buttons**
+
+Update the Delete button class (line 128) from:
+
+```svelte
+class="{btnBase} bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+```
+
+to:
+
+```svelte
+class="{btnBase} bg-red-100 text-red-700 ring-1 ring-red-200 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:ring-red-800 dark:hover:bg-red-900/50"
+```
+
+Update the Purge button class (line 137) from:
+
+```svelte
+class="{btnBase} bg-orange-100 text-orange-700 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:hover:bg-orange-900/50"
+```
+
+to:
+
+```svelte
+class="{btnBase} bg-orange-100 text-orange-700 ring-1 ring-orange-200 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:ring-orange-800 dark:hover:bg-orange-900/50"
+```
+
+Update the Fix Permissions button class (line 119) from:
+
+```svelte
+class="{btnBase} bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+```
+
+to:
+
+```svelte
+class="{btnBase} bg-blue-100 text-blue-700 ring-1 ring-blue-200 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-800 dark:hover:bg-blue-900/50"
+```
+
+- [ ] **Step 3: Verify buttons render as pills**
+
+Visit: http://localhost:5174/jobs/1
+Expected: Action buttons in title bar are pill-shaped with outlined destructive buttons
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/components/JobActions.svelte
+git commit -m "fix: update JobActions buttons to pill style with outlined destructive actions
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update existing tests
+
+**Files:**
+- Modify: `frontend/src/routes/jobs/__tests__/job-detail-page.test.ts`
+
+The existing tests check for elements that moved (e.g., status text, disc type). Update them to work with the new layout.
+
+- [ ] **Step 1: Update mock to include fields needed by buildMetadataFields**
+
+In the mock `fetchJob` return value (line 15-25), add missing fields:
+
+```typescript
+fetchJob: vi.fn(() => Promise.resolve({
+	job_id: 1, title: 'Test Movie', status: 'success', video_type: 'movie',
+	year: '2024', disctype: 'bluray', label: 'TEST_MOVIE', start_time: '2025-06-15T10:00:00Z',
+	stop_time: '2025-06-15T11:00:00Z', job_length: '1h 0m', devpath: '/dev/sr0',
+	imdb_id: 'tt1234567', poster_url: null, errors: null, stage: null,
+	no_of_titles: 3, logfile: 'job_1.log', crc_id: 'abc123', multi_title: false,
+	source_type: 'disc', source_path: null, path: null, raw_path: null, transcode_path: null,
+	disc_number: null, disc_total: null, season: null, season_auto: null, tvdb_id: null,
+	artist: null, artist_auto: null, album: null, album_auto: null,
+	tracks: [
+		{ track_id: 1, job_id: 1, track_number: '1', length: 7200, aspect_ratio: '16:9', fps: 24, enabled: true, basename: 'title_01', filename: 'title_01.mkv', orig_filename: 'title_01.mkv', new_filename: null, ripped: true, status: 'success', error: null, source: null, title: null, year: null, imdb_id: null, poster_url: null, video_type: null, episode_number: null, episode_name: null, custom_filename: null }
+	],
+	config: {}
+})),
+```
+
+- [ ] **Step 2: Update the breadcrumb test expectation**
+
+The "Back to Dashboard" link is now a breadcrumb. The existing tests should still pass since they check for title, status badge, and disc type which are still rendered. Add a breadcrumb test:
+
+```typescript
+it('renders breadcrumb navigation', async () => {
+	renderComponent(JobDetailPage);
+	await waitFor(() => {
+		expect(screen.getByText('Dashboard')).toBeInTheDocument();
+	});
+});
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/routes/jobs/__tests__/job-detail-page.test.ts
+git commit -m "test: update job detail page tests for header redesign
+
+Add missing mock fields for buildMetadataFields, add breadcrumb test.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Remove the Log button reference from home page transcoder fix
+
+**Files:**
+- Verify: `frontend/src/routes/+page.svelte`
+
+- [ ] **Step 1: Verify the transcoder layout fix from earlier is still in place**
+
+Check that the transcoder section on the home page uses `space-y-2` not the grid layout:
+
+```bash
+cd frontend && grep -n "space-y-2" src/routes/+page.svelte | head -5
+```
+
+Expected: The active transcodes section should show `space-y-2`
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd frontend && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit any remaining changes**
+
+Only commit if there are uncommitted changes from the transcoder fix:
+
+```bash
+git add frontend/src/routes/+page.svelte
+git commit -m "fix: use full-width row layout for transcoder cards on home page
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Final verification and cleanup
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd frontend && npx vitest run`
+Expected: All tests pass, no regressions
+
+- [ ] **Step 2: Visual verification across job types**
+
+Visit each job type in the browser and verify:
+- http://localhost:5174/jobs/1 (movie, success) - 4-col grid, poster, all fields
+- http://localhost:5174/jobs/4 (series, transcoding) - has Title Mode select
+- http://localhost:5174/jobs/9 (music) - no Title Mode, shows Artist/Album if present
+- http://localhost:5174/jobs/8 (waiting, unidentified) - minimal fields, empty padded cells
+- http://localhost:5174/jobs/11 (waiting, identified) - IMDb badge and field
+- http://localhost:5174/jobs/2 (DVD, success) - CRC field and CRC Lookup panel button
+
+- [ ] **Step 3: Verify panel toggles work**
+
+Click each panel button and confirm content expands within the container. Click again to collapse.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/job-detail-header-redesign
+```

--- a/docs/superpowers/specs/2026-04-08-job-detail-header-redesign.md
+++ b/docs/superpowers/specs/2026-04-08-job-detail-header-redesign.md
@@ -1,0 +1,193 @@
+# Job Detail Header Redesign
+
+## Overview
+
+Reorganize the top of the job detail page (`/jobs/[id]`) into a single structured container with clear visual grouping. Drawing styling cues from the settings page (bordered containers, grid lines, consistent input styling).
+
+## Layout Structure
+
+One container with four vertical sections:
+
+```
++------------------------------------------------------------------+
+| Title Bar: Title (Year)  badges...     [action buttons -->]      |
++------------------------------------------------------------------+
+| Poster |  4-col metadata grid with full cell borders             |
+| (2:3)  |  (rows/cols adapt to field count)                       |
+|        |                                                          |
++------------------------------------------------------------------+
+| Panel toggle bar: Identify | Rip Settings | Transcode | CRC | Debug |
++------------------------------------------------------------------+
+| (expanded panel content, if any panel is active)                 |
++------------------------------------------------------------------+
+```
+
+### I. Title Bar
+
+Top edge of the container, spans full width.
+
+**Left side (flowing):**
+- Title (large, bold, white)
+- Year (muted, in parentheses)
+- Status badge (pill)
+- Multi-Title badge (purple pill, when applicable)
+- IMDb badge (yellow pill, when applicable)
+
+**Right side (pushed with `margin-left: auto`):**
+- Action buttons (pill-style, contextual per job state)
+
+**Action buttons by state:**
+- Active jobs: Abandon (yellow)
+- Completed success: Re-transcode (indigo), Fix Permissions (blue/outlined), Delete (red/outlined), Purge (orange/outlined)
+- Completed fail: Delete (red/outlined), Purge (orange/outlined)
+- Waiting: Abandon (yellow)
+
+**Removed:** Log button (was in the old action bar). Log is accessible from the inline log feed and log page.
+
+### II. Poster + Metadata Grid
+
+Below the title bar, inside the same container.
+
+**Poster (left column):**
+- Fixed width: 120px
+- Aspect ratio: 2:3 (natural height via `aspect-ratio: 2/3`)
+- Top-aligned (`align-items: flex-start`)
+- Separated from grid by vertical border
+- Placeholder icon when no poster available (dashed border, disc icon)
+- Music discs: 1:1 aspect ratio (album art)
+
+**Metadata Grid (right side):**
+- Always 4 columns
+- Pad incomplete last row with empty bordered cells
+- All cells have full borders (top, bottom, left, right dividers using `border-primary/15`)
+- Labels: uppercase, small, muted (`text-xs text-gray-500 uppercase tracking-wide`)
+- Values: white, medium weight (`text-sm font-medium text-white`)
+- Monospace for: Label, CRC, paths
+- Select dropdown for Title Mode (matching settings page inputClass styling)
+- IMDb/TVDB render as linked text (the ID, e.g. tt0133093, linking to external site)
+
+### III. Panel Toggle Bar
+
+Attached to the bottom of the container, full width.
+
+- Equal-width buttons separated by vertical dividers
+- Inactive: muted text, no background
+- Active: primary color text, subtle background tint, bottom border highlight (2px solid primary)
+- Clicking a panel toggles it (click active panel to collapse)
+
+**Panels shown (contextual):**
+- Identify (always for video discs)
+- Rip Settings (always)
+- Transcode Settings (video discs only)
+- CRC Lookup (DVD only)
+- Debug (always)
+
+### IV. Expanded Panel Content
+
+When a panel is active, its content renders below the toggle bar within the same container. Same components as today (TitleSearch, RipSettings, TranscodeOverrides, CrcLookup), just relocated.
+
+## Metadata Fields by Job Type
+
+### Video Disc - Movie
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Type | `video_type` | "Movie", "Series", etc. |
+| Disc Type | `disctype` | "Blu-ray", "DVD", "4K UHD" |
+| Title Mode | `multi_title` | Select dropdown (Single/Multi), video discs only |
+| Titles | `no_of_titles` | Integer |
+| Label | `label` | Monospace |
+| Device | `devpath` | e.g. /dev/sr0 |
+| Source | `source_type` | "Disc" or "Folder" |
+| CRC | `crc_id` | Monospace, only when present AND DVD |
+| IMDb | `imdb_id` | Linked text, only when present |
+| Disc # | `disc_number`/`disc_total` | "2 of 4", only when disc_number present |
+| Started | `start_time` | Formatted datetime |
+| Finished | `stop_time` | Formatted datetime, completed jobs only |
+| Duration | `job_length` | Time string, completed jobs only |
+| Elapsed | computed | Active jobs only (replaces Finished/Duration) |
+| Output | `path` | Monospace, truncated with tooltip, when present |
+| Raw | `raw_path` | Monospace, when present |
+| Transcode | `transcode_path` | Monospace, when present |
+
+### Video Disc - Series
+
+All movie fields plus:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Season | `season` or `season_auto` | When present |
+| TVDB | `tvdb_id` | Linked text, when present |
+
+### Music Disc
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Type | `video_type` / `disctype` | "Music" |
+| Disc Type | `disctype` | "Music CD" |
+| Titles | `no_of_titles` | Track count |
+| Label | `label` | Monospace |
+| Device | `devpath` | |
+| Source | `source_type` | |
+| Artist | `artist` or `artist_auto` | When present |
+| Album | `album` or `album_auto` | When present |
+| Started | `start_time` | |
+| Finished | `stop_time` | Completed only |
+| Duration | `job_length` | Completed only |
+| Elapsed | computed | Active only |
+| Output | `path` | When present |
+
+**Not shown for music:** Title Mode, CRC, IMDb, TVDB, Season, Disc #
+
+### Folder Import
+
+Same as video disc fields but:
+- Source shows "Folder"
+- Source Path field added (shows `source_path`, monospace)
+- Device may or may not be present
+
+### Waiting / Unidentified
+
+Whatever fields are populated. Typically a minimal set:
+- Type (may be "unknown"), Disc Type, Titles, Label, Device, Source, Started
+
+## Grid Column Logic
+
+- Always 4 columns
+- Field count varies by job type and state (7-16 fields)
+- Rows = ceil(field_count / 4)
+- Empty cells on the last row rendered with borders but no content
+- All cells get `border-bottom` and interior cells get `border-right` (rightmost column borders handled by the container edge)
+
+## Breadcrumb
+
+Replace "Back to Dashboard" link with breadcrumb:
+
+```
+Dashboard > [Job Title]
+```
+
+"Dashboard" links to `/`, job title is plain text (current page).
+
+## Styling Tokens
+
+All styling follows existing patterns from the settings page:
+
+- Container: `rounded-lg border border-primary/20 bg-surface dark:border-primary/20 dark:bg-surface-dark`
+- Grid borders: `border-primary/15` (or `border-primary/20` to match container)
+- Labels: `text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400`
+- Values: `text-sm font-medium text-gray-900 dark:text-white`
+- Monospace values: `font-mono text-xs`
+- Select inputs: settings page `inputClass` pattern (`rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm`)
+- Action buttons: pill style (`rounded-full px-3 py-1.5 text-xs font-medium`)
+- Panel toggle bar: `bg-surface/50` background, `border-t border-primary/15`
+
+## Scope
+
+This spec covers only the header section of the job detail page (everything above the tracks table and inline log feeds). The tracks table, error banners, auto-vs-manual diff banner, and inline log feeds remain unchanged.
+
+## Responsive Behavior
+
+- On mobile (< md): poster stacks above the grid, grid drops to 2 columns
+- Panel toggle bar wraps or scrolls horizontally on small screens
+- Action buttons in title bar wrap below the title/badges on narrow screens

--- a/frontend/src/lib/__tests__/job-fields.test.ts
+++ b/frontend/src/lib/__tests__/job-fields.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { JobDetail } from '../types/arm';
+import { buildMetadataFields, type MetadataField } from '../utils/job-fields';
+
+// Mock format utilities so tests don't depend on locale/time
+vi.mock('../utils/format', () => ({
+	formatDateTime: (s: string | null) => (s ? `formatted:${s}` : 'N/A'),
+	timeAgo: (s: string | null) => (s ? `ago:${s}` : 'N/A'),
+}));
+
+function createJob(overrides: Partial<JobDetail> = {}): JobDetail {
+	return {
+		job_id: 1,
+		arm_version: '2.0',
+		crc_id: null,
+		logfile: null,
+		start_time: '2026-01-01T10:00:00',
+		stop_time: null,
+		job_length: null,
+		status: 'ripping',
+		stage: null,
+		no_of_titles: 5,
+		title: 'Test Movie',
+		title_auto: null,
+		title_manual: null,
+		year: '2025',
+		year_auto: null,
+		year_manual: null,
+		video_type: 'movie',
+		video_type_auto: null,
+		video_type_manual: null,
+		imdb_id: null,
+		imdb_id_auto: null,
+		imdb_id_manual: null,
+		poster_url: null,
+		poster_url_auto: null,
+		poster_url_manual: null,
+		devpath: '/dev/sr0',
+		mountpoint: null,
+		hasnicetitle: null,
+		errors: null,
+		disctype: 'dvd',
+		label: 'DISC_LABEL',
+		path: null,
+		raw_path: null,
+		transcode_path: null,
+		artist: null,
+		artist_auto: null,
+		artist_manual: null,
+		album: null,
+		album_auto: null,
+		album_manual: null,
+		season: null,
+		season_auto: null,
+		season_manual: null,
+		episode: null,
+		episode_auto: null,
+		episode_manual: null,
+		transcode_overrides: null,
+		multi_title: false,
+		title_pattern_override: null,
+		folder_pattern_override: null,
+		disc_number: null,
+		disc_total: null,
+		ejected: null,
+		pid: null,
+		manual_pause: null,
+		wait_start_time: null,
+		tracks_total: null,
+		tracks_ripped: null,
+		tvdb_id: null,
+		tracks: [],
+		config: null,
+		...overrides,
+	};
+}
+
+function fieldLabels(fields: MetadataField[]): string[] {
+	return fields.filter((f) => !f.empty).map((f) => f.label);
+}
+
+function findField(fields: MetadataField[], label: string): MetadataField | undefined {
+	return fields.find((f) => f.label === label);
+}
+
+describe('buildMetadataFields', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T12:00:00'));
+	});
+
+	describe('always-present fields', () => {
+		it('includes base fields for any job', () => {
+			const fields = buildMetadataFields(createJob());
+			const labels = fieldLabels(fields);
+			expect(labels).toContain('Type');
+			expect(labels).toContain('Disc Type');
+			expect(labels).toContain('Titles');
+			expect(labels).toContain('Label');
+			expect(labels).toContain('Device');
+			expect(labels).toContain('Source');
+			expect(labels).toContain('Started');
+		});
+
+		it('Label is mono', () => {
+			const fields = buildMetadataFields(createJob());
+			expect(findField(fields, 'Label')?.mono).toBe(true);
+		});
+
+		it('Type shows video_type', () => {
+			const fields = buildMetadataFields(createJob({ video_type: 'series' }));
+			expect(findField(fields, 'Type')?.value).toBe('Series');
+		});
+
+		it('Disc Type uses discTypeLabel', () => {
+			const fields = buildMetadataFields(createJob({ disctype: 'bluray' }));
+			expect(findField(fields, 'Disc Type')?.value).toBe('Blu-ray');
+		});
+
+		it('Titles shows no_of_titles', () => {
+			const fields = buildMetadataFields(createJob({ no_of_titles: 12 }));
+			expect(findField(fields, 'Titles')?.value).toBe('12');
+		});
+
+		it('Device shows devpath', () => {
+			const fields = buildMetadataFields(createJob({ devpath: '/dev/sr1' }));
+			expect(findField(fields, 'Device')?.value).toBe('/dev/sr1');
+		});
+
+		it('Source shows disc or folder', () => {
+			expect(findField(buildMetadataFields(createJob()), 'Source')?.value).toBe('Disc');
+			expect(
+				findField(buildMetadataFields(createJob({ source_type: 'folder' })), 'Source')?.value
+			).toBe('Folder');
+		});
+
+		it('Started uses formatDateTime', () => {
+			const fields = buildMetadataFields(createJob({ start_time: '2026-01-01T10:00:00' }));
+			expect(findField(fields, 'Started')?.value).toBe('formatted:2026-01-01T10:00:00');
+		});
+	});
+
+	describe('video disc fields', () => {
+		it('includes Title Mode for movie disc', () => {
+			const fields = buildMetadataFields(createJob({ video_type: 'movie', disctype: 'dvd' }));
+			const f = findField(fields, 'Title Mode');
+			expect(f).toBeDefined();
+			expect(f?.isSelect).toBe(true);
+		});
+
+		it('includes Title Mode for series disc', () => {
+			const fields = buildMetadataFields(createJob({ video_type: 'series', disctype: 'bluray' }));
+			expect(findField(fields, 'Title Mode')).toBeDefined();
+		});
+
+		it('Title Mode value reflects multi_title', () => {
+			expect(
+				findField(buildMetadataFields(createJob({ multi_title: true })), 'Title Mode')?.value
+			).toBe('multi');
+			expect(
+				findField(buildMetadataFields(createJob({ multi_title: false })), 'Title Mode')?.value
+			).toBe('single');
+		});
+
+		it('excludes Title Mode for music disc', () => {
+			const fields = buildMetadataFields(createJob({ video_type: 'music', disctype: 'music' }));
+			expect(findField(fields, 'Title Mode')).toBeUndefined();
+		});
+	});
+
+	describe('DVD CRC field', () => {
+		it('includes CRC for DVD when present', () => {
+			const fields = buildMetadataFields(createJob({ disctype: 'dvd', crc_id: 'ABC123' }));
+			const f = findField(fields, 'CRC');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('ABC123');
+			expect(f?.mono).toBe(true);
+		});
+
+		it('excludes CRC when not present', () => {
+			const fields = buildMetadataFields(createJob({ disctype: 'dvd', crc_id: null }));
+			expect(findField(fields, 'CRC')).toBeUndefined();
+		});
+
+		it('excludes CRC for non-DVD disc types', () => {
+			const fields = buildMetadataFields(createJob({ disctype: 'bluray', crc_id: 'ABC123' }));
+			expect(findField(fields, 'CRC')).toBeUndefined();
+		});
+	});
+
+	describe('IMDb field', () => {
+		it('includes IMDb when present and not music', () => {
+			const fields = buildMetadataFields(createJob({ imdb_id: 'tt1234567', video_type: 'movie' }));
+			const f = findField(fields, 'IMDb');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('tt1234567');
+			expect(f?.link).toBe('https://www.imdb.com/title/tt1234567');
+		});
+
+		it('excludes IMDb when not present', () => {
+			const fields = buildMetadataFields(createJob({ imdb_id: null }));
+			expect(findField(fields, 'IMDb')).toBeUndefined();
+		});
+
+		it('excludes IMDb for music', () => {
+			const fields = buildMetadataFields(
+				createJob({ imdb_id: 'tt1234567', video_type: 'music', disctype: 'music' })
+			);
+			expect(findField(fields, 'IMDb')).toBeUndefined();
+		});
+	});
+
+	describe('series-specific fields', () => {
+		it('includes Season and TVDB for series when present', () => {
+			const fields = buildMetadataFields(
+				createJob({ video_type: 'series', season: '2', tvdb_id: 12345 })
+			);
+			const seasonField = findField(fields, 'Season');
+			expect(seasonField).toBeDefined();
+			expect(seasonField?.value).toBe('2');
+
+			const tvdbField = findField(fields, 'TVDB');
+			expect(tvdbField).toBeDefined();
+			expect(tvdbField?.value).toBe('12345');
+			expect(tvdbField?.link).toBe('https://www.thetvdb.com/dereferrer/series/12345');
+		});
+
+		it('excludes Season and TVDB for movie', () => {
+			const fields = buildMetadataFields(
+				createJob({ video_type: 'movie', season: '1', tvdb_id: 999 })
+			);
+			expect(findField(fields, 'Season')).toBeUndefined();
+			expect(findField(fields, 'TVDB')).toBeUndefined();
+		});
+
+		it('excludes TVDB when not present even for series', () => {
+			const fields = buildMetadataFields(
+				createJob({ video_type: 'series', tvdb_id: null })
+			);
+			expect(findField(fields, 'TVDB')).toBeUndefined();
+		});
+
+		it('excludes Season when not present for series', () => {
+			const fields = buildMetadataFields(
+				createJob({ video_type: 'series', season: null })
+			);
+			expect(findField(fields, 'Season')).toBeUndefined();
+		});
+	});
+
+	describe('music-specific fields', () => {
+		it('includes Artist and Album for music', () => {
+			const fields = buildMetadataFields(
+				createJob({ video_type: 'music', disctype: 'music', artist: 'Tool', album: 'Lateralus' })
+			);
+			expect(findField(fields, 'Artist')?.value).toBe('Tool');
+			expect(findField(fields, 'Album')?.value).toBe('Lateralus');
+		});
+
+		it('excludes Title Mode, IMDb, TVDB, Season, CRC for music', () => {
+			const fields = buildMetadataFields(
+				createJob({
+					video_type: 'music',
+					disctype: 'music',
+					imdb_id: 'tt000',
+					tvdb_id: 123,
+					season: '1',
+					crc_id: 'ABC',
+					artist: 'Tool',
+					album: 'Lateralus',
+				})
+			);
+			const labels = fieldLabels(fields);
+			expect(labels).not.toContain('Title Mode');
+			expect(labels).not.toContain('IMDb');
+			expect(labels).not.toContain('TVDB');
+			expect(labels).not.toContain('Season');
+			expect(labels).not.toContain('CRC');
+		});
+
+		it('excludes Artist and Album for non-music', () => {
+			const fields = buildMetadataFields(createJob({ video_type: 'movie' }));
+			expect(findField(fields, 'Artist')).toBeUndefined();
+			expect(findField(fields, 'Album')).toBeUndefined();
+		});
+	});
+
+	describe('disc number', () => {
+		it('shows disc number when present', () => {
+			const fields = buildMetadataFields(createJob({ disc_number: 2, disc_total: 4 }));
+			const f = findField(fields, 'Disc #');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('2 of 4');
+		});
+
+		it('shows just disc number without total', () => {
+			const fields = buildMetadataFields(createJob({ disc_number: 1, disc_total: null }));
+			const f = findField(fields, 'Disc #');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('1');
+		});
+
+		it('excludes disc number when not present', () => {
+			const fields = buildMetadataFields(createJob({ disc_number: null }));
+			expect(findField(fields, 'Disc #')).toBeUndefined();
+		});
+	});
+
+	describe('folder import fields', () => {
+		it('includes Source Path for folder imports', () => {
+			const fields = buildMetadataFields(
+				createJob({ source_type: 'folder', source_path: '/media/imports/MOVIE' })
+			);
+			const f = findField(fields, 'Source Path');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('/media/imports/MOVIE');
+			expect(f?.mono).toBe(true);
+		});
+
+		it('excludes Source Path for disc jobs', () => {
+			const fields = buildMetadataFields(createJob());
+			expect(findField(fields, 'Source Path')).toBeUndefined();
+		});
+	});
+
+	describe('time fields based on job state', () => {
+		it('shows Elapsed for active jobs', () => {
+			const fields = buildMetadataFields(createJob({ status: 'ripping' }));
+			const labels = fieldLabels(fields);
+			expect(labels).toContain('Elapsed');
+			expect(labels).not.toContain('Finished');
+			expect(labels).not.toContain('Duration');
+		});
+
+		it('shows Finished and Duration for completed jobs', () => {
+			const fields = buildMetadataFields(
+				createJob({
+					status: 'success',
+					stop_time: '2026-01-01T11:30:00',
+					job_length: '01:30:00',
+				})
+			);
+			const labels = fieldLabels(fields);
+			expect(labels).toContain('Finished');
+			expect(labels).toContain('Duration');
+			expect(labels).not.toContain('Elapsed');
+		});
+
+		it('Finished uses formatDateTime', () => {
+			const fields = buildMetadataFields(
+				createJob({ status: 'success', stop_time: '2026-01-01T11:30:00', job_length: '01:30:00' })
+			);
+			expect(findField(fields, 'Finished')?.value).toBe('formatted:2026-01-01T11:30:00');
+		});
+
+		it('Duration shows job_length', () => {
+			const fields = buildMetadataFields(
+				createJob({ status: 'success', stop_time: '2026-01-01T11:30:00', job_length: '01:30:00' })
+			);
+			expect(findField(fields, 'Duration')?.value).toBe('01:30:00');
+		});
+
+		it('Elapsed uses timeAgo on start_time', () => {
+			const fields = buildMetadataFields(
+				createJob({ status: 'ripping', start_time: '2026-01-01T10:00:00' })
+			);
+			expect(findField(fields, 'Elapsed')?.value).toBe('ago:2026-01-01T10:00:00');
+		});
+	});
+
+	describe('path fields', () => {
+		it('includes Output path when present', () => {
+			const fields = buildMetadataFields(createJob({ path: '/output/movie' }));
+			const f = findField(fields, 'Output');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('/output/movie');
+			expect(f?.mono).toBe(true);
+		});
+
+		it('includes Raw path when present', () => {
+			const fields = buildMetadataFields(createJob({ raw_path: '/raw/movie' }));
+			const f = findField(fields, 'Raw');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('/raw/movie');
+			expect(f?.mono).toBe(true);
+		});
+
+		it('includes Transcode path when present', () => {
+			const fields = buildMetadataFields(createJob({ transcode_path: '/transcode/movie' }));
+			const f = findField(fields, 'Transcode');
+			expect(f).toBeDefined();
+			expect(f?.value).toBe('/transcode/movie');
+			expect(f?.mono).toBe(true);
+		});
+
+		it('excludes paths when not present', () => {
+			const fields = buildMetadataFields(createJob());
+			expect(findField(fields, 'Output')).toBeUndefined();
+			expect(findField(fields, 'Raw')).toBeUndefined();
+			expect(findField(fields, 'Transcode')).toBeUndefined();
+		});
+	});
+
+	describe('padding to multiple of 4', () => {
+		it('total length is a multiple of 4', () => {
+			const fields = buildMetadataFields(createJob());
+			expect(fields.length % 4).toBe(0);
+		});
+
+		it('padded fields have empty=true', () => {
+			const fields = buildMetadataFields(createJob());
+			const empties = fields.filter((f) => f.empty);
+			// Each empty field should have label='' and value=''
+			for (const e of empties) {
+				expect(e.label).toBe('');
+				expect(e.value).toBe('');
+			}
+		});
+
+		it('content fields do not have empty=true', () => {
+			const fields = buildMetadataFields(createJob());
+			const content = fields.filter((f) => !f.empty);
+			expect(content.length).toBeGreaterThan(0);
+			for (const f of content) {
+				expect(f.label).not.toBe('');
+			}
+		});
+
+		it('pads correctly for different field counts', () => {
+			// Movie disc with paths - many fields
+			const manyFields = buildMetadataFields(
+				createJob({
+					status: 'success',
+					stop_time: '2026-01-01T11:30:00',
+					job_length: '01:30:00',
+					path: '/output',
+					raw_path: '/raw',
+					transcode_path: '/transcode',
+					imdb_id: 'tt1234567',
+					crc_id: 'CRC1',
+					disc_number: 1,
+					disc_total: 3,
+				})
+			);
+			expect(manyFields.length % 4).toBe(0);
+
+			// Music disc - fewer fields
+			const musicFields = buildMetadataFields(
+				createJob({
+					video_type: 'music',
+					disctype: 'music',
+					artist: 'Artist',
+					album: 'Album',
+				})
+			);
+			expect(musicFields.length % 4).toBe(0);
+
+			// Series with all optional fields
+			const seriesFields = buildMetadataFields(
+				createJob({
+					video_type: 'series',
+					disctype: 'bluray',
+					season: '3',
+					tvdb_id: 54321,
+					imdb_id: 'tt9999999',
+					disc_number: 2,
+					disc_total: 5,
+					status: 'success',
+					stop_time: '2026-01-01T11:30:00',
+					job_length: '02:00:00',
+					path: '/output',
+				})
+			);
+			expect(seriesFields.length % 4).toBe(0);
+		});
+	});
+
+	describe('field ordering', () => {
+		it('starts with base fields in correct order', () => {
+			const fields = buildMetadataFields(createJob());
+			const labels = fieldLabels(fields);
+			const baseOrder = ['Type', 'Disc Type', 'Titles', 'Label', 'Device', 'Source', 'Started'];
+			for (let i = 0; i < baseOrder.length; i++) {
+				expect(labels[i]).toBe(baseOrder[i]);
+			}
+		});
+	});
+
+	describe('null/missing field values', () => {
+		it('handles null video_type', () => {
+			const fields = buildMetadataFields(createJob({ video_type: null }));
+			expect(findField(fields, 'Type')?.value).toBe('Unknown');
+		});
+
+		it('handles null disctype', () => {
+			const fields = buildMetadataFields(createJob({ disctype: null }));
+			expect(findField(fields, 'Disc Type')?.value).toBe('Unknown');
+		});
+
+		it('handles null no_of_titles', () => {
+			const fields = buildMetadataFields(createJob({ no_of_titles: null }));
+			expect(findField(fields, 'Titles')?.value).toBe('-');
+		});
+
+		it('handles null devpath', () => {
+			const fields = buildMetadataFields(createJob({ devpath: null }));
+			expect(findField(fields, 'Device')?.value).toBe('-');
+		});
+
+		it('handles null label', () => {
+			const fields = buildMetadataFields(createJob({ label: null }));
+			expect(findField(fields, 'Label')?.value).toBe('-');
+		});
+	});
+});

--- a/frontend/src/lib/components/JobActions.svelte
+++ b/frontend/src/lib/components/JobActions.svelte
@@ -97,7 +97,7 @@
 	let btnBase = $derived(
 		compact
 			? 'rounded px-2 py-0.5 text-xs font-medium disabled:opacity-50 transition-colors'
-			: 'rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 transition-colors'
+			: 'rounded-full px-3 py-1.5 text-xs font-medium disabled:opacity-50 transition-colors'
 	);
 </script>
 
@@ -116,7 +116,7 @@
 			<button
 				onclick={handleFixPerms}
 				disabled={loading !== null}
-				class="{btnBase} bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+				class="{btnBase} bg-blue-100 text-blue-700 ring-1 ring-blue-200 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-800 dark:hover:bg-blue-900/50"
 			>
 				{loading === 'fixperms' ? 'Fixing...' : 'Fix Permissions'}
 			</button>
@@ -125,7 +125,7 @@
 			<button
 				onclick={handleDelete}
 				disabled={loading !== null}
-				class="{btnBase} bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+				class="{btnBase} bg-red-100 text-red-700 ring-1 ring-red-200 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:ring-red-800 dark:hover:bg-red-900/50"
 			>
 				{loading === 'delete' ? 'Deleting...' : 'Delete'}
 			</button>
@@ -134,7 +134,7 @@
 			<button
 				onclick={handlePurge}
 				disabled={loading !== null}
-				class="{btnBase} bg-orange-100 text-orange-700 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:hover:bg-orange-900/50"
+				class="{btnBase} bg-orange-100 text-orange-700 ring-1 ring-orange-200 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:ring-orange-800 dark:hover:bg-orange-900/50"
 			>
 				{loading === 'purge' ? 'Purging...' : 'Purge'}
 			</button>

--- a/frontend/src/lib/components/JobActions.test.ts
+++ b/frontend/src/lib/components/JobActions.test.ts
@@ -180,7 +180,7 @@ describe('JobActions', () => {
 				props: { job: createJob({ status: 'success' }), compact: false }
 			});
 			const deleteBtn = screen.getByText('Delete');
-			expect(deleteBtn).toHaveClass('text-sm');
+			expect(deleteBtn).toHaveClass('text-xs');
 		});
 	});
 });

--- a/frontend/src/lib/utils/job-fields.ts
+++ b/frontend/src/lib/utils/job-fields.ts
@@ -1,0 +1,125 @@
+import type { JobDetail } from '$lib/types/arm';
+import { formatDateTime, timeAgo } from '$lib/utils/format';
+import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
+
+export interface MetadataField {
+	label: string;
+	value: string;
+	mono?: boolean;
+	link?: string;
+	isSelect?: boolean;
+	empty?: boolean;
+}
+
+function videoTypeLabel(vt: string | null): string {
+	if (!vt) return 'Unknown';
+	const labels: Record<string, string> = {
+		movie: 'Movie',
+		series: 'Series',
+		music: 'Music',
+		data: 'Data',
+	};
+	return labels[vt.toLowerCase()] ?? vt;
+}
+
+export function buildMetadataFields(job: JobDetail): MetadataField[] {
+	const isMusic = job.video_type?.toLowerCase() === 'music';
+	const isSeries = job.video_type?.toLowerCase() === 'series';
+	const isDvd = job.disctype?.toLowerCase() === 'dvd';
+	const isFolderImport = job.source_type === 'folder';
+	const active = isJobActive(job.status);
+
+	const fields: MetadataField[] = [];
+
+	// --- Always-present base fields ---
+	fields.push({ label: 'Type', value: videoTypeLabel(job.video_type) });
+	fields.push({ label: 'Disc Type', value: discTypeLabel(job.disctype) });
+	fields.push({ label: 'Titles', value: job.no_of_titles != null ? String(job.no_of_titles) : '-' });
+	fields.push({ label: 'Label', value: job.label ?? '-', mono: true });
+	fields.push({ label: 'Device', value: job.devpath ?? '-' });
+	fields.push({ label: 'Source', value: isFolderImport ? 'Folder' : 'Disc' });
+	fields.push({ label: 'Started', value: formatDateTime(job.start_time) });
+
+	// --- Video discs only: Title Mode ---
+	if (!isMusic) {
+		fields.push({
+			label: 'Title Mode',
+			value: job.multi_title ? 'multi' : 'single',
+			isSelect: true,
+		});
+	}
+
+	// --- DVD only + when present: CRC ---
+	if (isDvd && job.crc_id) {
+		fields.push({ label: 'CRC', value: job.crc_id, mono: true });
+	}
+
+	// --- When present + not music: IMDb ---
+	if (job.imdb_id && !isMusic) {
+		fields.push({
+			label: 'IMDb',
+			value: job.imdb_id,
+			link: `https://www.imdb.com/title/${job.imdb_id}`,
+		});
+	}
+
+	// --- Series + when present: Season, TVDB ---
+	if (isSeries && job.season) {
+		fields.push({ label: 'Season', value: job.season });
+	}
+	if (isSeries && job.tvdb_id) {
+		fields.push({
+			label: 'TVDB',
+			value: String(job.tvdb_id),
+			link: `https://www.thetvdb.com/dereferrer/series/${job.tvdb_id}`,
+		});
+	}
+
+	// --- Music only: Artist, Album ---
+	if (isMusic) {
+		fields.push({ label: 'Artist', value: job.artist ?? '-' });
+		fields.push({ label: 'Album', value: job.album ?? '-' });
+	}
+
+	// --- Disc number when present ---
+	if (job.disc_number != null) {
+		const discValue =
+			job.disc_total != null ? `${job.disc_number} of ${job.disc_total}` : String(job.disc_number);
+		fields.push({ label: 'Disc #', value: discValue });
+	}
+
+	// --- Folder imports: Source Path ---
+	if (isFolderImport && job.source_path) {
+		fields.push({ label: 'Source Path', value: job.source_path, mono: true });
+	}
+
+	// --- Time fields based on job state ---
+	if (active) {
+		fields.push({ label: 'Elapsed', value: timeAgo(job.start_time) });
+	} else {
+		fields.push({ label: 'Finished', value: formatDateTime(job.stop_time) });
+		fields.push({ label: 'Duration', value: job.job_length ?? '-' });
+	}
+
+	// --- Path fields when present ---
+	if (job.path) {
+		fields.push({ label: 'Output', value: job.path, mono: true });
+	}
+	if (job.raw_path) {
+		fields.push({ label: 'Raw', value: job.raw_path, mono: true });
+	}
+	if (job.transcode_path) {
+		fields.push({ label: 'Transcode', value: job.transcode_path, mono: true });
+	}
+
+	// --- Pad to multiple of 4 ---
+	const remainder = fields.length % 4;
+	if (remainder !== 0) {
+		const padding = 4 - remainder;
+		for (let i = 0; i < padding; i++) {
+			fields.push({ label: '', value: '', empty: true });
+		}
+	}
+
+	return fields;
+}

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -130,6 +130,14 @@
 
 	let metadataFields = $derived(job ? buildMetadataFields(job) : []);
 
+	const panelTabBase = 'flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15';
+	const panelTabActive = 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10';
+	const panelTabInactive = 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300';
+	function panelTabClass(id: string, last = false): string {
+		const base = last ? panelTabBase.replace(' border-r border-primary/15', '') : panelTabBase;
+		return `${base} ${activePanel === id ? panelTabActive : panelTabInactive}`;
+	}
+
 	function formatTvEpisodeName(track: { episode_number?: string | null; episode_name?: string | null }): string {
 		if (!job || !track.episode_number) return '--';
 		const pattern = job.config?.TV_TITLE_PATTERN ?? '{title} S{season}E{episode}';
@@ -355,40 +363,22 @@
 			<!-- Panel toggle bar -->
 			<div class="flex border-t border-primary/15 bg-surface/50 dark:border-primary/15 dark:bg-surface-dark/50">
 				{#if isVideoDisc}
-					<button
-						onclick={() => (activePanel = activePanel === 'title' ? null : 'title')}
-						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'title' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
-					>Identify</button>
+					<button onclick={() => (activePanel = activePanel === 'title' ? null : 'title')} class={panelTabClass('title')}>Identify</button>
 				{/if}
 				{#if isMusicDisc}
-					<button
-						onclick={() => (activePanel = activePanel === 'music' ? null : 'music')}
-						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'music' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
-					>Search Music</button>
+					<button onclick={() => (activePanel = activePanel === 'music' ? null : 'music')} class={panelTabClass('music')}>Search Music</button>
 				{/if}
 				{#if job.config}
-					<button
-						onclick={() => (activePanel = activePanel === 'rip' ? null : 'rip')}
-						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'rip' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
-					>Rip Settings</button>
+					<button onclick={() => (activePanel = activePanel === 'rip' ? null : 'rip')} class={panelTabClass('rip')}>Rip Settings</button>
 				{/if}
 				{#if isVideoDisc && (job.video_type === 'series' || job.imdb_id)}
-					<button
-						onclick={() => (activePanel = activePanel === 'tvdb' ? null : 'tvdb')}
-						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'tvdb' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
-					>Episodes</button>
+					<button onclick={() => (activePanel = activePanel === 'tvdb' ? null : 'tvdb')} class={panelTabClass('tvdb')}>Episodes</button>
 				{/if}
 				{#if isVideoDisc}
-					<button
-						onclick={() => (activePanel = activePanel === 'transcode' ? null : 'transcode')}
-						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'transcode' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
-					>Transcode Settings</button>
+					<button onclick={() => (activePanel = activePanel === 'transcode' ? null : 'transcode')} class={panelTabClass('transcode')}>Transcode Settings</button>
 				{/if}
 				{#if hasCrcData}
-					<button
-						onclick={() => (activePanel = activePanel === 'crc' ? null : 'crc')}
-						class="flex-1 px-4 py-2.5 text-center text-sm font-medium transition-colors {activePanel === 'crc' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
-					>CRC Lookup</button>
+					<button onclick={() => (activePanel = activePanel === 'crc' ? null : 'crc')} class={panelTabClass('crc', true)}>CRC Lookup</button>
 				{/if}
 			</div>
 

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -19,6 +19,7 @@
 	import EpisodeMatch from '$lib/components/EpisodeMatch.svelte';
 	import { formatDateTime, timeAgo, statusLabel } from '$lib/utils/format';
 	import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
+	import { buildMetadataFields } from '$lib/utils/job-fields';
 
 	let job = $state<JobDetail | null>(null);
 	let error = $state<string | null>(null);
@@ -126,6 +127,8 @@
 	let hasCrcData = $derived(
 		!isMusicDisc && (job?.disctype === 'dvd' || !!job?.crc_id)
 	);
+
+	let metadataFields = $derived(job ? buildMetadataFields(job) : []);
 
 	function formatTvEpisodeName(track: { episode_number?: string | null; episode_name?: string | null }): string {
 		if (!job || !track.episode_number) return '--';
@@ -248,63 +251,39 @@
 	<div class="py-8 text-center text-gray-400">Loading...</div>
 {:else}
 	<div class="space-y-6">
-		<!-- Back link -->
-		<a href="/" class="inline-flex items-center gap-1 text-sm text-primary-text hover:underline dark:text-primary-text-dark">
-			<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-			</svg>
-			Back to Dashboard
-		</a>
+		<!-- Breadcrumb -->
+		<nav class="text-sm">
+			<a href="/" class="text-primary-text hover:underline dark:text-primary-text-dark">Dashboard</a>
+			<span class="mx-1.5 text-gray-400 dark:text-gray-500">&rsaquo;</span>
+			<span class="text-gray-500 dark:text-gray-400">{job.title || job.label || 'Untitled'}</span>
+		</nav>
 
-		<!-- Header -->
-		<div class="flex flex-col gap-6 md:flex-row">
-			{#if job.poster_url}
-				<img
-					src={posterSrc(job.poster_url)}
-					alt={job.title ?? 'Poster'}
-					class="rounded-lg object-cover shadow-md {isMusicDisc ? 'h-48 w-48' : 'h-64 w-44'}"
-					onerror={posterFallback}
-				/>
-			{/if}
-			<div class="flex-1 space-y-3">
-				<div class="flex flex-wrap items-center gap-3">
-					<h1 class="text-2xl font-bold text-gray-900 dark:text-white">
-						{job.title || job.label || 'Untitled'}
-					</h1>
-					{#if job.year}
-						<span class="text-lg text-gray-500 dark:text-gray-400">({job.year})</span>
-					{/if}
-					<StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} />
-					{#if job.multi_title}
-						<span class="rounded-sm bg-purple-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">Multi-Title</span>
-					{/if}
-					{#if job.imdb_id && !isMusicDisc}
-						<a
-							href="https://www.imdb.com/title/{job.imdb_id}"
-							target="_blank"
-							rel="noopener noreferrer"
-							class="inline-flex items-center gap-1 rounded-sm bg-yellow-400 px-2 py-0.5 text-xs font-bold text-black"
-						>
-							IMDb
-						</a>
-					{/if}
-				</div>
+		<!-- Main header container -->
+		<div class="rounded-lg border border-primary/20 bg-surface shadow-xs overflow-hidden dark:border-primary/20 dark:bg-surface-dark">
 
-				<!-- Action bar -->
-				<div class="flex flex-wrap items-center gap-2 rounded-lg border border-primary/20 bg-surface px-3 py-2 dark:border-primary/20 dark:bg-surface-dark">
-					{#if job.logfile}
-						<a
-							href="/logs/{job.logfile}"
-							class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15"
-						>
-							Log
-						</a>
-					{/if}
+			<!-- Title bar -->
+			<div class="flex flex-wrap items-center gap-2 border-b border-primary/15 px-5 py-3 dark:border-primary/15">
+				<h1 class="text-xl font-bold text-gray-900 dark:text-white">
+					{job.title || job.label || 'Untitled'}
+				</h1>
+				{#if job.year && job.year !== '0000'}
+					<span class="text-base text-gray-400 dark:text-gray-500">({job.year})</span>
+				{/if}
+				<StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} />
+				{#if job.multi_title}
+					<span class="rounded-full bg-purple-100 px-2.5 py-0.5 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">Multi-Title</span>
+				{/if}
+				{#if job.imdb_id && !isMusicDisc}
+					<a href="https://www.imdb.com/title/{job.imdb_id}" target="_blank" rel="noopener noreferrer" class="rounded-full bg-yellow-400 px-2.5 py-0.5 text-[10px] font-bold text-black">IMDb</a>
+				{/if}
+
+				<!-- Action buttons pushed right -->
+				<div class="flex flex-wrap items-center gap-2 ml-auto">
 					{#if isVideoDisc && (job.status === 'success' || job.status === 'fail')}
 						<button
 							onclick={handleRetranscode}
 							disabled={retranscoding}
-							class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400 dark:hover:bg-indigo-900/50"
+							class="rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400 dark:hover:bg-indigo-900/50"
 						>
 							{retranscoding ? 'Queuing...' : 'Re-transcode'}
 						</button>
@@ -316,96 +295,132 @@
 						</span>
 					{/if}
 				</div>
+			</div>
 
-				<dl class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm md:grid-cols-3">
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">Status</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{statusLabel(job.status)}</dd>
-					</div>
-					{#if job.stage}
-						<div>
-							<dt class="text-gray-500 dark:text-gray-400">Stage</dt>
-							<dd class="font-medium text-gray-900 dark:text-white">{job.stage}</dd>
+			<!-- Poster + Metadata grid -->
+			<div class="flex items-start">
+				<!-- Poster -->
+				<div class="shrink-0 border-r border-primary/15 p-4 dark:border-primary/15">
+					{#if job.poster_url}
+						<img
+							src={posterSrc(job.poster_url)}
+							alt={job.title ?? 'Poster'}
+							class="rounded-md object-cover shadow-sm {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+							onerror={posterFallback}
+						/>
+					{:else}
+						<div
+							class="flex items-center justify-center rounded-md border border-dashed border-primary/20 bg-primary/5 dark:border-primary/15 dark:bg-primary/5 {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+						>
+							<svg class="h-8 w-8 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+								<circle cx="12" cy="12" r="10" />
+								<circle cx="12" cy="12" r="3" />
+							</svg>
 						</div>
 					{/if}
-					{#if !isMusicDisc}
-						<div>
-							<dt class="text-gray-500 dark:text-gray-400">Video Type</dt>
-							<dd class="font-medium text-gray-900 dark:text-white">{job.video_type ?? 'N/A'}</dd>
-						</div>
-					{/if}
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">Disc Type</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{discTypeLabel(job.disctype)}</dd>
-					</div>
-					{#if job.disc_number}
-						<div>
-							<dt class="text-gray-500 dark:text-gray-400">Disc</dt>
-							<dd class="font-medium text-gray-900 dark:text-white">{job.disc_number}{#if job.disc_total} of {job.disc_total}{/if}</dd>
-						</div>
-					{/if}
-					{#if isVideoDisc}
-						<div>
-							<dt class="text-gray-500 dark:text-gray-400">Title Mode</dt>
-							<dd>
-								<select
-									value={job.multi_title ? 'multi' : 'single'}
-									onchange={(e) => { const v = e.currentTarget.value; if ((v === 'multi') !== !!job?.multi_title) handleToggleMultiTitle(); }}
-									disabled={togglingMultiTitle}
-									class="rounded-sm border border-primary/25 bg-primary/5 px-1 py-0.5 text-sm font-medium text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
-								>
-									<option value="single">Single Title</option>
-									<option value="multi">Multi-Title</option>
-								</select>
-							</dd>
-						</div>
-					{/if}
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">Device</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{job.devpath ?? 'N/A'}</dd>
-					</div>
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">{isMusicDisc ? 'Tracks' : 'Titles'}</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{job.no_of_titles ?? 'N/A'}</dd>
-					</div>
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">Started</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{formatDateTime(job.start_time)}</dd>
-					</div>
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">Finished</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{formatDateTime(job.stop_time)}</dd>
-					</div>
-					<div>
-						<dt class="text-gray-500 dark:text-gray-400">Duration</dt>
-						<dd class="font-medium text-gray-900 dark:text-white">{job.job_length ?? 'N/A'}</dd>
-					</div>
-				</dl>
+				</div>
 
-				{#if job.errors}
-					<div class="rounded-lg border p-3 text-sm {job.status === 'success'
-						? 'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400'
-						: 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400'}">
-						<strong>{job.status === 'success' ? 'Warnings:' : 'Errors:'}</strong> {job.errors}
-					</div>
+				<!-- Metadata grid -->
+				<div class="flex-1 grid grid-cols-4">
+					{#each metadataFields as field, i}
+						{@const isRightEdge = (i + 1) % 4 === 0}
+						<div class="px-4 py-3 border-b border-primary/15 dark:border-primary/15 {!isRightEdge ? 'border-r' : ''}">
+							{#if !field.empty}
+								<div class="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">{field.label}</div>
+								{#if field.isSelect}
+									<div class="mt-1">
+										<select
+											value={job.multi_title ? 'multi' : 'single'}
+											onchange={(e) => { const v = e.currentTarget.value; if ((v === 'multi') !== !!job?.multi_title) handleToggleMultiTitle(); }}
+											disabled={togglingMultiTitle}
+											class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+										>
+											<option value="single">Single Title</option>
+											<option value="multi">Multi-Title</option>
+										</select>
+									</div>
+								{:else if field.link}
+									<a href={field.link} target="_blank" rel="noopener noreferrer" class="mt-1 block text-sm font-medium text-primary hover:underline dark:text-primary {field.mono ? 'font-mono text-xs' : ''}">{field.value}</a>
+								{:else}
+									<div class="mt-1 text-sm font-medium text-gray-900 dark:text-white {field.mono ? 'font-mono text-xs truncate' : ''}" title={field.mono ? field.value : undefined}>{field.value}</div>
+								{/if}
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Panel toggle bar -->
+			<div class="flex border-t border-primary/15 bg-surface/50 dark:border-primary/15 dark:bg-surface-dark/50">
+				{#if isVideoDisc}
+					<button
+						onclick={() => (activePanel = activePanel === 'title' ? null : 'title')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'title' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Identify</button>
 				{/if}
-
-				{#if job.logfile}
-					<InlineLogFeed logfile={job.logfile} maxEntries={15} title="ARM Ripper Log" />
+				{#if isMusicDisc}
+					<button
+						onclick={() => (activePanel = activePanel === 'music' ? null : 'music')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'music' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Search Music</button>
 				{/if}
-				{#if transcoderLogfile && !isMusicDisc && job?.disctype !== 'data' && job?.status !== 'ripping' && job?.status !== 'ready' && job?.status !== 'identifying' && job?.status !== 'waiting'}
-					<InlineLogFeed
-						logfile={transcoderLogfile}
-						maxEntries={15}
-						title="Transcoder Log"
-						fetchFn={fetchStructuredTranscoderLogContent}
-						logLinkBase="/logs/transcoder"
-					/>
+				{#if job.config}
+					<button
+						onclick={() => (activePanel = activePanel === 'rip' ? null : 'rip')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'rip' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Rip Settings</button>
+				{/if}
+				{#if isVideoDisc && (job.video_type === 'series' || job.imdb_id)}
+					<button
+						onclick={() => (activePanel = activePanel === 'tvdb' ? null : 'tvdb')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'tvdb' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Episodes</button>
+				{/if}
+				{#if isVideoDisc}
+					<button
+						onclick={() => (activePanel = activePanel === 'transcode' ? null : 'transcode')}
+						class="flex-1 border-r border-primary/15 px-4 py-2.5 text-center text-sm font-medium transition-colors dark:border-primary/15 {activePanel === 'transcode' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>Transcode Settings</button>
+				{/if}
+				{#if hasCrcData}
+					<button
+						onclick={() => (activePanel = activePanel === 'crc' ? null : 'crc')}
+						class="flex-1 px-4 py-2.5 text-center text-sm font-medium transition-colors {activePanel === 'crc' ? 'text-primary border-b-2 border-b-primary bg-primary/5 dark:bg-primary/10' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'}"
+					>CRC Lookup</button>
 				{/if}
 			</div>
+
+			<!-- Active panel content -->
+			{#if activePanel === 'title'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<TitleSearch {job} onapply={handleTitleApply} />
+				</div>
+			{:else if activePanel === 'music'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<MusicSearch {job} onapply={handleTitleApply} />
+				</div>
+			{:else if activePanel === 'crc'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<CrcLookup {job} onapply={loadJob} />
+				</div>
+			{:else if activePanel === 'rip'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<RipSettings {job} config={job.config!} isMusic={isMusicDisc} multiTitle={!!job.multi_title} onsaved={handleConfigSaved} />
+				</div>
+			{:else if activePanel === 'tvdb'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<EpisodeMatch {job} onapply={loadJob} />
+				</div>
+			{:else if activePanel === 'transcode'}
+				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
+					<TranscodeOverrides {job} onsaved={loadJob} />
+				</div>
+			{/if}
 		</div>
 
-		<!-- Auto vs Manual title info -->
+		<!-- Auto vs Manual title info (outside container) -->
 		{#if hasAutoManualDiff}
 			<div class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm dark:border-amber-800 dark:bg-amber-900/20">
 				<svg class="h-4 w-4 shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -417,83 +432,25 @@
 			</div>
 		{/if}
 
-		<!-- Toggle button bar -->
-		<div class="flex flex-wrap gap-2">
-			{#if isVideoDisc}
-				<button
-					onclick={() => (activePanel = activePanel === 'title' ? null : 'title')}
-					class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {activePanel === 'title' ? 'bg-indigo-200 text-indigo-800 dark:bg-indigo-800/50 dark:text-indigo-300' : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400 dark:hover:bg-indigo-900/50'}"
-				>
-					Identify
-				</button>
-			{/if}
-			{#if isMusicDisc}
-				<button
-					onclick={() => (activePanel = activePanel === 'music' ? null : 'music')}
-					class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {activePanel === 'music' ? 'bg-indigo-200 text-indigo-800 dark:bg-indigo-800/50 dark:text-indigo-300' : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400 dark:hover:bg-indigo-900/50'}"
-				>
-					Search Music
-				</button>
-			{/if}
-			{#if hasCrcData}
-				<button
-					onclick={() => (activePanel = activePanel === 'crc' ? null : 'crc')}
-					class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {activePanel === 'crc' ? 'bg-primary/15 text-gray-900 ring-1 ring-primary/40 dark:bg-primary/20 dark:text-white dark:ring-primary/40' : 'bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15'}"
-				>
-					CRC Database
-				</button>
-			{/if}
-			{#if job.config}
-				<button
-					onclick={() => (activePanel = activePanel === 'rip' ? null : 'rip')}
-					class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {activePanel === 'rip' ? 'bg-primary/15 text-gray-900 ring-1 ring-primary/40 dark:bg-primary/20 dark:text-white dark:ring-primary/40' : 'bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15'}"
-				>
-					Rip Settings
-				</button>
-			{/if}
-			{#if isVideoDisc && (job.video_type === 'series' || job.imdb_id)}
-				<button
-					onclick={() => (activePanel = activePanel === 'tvdb' ? null : 'tvdb')}
-					class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {activePanel === 'tvdb' ? 'bg-blue-200 text-blue-800 dark:bg-blue-800/50 dark:text-blue-300' : 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50'}"
-				>
-					Episodes
-				</button>
-			{/if}
-			{#if isVideoDisc}
-				<button
-					onclick={() => (activePanel = activePanel === 'transcode' ? null : 'transcode')}
-					class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {activePanel === 'transcode' ? 'bg-primary/15 text-gray-900 ring-1 ring-primary/40 dark:bg-primary/20 dark:text-white dark:ring-primary/40' : 'bg-primary/5 text-gray-700 ring-1 ring-primary/25 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-200 dark:ring-primary/30 dark:hover:bg-primary/15'}"
-				>
-					Transcode Settings
-				</button>
-			{/if}
-		</div>
+		{#if job.errors}
+			<div class="rounded-lg border p-3 text-sm {job.status === 'success'
+				? 'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400'
+				: 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400'}">
+				<strong>{job.status === 'success' ? 'Warnings:' : 'Errors:'}</strong> {job.errors}
+			</div>
+		{/if}
 
-		<!-- Active panel content -->
-		{#if activePanel === 'title'}
-			<section class="rounded-lg border border-primary/20 p-4 dark:border-primary/20">
-				<TitleSearch {job} onapply={handleTitleApply} />
-			</section>
-		{:else if activePanel === 'music'}
-			<section class="rounded-lg border border-primary/20 p-4 dark:border-primary/20">
-				<MusicSearch {job} onapply={handleTitleApply} />
-			</section>
-		{:else if activePanel === 'crc'}
-			<section class="rounded-lg border border-primary/20 p-4 dark:border-primary/20">
-				<CrcLookup {job} onapply={loadJob} />
-			</section>
-		{:else if activePanel === 'rip'}
-			<section class="rounded-lg border border-primary/20 p-4 dark:border-primary/20">
-				<RipSettings {job} config={job.config!} isMusic={isMusicDisc} multiTitle={!!job.multi_title} onsaved={handleConfigSaved} />
-			</section>
-		{:else if activePanel === 'tvdb'}
-			<section class="rounded-lg border border-primary/20 p-4 dark:border-primary/20">
-				<EpisodeMatch {job} onapply={loadJob} />
-			</section>
-		{:else if activePanel === 'transcode'}
-			<section class="rounded-lg border border-primary/20 p-4 dark:border-primary/20">
-				<TranscodeOverrides {job} onsaved={loadJob} />
-			</section>
+		{#if job.logfile}
+			<InlineLogFeed logfile={job.logfile} maxEntries={15} title="ARM Ripper Log" />
+		{/if}
+		{#if transcoderLogfile && !isMusicDisc && job?.disctype !== 'data' && job?.status !== 'ripping' && job?.status !== 'ready' && job?.status !== 'identifying' && job?.status !== 'waiting'}
+			<InlineLogFeed
+				logfile={transcoderLogfile}
+				maxEntries={15}
+				title="Transcoder Log"
+				fetchFn={fetchStructuredTranscoderLogContent}
+				logLinkBase="/logs/transcoder"
+			/>
 		{/if}
 
 		<!-- Tracks -->

--- a/frontend/src/routes/jobs/__tests__/job-detail-page.test.ts
+++ b/frontend/src/routes/jobs/__tests__/job-detail-page.test.ts
@@ -18,6 +18,9 @@ vi.mock('$lib/api/jobs', () => ({
 		stop_time: '2025-06-15T11:00:00Z', job_length: '1h 0m', devpath: '/dev/sr0',
 		imdb_id: 'tt1234567', poster_url: null, errors: null, stage: null,
 		no_of_titles: 3, logfile: 'job_1.log', crc_id: 'abc123', multi_title: false,
+		source_type: 'disc', source_path: null, path: null, raw_path: null, transcode_path: null,
+		disc_number: null, disc_total: null, season: null, season_auto: null, tvdb_id: null,
+		artist: null, artist_auto: null, album: null, album_auto: null,
 		tracks: [
 			{ track_id: 1, job_id: 1, track_number: '1', length: 7200, aspect_ratio: '16:9', fps: 24, enabled: true, basename: 'title_01', filename: 'title_01.mkv', orig_filename: 'title_01.mkv', new_filename: null, ripped: true, status: 'success', error: null, source: null, title: null, year: null, imdb_id: null, poster_url: null, video_type: null, episode_number: null, episode_name: null }
 		],
@@ -63,7 +66,14 @@ describe('Job Detail Page', () => {
 		it('renders job title after loading', async () => {
 			renderComponent(JobDetailPage);
 			await waitFor(() => {
-				expect(screen.getByText('Test Movie')).toBeInTheDocument();
+				expect(screen.getByRole('heading', { name: 'Test Movie' })).toBeInTheDocument();
+			});
+		});
+
+		it('renders breadcrumb navigation', async () => {
+			renderComponent(JobDetailPage);
+			await waitFor(() => {
+				expect(screen.getByText('Dashboard')).toBeInTheDocument();
 			});
 		});
 


### PR DESCRIPTION
## Summary

- Reorganize job detail page header into a single bordered container with title bar, poster + 4-column metadata grid, and integrated panel toggle bar
- Replace flat metadata layout with bordered grid cells that adapt field count by job type (movie, series, music, folder import, waiting)
- Move action buttons (Re-transcode, Fix Permissions, Delete, Purge) into title bar as pills, remove standalone Log button
- Replace "Back to Dashboard" link with breadcrumb navigation
- Surface additional metadata: Label, CRC (DVD only), IMDb/TVDB links, Season, Disc #, Artist/Album, output paths
- Fix transcoder cards on home page to use full-width rows matching active rips layout

## Test plan

- [x] 738 tests passing (74 test files), no regressions
- [x] 49 new tests for `buildMetadataFields` utility covering all job type variants
- [ ] Visual verification on hifi-server across job types (movie, series, music, waiting, folder import)
- [ ] Panel toggle bar opens/closes correctly for all panel types
- [ ] Dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)