### PR TITLE
fix: add missing poster placeholder SVG

### DIFF
--- a/frontend/static/img/poster-placeholder.svg
+++ b/frontend/static/img/poster-placeholder.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300" fill="none">
+  <rect width="200" height="300" rx="4" fill="#f5f5f5" stroke="#d4d4d4" stroke-width="2"/>
+  <rect x="70" y="100" width="60" height="48" rx="3" stroke="#a3a3a3" stroke-width="2.5" fill="none"/>
+  <circle cx="85" cy="116" r="5" fill="#a3a3a3"/>
+  <path d="M73 142 l18-20 l12 14 l8-8 l16 18" stroke="#a3a3a3" stroke-width="2.5" stroke-linejoin="round" fill="none"/>
+  <text x="100" y="176" text-anchor="middle" font-family="system-ui,sans-serif" font-size="14" fill="#a3a3a3">No Poster</text>
+</svg>


### PR DESCRIPTION
## Summary
- The fallback poster image at `/img/poster-placeholder.svg` was referenced in `posterSrc()` and `posterFallback()` but the file never existed
- When a poster URL failed to load (expired Amazon URL, missing CRC64 poster, etc.), the `onerror` handler tried to swap in the placeholder — which also 404'd, resulting in a broken image icon
- Adds a simple 200x300 (2:3 aspect ratio) SVG with a camera icon and "No Poster" text, matching the neutral gray style of the existing disc type SVGs

## Test plan
- [ ] Load a job with no poster URL — should show the placeholder instead of a broken image
- [ ] Load a job with an expired/broken poster URL — image proxy returns 502, `onerror` fires, placeholder renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)