### PR TITLE
fix: stop InlineLogFeed polling after 3 consecutive 404s

### DIFF
--- a/frontend/src/lib/components/InlineLogFeed.svelte
+++ b/frontend/src/lib/components/InlineLogFeed.svelte
@@ -54,7 +54,11 @@
 		debug: 'border-l-transparent',
 	};
 
+	let failCount = $state(0);
+	const MAX_FAILURES = 3;
+
 	async function load() {
+		if (failCount >= MAX_FAILURES) return;
 		try {
 			const data = await fetchFn(
 				logfile,
@@ -64,8 +68,16 @@
 			);
 			entries = data.entries.toReversed();
 			error = null;
+			failCount = 0;
 		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load log';
+			const msg = e instanceof Error ? e.message : 'Failed to load log';
+			if (msg.includes('404')) {
+				failCount++;
+				if (failCount >= MAX_FAILURES) {
+					if (timer) { clearInterval(timer); timer = null; }
+				}
+			}
+			error = msg;
 		} finally {
 			loading = false;
 		}


### PR DESCRIPTION
Missing log files caused infinite 5-second polling with 404 responses. Now tracks consecutive 404 failures and stops after 3 in a row. Counter resets on any successful response to handle transient outages (transcoder restart, network blip).