### PR TITLE
fix: filter track counts by minlength, correct skipped track display

### DIFF
--- a/backend/services/arm_db.py
+++ b/backend/services/arm_db.py
@@ -88,6 +88,25 @@ def is_available() -> bool:
 ACTIVE_STATUSES = {"identifying", "ready", "active", "ripping", "copying", "ejecting", "transcoding", "waiting", "info", "waiting_transcode"}
 
 
+def _minlength(job) -> int:
+    """Return MINLENGTH for a job from its config, defaulting to 0."""
+    try:
+        if job.config and job.config.MINLENGTH:
+            return int(job.config.MINLENGTH)
+    except (ValueError, TypeError):
+        pass
+    return 0
+
+
+def _rippable_tracks(job) -> list:
+    """Return tracks above minlength (the ones ARM will actually rip)."""
+    tracks = list(job.tracks) if job.tracks else []
+    ml = _minlength(job)
+    if ml <= 0:
+        return tracks
+    return [t for t in tracks if t.length is None or t.length >= ml]
+
+
 def get_active_jobs() -> list[dict]:
     """Return active jobs as dicts enriched with track progress counts."""
     try:
@@ -99,9 +118,9 @@ def get_active_jobs() -> list[dict]:
             result = []
             for job in jobs:
                 job_dict = {col.name: getattr(job, col.name) for col in Job.__table__.columns}
-                tracks = list(job.tracks) if job.tracks else []
-                job_dict["tracks_total"] = len(tracks)
-                job_dict["tracks_ripped"] = sum(1 for t in tracks if t.ripped)
+                rippable = _rippable_tracks(job)
+                job_dict["tracks_total"] = len(rippable)
+                job_dict["tracks_ripped"] = sum(1 for t in rippable if t.ripped)
                 result.append(job_dict)
             return result
     except Exception:
@@ -266,10 +285,10 @@ def get_job_track_counts(job_id: int) -> dict:
             job = session.scalars(stmt).unique().first()
             if not job:
                 return {"tracks_total": 0, "tracks_ripped": 0}
-            tracks = list(job.tracks) if job.tracks else []
+            rippable = _rippable_tracks(job)
             return {
-                "tracks_total": len(tracks),
-                "tracks_ripped": sum(1 for t in tracks if t.ripped),
+                "tracks_total": len(rippable),
+                "tracks_ripped": sum(1 for t in rippable if t.ripped),
             }
     except Exception:
         return {"tracks_total": 0, "tracks_ripped": 0}

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -652,7 +652,7 @@
 										</td>
 									{/if}
 									<td class="px-4 py-3">
-										{#if track.enabled}
+										{#if track.enabled && !tooShort}
 											<span class="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold {track.ripped
 												? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
 												: 'bg-gray-100 text-gray-400 dark:bg-gray-700/50 dark:text-gray-500'}"
@@ -661,7 +661,7 @@
 											</span>
 										{/if}
 									</td>
-									<td class="px-4 py-3"><StatusBadge status={!track.enabled ? 'skipped' : track.status} /></td>
+									<td class="px-4 py-3"><StatusBadge status={!track.enabled || tooShort ? 'skipped' : track.status} /></td>
 									</tr>
 								{#if editingTrackId === track.track_id}
 									<tr>


### PR DESCRIPTION
## Summary

- Fix track count on home page and job detail showing all tracks (e.g. 7/13) instead of only rippable tracks above MINLENGTH (should be 7/7)
- `get_active_jobs()` and `get_job_track_counts()` now read the job's MINLENGTH config and exclude short tracks from totals
- Tracks with `length < MINLENGTH` are filtered out, matching what MakeMKV actually rips

## Problem

Job 129 (Wallace and Gromit, 13 tracks, MINLENGTH=600) showed "7/13" on the home page. 6 tracks were short extras (31-301 seconds) that MakeMKV skipped. The count should have been "7/7" since only 7 tracks were above the minimum length threshold.

The ARM backend doesn't set `enabled=False` on short tracks, so the UI backend was counting all tracks as rippable.

## Test plan

- [x] 573 backend tests pass
- [ ] Job 129 on hifi-server should show 7/7 instead of 7/13
- [ ] Jobs without MINLENGTH config default to counting all tracks (no regression)
- [ ] Music disc track counts unaffected (MINLENGTH doesn't apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)