### PR TITLE
fix: hide InlineLogFeed when log file returns 404

### DIFF
--- a/frontend/src/lib/components/InlineLogFeed.svelte
+++ b/frontend/src/lib/components/InlineLogFeed.svelte
@@ -100,7 +100,7 @@
 	});
 </script>
 
-{#if error}
+{#if error && !error.includes('404')}
 	<div class={containerClass ?? ''}>
 		<div class="text-sm text-red-400">{error}</div>
 	</div>


### PR DESCRIPTION
Missing log files showed red error text on job detail pages. Now the component hides entirely on 404 errors. Non-404 errors still display.