### PR TITLE
fix: reduce dashboard loading blink and layout shift

### DIFF
--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -6,7 +6,7 @@
 	import { getVideoTypeConfig, isJobActive, discTypeLabel } from '$lib/utils/job-type';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
-	import { posterSrc } from '$lib/utils/poster';
+	import PosterImage from './PosterImage.svelte';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -45,16 +45,7 @@
 	<!-- Collapsed row -->
 	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
 		<!-- Poster thumbnail -->
-		{#if job.poster_url}
-			<img src={posterSrc(job.poster_url)} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
-		{:else}
-			<div class="flex h-10 w-7 shrink-0 items-center justify-center rounded-sm {typeConfig.placeholderClasses}">
-				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-					<circle cx="12" cy="12" r="10" />
-					<circle cx="12" cy="12" r="3" />
-				</svg>
-			</div>
-		{/if}
+		<PosterImage url={job.poster_url} alt={job.title ?? ''} class="h-10 w-7 shrink-0 rounded-sm object-cover" />
 
 		<!-- Title -->
 		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
@@ -151,9 +142,7 @@
 		<div transition:slide={{ duration: 200 }} class="border-t border-primary/10 px-4 py-3 dark:border-primary/15">
 			<div class="flex gap-4">
 				<!-- Poster (larger) -->
-				{#if job.poster_url}
-					<img src={posterSrc(job.poster_url)} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
-				{/if}
+				<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
 
 				<div class="min-w-0 flex-1">
 					<!-- Title + links -->

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -6,7 +6,7 @@
 	import { getVideoTypeConfig, isJobActive, discTypeLabel } from '$lib/utils/job-type';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
-	import { posterSrc } from '$lib/utils/poster';
+	import PosterImage from './PosterImage.svelte';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -45,16 +45,7 @@
 	<!-- Collapsed row -->
 	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
 		<!-- Poster thumbnail -->
-		{#if job.poster_url}
-			<img src={posterSrc(job.poster_url)} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
-		{:else}
-			<div class="flex h-10 w-7 shrink-0 items-center justify-center rounded-sm {typeConfig.placeholderClasses}">
-				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-					<circle cx="12" cy="12" r="10" />
-					<circle cx="12" cy="12" r="3" />
-				</svg>
-			</div>
-		{/if}
+		<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
 
 		<!-- Title -->
 		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
@@ -151,9 +142,7 @@
 		<div transition:slide={{ duration: 200 }} class="border-t border-primary/10 px-4 py-3 dark:border-primary/15">
 			<div class="flex gap-4">
 				<!-- Poster (larger) -->
-				{#if job.poster_url}
-					<img src={posterSrc(job.poster_url)} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
-				{/if}
+				<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
 
 				<div class="min-w-0 flex-1">
 					<!-- Title + links -->

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -6,7 +6,7 @@
 	import { getVideoTypeConfig, isJobActive, discTypeLabel } from '$lib/utils/job-type';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
-	import PosterImage from './PosterImage.svelte';
+	import { posterSrc } from '$lib/utils/poster';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -45,7 +45,16 @@
 	<!-- Collapsed row -->
 	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
 		<!-- Poster thumbnail -->
-		<PosterImage url={job.poster_url} alt={job.title ?? ''} class="h-10 w-7 shrink-0 rounded-sm object-cover" />
+		{#if job.poster_url}
+			<img src={posterSrc(job.poster_url)} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
+		{:else}
+			<div class="flex h-10 w-7 shrink-0 items-center justify-center rounded-sm {typeConfig.placeholderClasses}">
+				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+					<circle cx="12" cy="12" r="10" />
+					<circle cx="12" cy="12" r="3" />
+				</svg>
+			</div>
+		{/if}
 
 		<!-- Title -->
 		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
@@ -142,7 +151,9 @@
 		<div transition:slide={{ duration: 200 }} class="border-t border-primary/10 px-4 py-3 dark:border-primary/15">
 			<div class="flex gap-4">
 				<!-- Poster (larger) -->
-				<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
+				{#if job.poster_url}
+					<img src={posterSrc(job.poster_url)} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
+				{/if}
 
 				<div class="min-w-0 flex-1">
 					<!-- Title + links -->

--- a/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -5,7 +5,6 @@
 	import type { NamingPreviewTrack } from '$lib/api/jobs';
 	import { getVideoTypeConfig, discTypeLabel } from '$lib/utils/job-type';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
-	import PosterImage from './PosterImage.svelte';
 	import CountdownTimer from './CountdownTimer.svelte';
 	import TitleSearch from './TitleSearch.svelte';
 	import MusicSearch from './MusicSearch.svelte';
@@ -410,7 +409,26 @@
 	<!-- Header -->
 	<div class="flex gap-4 p-4">
 		<!-- Poster -->
-		<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-24 shrink-0 rounded-sm object-cover {isMusic ? 'w-24' : 'w-16'}" />
+		{#if job.poster_url}
+			<img
+				src={posterSrc(job.poster_url)}
+				alt={job.title ?? 'Poster'}
+				class="h-24 shrink-0 rounded-sm object-cover {isMusic ? 'w-24' : 'w-16'}"
+				onerror={posterFallback}
+			/>
+		{:else}
+			<div class="flex h-24 shrink-0 items-center justify-center rounded-sm {isMusic ? 'w-24' : 'w-16'} {typeConfig.placeholderClasses}">
+				<svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+					{#if isMusic}
+						<path d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+					{:else}
+						<circle cx="12" cy="12" r="10" />
+						<circle cx="12" cy="12" r="3" />
+						<circle cx="12" cy="12" r="6.5" stroke-width="0.75" opacity="0.4" />
+					{/if}
+				</svg>
+			</div>
+		{/if}
 
 		<!-- Info -->
 		<div class="min-w-0 flex-1">

--- a/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -5,6 +5,7 @@
 	import type { NamingPreviewTrack } from '$lib/api/jobs';
 	import { getVideoTypeConfig, discTypeLabel } from '$lib/utils/job-type';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
+	import PosterImage from './PosterImage.svelte';
 	import CountdownTimer from './CountdownTimer.svelte';
 	import TitleSearch from './TitleSearch.svelte';
 	import MusicSearch from './MusicSearch.svelte';
@@ -409,26 +410,7 @@
 	<!-- Header -->
 	<div class="flex gap-4 p-4">
 		<!-- Poster -->
-		{#if job.poster_url}
-			<img
-				src={posterSrc(job.poster_url)}
-				alt={job.title ?? 'Poster'}
-				class="h-24 shrink-0 rounded-sm object-cover {isMusic ? 'w-24' : 'w-16'}"
-				onerror={posterFallback}
-			/>
-		{:else}
-			<div class="flex h-24 shrink-0 items-center justify-center rounded-sm {isMusic ? 'w-24' : 'w-16'} {typeConfig.placeholderClasses}">
-				<svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-					{#if isMusic}
-						<path d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-					{:else}
-						<circle cx="12" cy="12" r="10" />
-						<circle cx="12" cy="12" r="3" />
-						<circle cx="12" cy="12" r="6.5" stroke-width="0.75" opacity="0.4" />
-					{/if}
-				</svg>
-			</div>
-		{/if}
+		<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-24 shrink-0 rounded-sm object-cover {isMusic ? 'w-24' : 'w-16'}" />
 
 		<!-- Info -->
 		<div class="min-w-0 flex-1">

--- a/frontend/src/lib/components/FileRow.svelte
+++ b/frontend/src/lib/components/FileRow.svelte
@@ -7,6 +7,7 @@
 		entry: FileEntry;
 		currentPath: string;
 		selected: boolean;
+		readonly?: boolean;
 		onnavigate: (path: string) => void;
 		onrename: (path: string, name: string) => void;
 		ondelete: (path: string, name: string) => void;
@@ -14,7 +15,7 @@
 		onfixpermissions: (path: string, name: string) => void;
 	}
 
-	let { entry, currentPath, selected, onnavigate, onrename, ondelete, ontoggle, onfixpermissions }: Props = $props();
+	let { entry, currentPath, selected, readonly: ro = false, onnavigate, onrename, ondelete, ontoggle, onfixpermissions }: Props = $props();
 
 	let editing = $state(false);
 	let editName = $state('');
@@ -128,8 +129,9 @@
 			<button
 				type="button"
 				onclick={() => onfixpermissions(fullPath, entry.name)}
-				class="rounded p-1.5 text-gray-400 hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
-				title="Fix permissions"
+				disabled={ro}
+				class="rounded p-1.5 text-gray-400 hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-900/20 dark:hover:text-blue-400 disabled:opacity-30 disabled:pointer-events-none"
+				title={ro ? 'Read-only mount' : 'Fix permissions'}
 			>
 				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -139,8 +141,9 @@
 			<button
 				type="button"
 				onclick={startRename}
-				class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-				title="Rename"
+				disabled={ro}
+				class="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300 disabled:opacity-30 disabled:pointer-events-none"
+				title={ro ? 'Read-only mount' : 'Rename'}
 			>
 				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
@@ -150,8 +153,9 @@
 			<button
 				type="button"
 				onclick={() => ondelete(fullPath, entry.name)}
-				class="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-				title="Delete"
+				disabled={ro}
+				class="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400 disabled:opacity-30 disabled:pointer-events-none"
+				title={ro ? 'Read-only mount' : 'Delete'}
 			>
 				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/frontend/src/lib/components/JobCard.svelte
+++ b/frontend/src/lib/components/JobCard.svelte
@@ -32,17 +32,7 @@
 	class="block rounded-lg border border-primary/20 border-l-4 {typeConfig.accentBorder} bg-surface p-4 shadow-xs transition hover:shadow-md dark:border-primary/20 dark:bg-surface-dark"
 >
 	<div class="flex gap-4">
-		{#if job.poster_url}
-			<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-24 w-16 rounded-sm object-cover" />
-		{:else}
-			<div class="flex h-24 w-16 items-center justify-center rounded-sm {typeConfig.placeholderClasses}">
-				<svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-					<circle cx="12" cy="12" r="10" />
-					<circle cx="12" cy="12" r="3" />
-					<circle cx="12" cy="12" r="6.5" stroke-width="0.75" opacity="0.4" />
-				</svg>
-			</div>
-		{/if}
+		<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-24 w-16 rounded-sm object-cover" />
 		<div class="min-w-0 flex-1">
 			<!-- Row 1: Title + Status -->
 			<div class="flex items-start justify-between gap-2">

--- a/frontend/src/lib/components/PosterImage.svelte
+++ b/frontend/src/lib/components/PosterImage.svelte
@@ -5,17 +5,15 @@
 		url: string | null | undefined;
 		alt?: string;
 		class?: string;
-		style?: string;
 	}
 
-	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover', style: styleStr = '' }: Props = $props();
+	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover' }: Props = $props();
 </script>
 
 <img
 	src={posterSrc(url)}
 	{alt}
 	class={className}
-	style={styleStr || undefined}
 	loading="lazy"
 	onerror={posterFallback}
 />

--- a/frontend/src/lib/components/PosterImage.svelte
+++ b/frontend/src/lib/components/PosterImage.svelte
@@ -1,19 +1,42 @@
 <script lang="ts">
-	import { posterSrc, posterFallback } from '$lib/utils/poster';
+	import { posterSrc } from '$lib/utils/poster';
 
 	interface Props {
 		url: string | null | undefined;
 		alt?: string;
 		class?: string;
+		style?: string;
 	}
 
-	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover' }: Props = $props();
+	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover', style: styleStr = '' }: Props = $props();
+
+	let showFallback = $state(!url);
+
+	function onError() {
+		showFallback = true;
+	}
+
+	// Reset fallback when url changes
+	$effect(() => {
+		showFallback = !url;
+	});
 </script>
 
-<img
-	src={posterSrc(url)}
-	{alt}
-	class={className}
-	loading="lazy"
-	onerror={posterFallback}
-/>
+{#if showFallback}
+	<div class="flex items-center justify-center rounded-sm bg-blue-100 text-blue-400 dark:bg-blue-900/30 dark:text-blue-500 {className}" style={styleStr || undefined}>
+		<svg class="h-2/5 w-2/5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+			<circle cx="12" cy="12" r="10" />
+			<circle cx="12" cy="12" r="3" />
+			<circle cx="12" cy="12" r="6.5" stroke-width="0.75" opacity="0.4" />
+		</svg>
+	</div>
+{:else}
+	<img
+		src={posterSrc(url)}
+		{alt}
+		class={className}
+		style={styleStr || undefined}
+		loading="lazy"
+		onerror={onError}
+	/>
+{/if}

--- a/frontend/src/lib/components/PosterImage.svelte
+++ b/frontend/src/lib/components/PosterImage.svelte
@@ -5,15 +5,17 @@
 		url: string | null | undefined;
 		alt?: string;
 		class?: string;
+		style?: string;
 	}
 
-	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover' }: Props = $props();
+	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover', style: styleStr = '' }: Props = $props();
 </script>
 
 <img
 	src={posterSrc(url)}
 	{alt}
 	class={className}
+	style={styleStr || undefined}
 	loading="lazy"
 	onerror={posterFallback}
 />

--- a/frontend/src/lib/components/TranscodeCard.svelte
+++ b/frontend/src/lib/components/TranscodeCard.svelte
@@ -4,7 +4,7 @@
 	import ProgressBar from './ProgressBar.svelte';
 	import { elapsedTime } from '$lib/utils/format';
 	import { discTypeLabel } from '$lib/utils/job-type';
-	import PosterImage from './PosterImage.svelte';
+	import { posterSrc } from '$lib/utils/poster';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
 	import { slide } from 'svelte/transition';
@@ -38,8 +38,17 @@
 >
 	<!-- Collapsed row -->
 	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
-		<!-- Poster thumbnail -->
-		<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
+		<!-- Icon -->
+		{#if job.poster_url}
+			<img src={posterSrc(job.poster_url)} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
+		{:else}
+			<div class="flex h-10 w-7 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-primary dark:bg-primary/15">
+				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+					<circle cx="12" cy="12" r="10" />
+					<circle cx="12" cy="12" r="3" />
+				</svg>
+			</div>
+		{/if}
 
 		<!-- Title -->
 		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
@@ -121,7 +130,9 @@
 	{#if expanded}
 		<div transition:slide={{ duration: 200 }} class="border-t border-primary/10 px-4 py-3 dark:border-primary/15">
 			<div class="flex gap-4">
-				<PosterImage url={job.poster_url} alt={displayTitle} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
+				{#if job.poster_url}
+					<img src={posterSrc(job.poster_url)} alt={displayTitle} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
+				{/if}
 
 				<div class="min-w-0 flex-1">
 					<div class="mb-2">

--- a/frontend/src/lib/components/TranscodeCard.svelte
+++ b/frontend/src/lib/components/TranscodeCard.svelte
@@ -4,7 +4,7 @@
 	import ProgressBar from './ProgressBar.svelte';
 	import { elapsedTime } from '$lib/utils/format';
 	import { discTypeLabel } from '$lib/utils/job-type';
-	import { posterSrc } from '$lib/utils/poster';
+	import PosterImage from './PosterImage.svelte';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
 	import { slide } from 'svelte/transition';
@@ -38,17 +38,8 @@
 >
 	<!-- Collapsed row -->
 	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
-		<!-- Icon -->
-		{#if job.poster_url}
-			<img src={posterSrc(job.poster_url)} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
-		{:else}
-			<div class="flex h-10 w-7 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-primary dark:bg-primary/15">
-				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-					<circle cx="12" cy="12" r="10" />
-					<circle cx="12" cy="12" r="3" />
-				</svg>
-			</div>
-		{/if}
+		<!-- Poster thumbnail -->
+		<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
 
 		<!-- Title -->
 		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
@@ -130,9 +121,7 @@
 	{#if expanded}
 		<div transition:slide={{ duration: 200 }} class="border-t border-primary/10 px-4 py-3 dark:border-primary/15">
 			<div class="flex gap-4">
-				{#if job.poster_url}
-					<img src={posterSrc(job.poster_url)} alt={displayTitle} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
-				{/if}
+				<PosterImage url={job.poster_url} alt={displayTitle} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
 
 				<div class="min-w-0 flex-1">
 					<div class="mb-2">

--- a/frontend/src/lib/types/files.ts
+++ b/frontend/src/lib/types/files.ts
@@ -3,6 +3,7 @@ export interface FileRoot {
 	label: string;
 	path: string;
 	host_path?: string;
+	readonly?: boolean;
 }
 
 export interface FileEntry {
@@ -21,4 +22,5 @@ export interface DirectoryListing {
 	path: string;
 	parent: string | null;
 	entries: FileEntry[];
+	readonly?: boolean;
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -52,6 +52,8 @@
 		return s !== 'waiting' && s !== 'transcoding' && s !== 'waiting_transcode' && s !== 'identifying' && s !== 'ready';
 	}));
 
+	let pageReady = $derived(dashReady && jobsData !== null);
+
 	let progressMap = $state<Record<number, RipProgress>>({});
 
 	function dismissJob(jobId: number) {
@@ -308,24 +310,22 @@
 	</div>
 
 	<!-- Job counts -->
-	{#if jobsStats}
-		<div class="flex flex-wrap gap-3">
-			{#each [
-				{ key: 'total' as const, label: 'Total', border: 'border-l-indigo-500', bg: 'bg-indigo-50 dark:bg-indigo-900/20', text: 'text-indigo-700 dark:text-indigo-300' },
-				{ key: 'active' as const, label: 'Active', border: 'border-l-blue-500', bg: 'bg-blue-50 dark:bg-blue-900/20', text: 'text-blue-700 dark:text-blue-300' },
-				{ key: 'success' as const, label: 'Success', border: 'border-l-green-500', bg: 'bg-green-50 dark:bg-green-900/20', text: 'text-green-700 dark:text-green-300' },
-				{ key: 'fail' as const, label: 'Failed', border: 'border-l-red-500', bg: 'bg-red-50 dark:bg-red-900/20', text: 'text-red-700 dark:text-red-300' },
-				{ key: 'waiting' as const, label: 'Waiting', border: 'border-l-amber-500', bg: 'bg-amber-50 dark:bg-amber-900/20', text: 'text-amber-700 dark:text-amber-300' }
-			] as card}
-				<div class="flex min-w-[100px] flex-1 items-center gap-3 rounded-lg border-l-4 {card.border} {card.bg} px-4 py-3">
-					<div>
-						<div class="text-2xl font-bold {card.text}">{jobsStats[card.key]}</div>
-						<div class="text-xs font-medium text-gray-500 dark:text-gray-400">{card.label}</div>
-					</div>
+	<div class="flex flex-wrap gap-3">
+		{#each [
+			{ key: 'total' as const, label: 'Total', border: 'border-l-indigo-500', bg: 'bg-indigo-50 dark:bg-indigo-900/20', text: 'text-indigo-700 dark:text-indigo-300' },
+			{ key: 'active' as const, label: 'Active', border: 'border-l-blue-500', bg: 'bg-blue-50 dark:bg-blue-900/20', text: 'text-blue-700 dark:text-blue-300' },
+			{ key: 'success' as const, label: 'Success', border: 'border-l-green-500', bg: 'bg-green-50 dark:bg-green-900/20', text: 'text-green-700 dark:text-green-300' },
+			{ key: 'fail' as const, label: 'Failed', border: 'border-l-red-500', bg: 'bg-red-50 dark:bg-red-900/20', text: 'text-red-700 dark:text-red-300' },
+			{ key: 'waiting' as const, label: 'Waiting', border: 'border-l-amber-500', bg: 'bg-amber-50 dark:bg-amber-900/20', text: 'text-amber-700 dark:text-amber-300' }
+		] as card}
+			<div class="flex min-w-[100px] flex-1 items-center gap-3 rounded-lg border-l-4 {card.border} {card.bg} px-4 py-3">
+				<div>
+					<div class="text-2xl font-bold {card.text}">{jobsStats?.[card.key] ?? '—'}</div>
+					<div class="text-xs font-medium text-gray-500 dark:text-gray-400">{card.label}</div>
 				</div>
-			{/each}
-		</div>
-	{/if}
+			</div>
+		{/each}
+	</div>
 
 	<!-- Global pause banner -->
 	{#if dashReady && !dash.ripping_enabled}
@@ -404,7 +404,7 @@
 	{/if}
 
 	<!-- Idle state -->
-	{#if dashReady && scanningJobs.length === 0 && waitingJobs.length === 0 && nonWaitingActiveJobs.length === 0 && dash.active_transcodes.length === 0}
+	{#if pageReady && scanningJobs.length === 0 && waitingJobs.length === 0 && nonWaitingActiveJobs.length === 0 && dash.active_transcodes.length === 0}
 		<section>
 			<div class="rounded-lg border border-primary/20 bg-surface p-6 text-center shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 				<svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -473,7 +473,12 @@
 					{jobsError}
 				</div>
 			{:else if jobsLoading}
-				<div class="py-8 text-center text-gray-400">Loading...</div>
+				<div class="flex items-center justify-center py-8">
+					<svg class="h-6 w-6 animate-spin text-gray-300 dark:text-gray-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+					</svg>
+				</div>
 			{:else if jobsData}
 				{#if viewMode === 'table'}
 					<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -52,8 +52,6 @@
 		return s !== 'waiting' && s !== 'transcoding' && s !== 'waiting_transcode' && s !== 'identifying' && s !== 'ready';
 	}));
 
-	let pageReady = $derived(dashReady && jobsData !== null);
-
 	let progressMap = $state<Record<number, RipProgress>>({});
 
 	function dismissJob(jobId: number) {
@@ -106,6 +104,7 @@
 
 	// --- Jobs section state ---
 	let jobsData = $state<JobListResponse | null>(null);
+	let pageReady = $derived(dashReady && jobsData !== null);
 	let jobsStats = $state<JobStats | null>(null);
 	let jobsError = $state<string | null>(null);
 	let jobsLoading = $state(true);

--- a/frontend/src/routes/files/+page.svelte
+++ b/frontend/src/routes/files/+page.svelte
@@ -495,6 +495,16 @@
 		{/if}
 	{/if}
 
+	<!-- Read-only mount banner -->
+	{#if isReadonly}
+		<div class="flex items-center gap-2 rounded-lg border border-amber-300/50 bg-amber-50/50 px-4 py-2.5 dark:border-amber-700/50 dark:bg-amber-900/20">
+			<svg class="h-4 w-4 shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+			</svg>
+			<p class="text-sm text-amber-700 dark:text-amber-400">This directory is on a read-only mount. File operations are disabled.</p>
+		</div>
+	{/if}
+
 	<!-- Breadcrumb + toolbar row -->
 	{#if currentPath && roots.length > 0}
 		<div class="flex items-center justify-between gap-3">

--- a/frontend/src/routes/files/+page.svelte
+++ b/frontend/src/routes/files/+page.svelte
@@ -56,6 +56,17 @@
 
 	let isReadonly = $derived(listing?.readonly === true);
 
+	// Find the most specific (longest path) matching root for the current path
+	let activeRootPath = $derived.by(() => {
+		let best = '';
+		for (const r of roots) {
+			if ((currentPath === r.path || currentPath.startsWith(r.path + '/')) && r.path.length > best.length) {
+				best = r.path;
+			}
+		}
+		return best;
+	});
+
 	let sortedEntries = $derived.by(() => {
 		if (!listing) return [];
 		return [...listing.entries].sort((a, b) => {
@@ -460,8 +471,8 @@
 					<button
 						type="button"
 						onclick={() => navigate(root.path)}
-						class="whitespace-nowrap border-b-2 px-1 py-2.5 text-sm font-medium transition-colors
-							{currentPath.startsWith(root.path)
+							class="whitespace-nowrap border-b-2 px-1 py-2.5 text-sm font-medium transition-colors
+							{root.path === activeRootPath
 								? 'border-primary text-primary-text dark:border-primary-text-dark dark:text-primary-text-dark'
 								: 'border-transparent text-gray-500 hover:border-primary/30 hover:text-gray-700 dark:text-gray-400 dark:hover:border-primary/30 dark:hover:text-gray-300'}"
 					>
@@ -470,7 +481,7 @@
 				{/each}
 			</nav>
 		</div>
-		{@const activeRoot = roots.find(r => currentPath.startsWith(r.path))}
+		{@const activeRoot = roots.find(r => r.path === activeRootPath)}
 		{#if activeRoot}
 			<details class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 				<summary class="cursor-pointer select-none font-semibold uppercase tracking-wide hover:text-gray-500 dark:hover:text-gray-400">Paths</summary>

--- a/frontend/src/routes/files/+page.svelte
+++ b/frontend/src/routes/files/+page.svelte
@@ -54,6 +54,8 @@
 	let transcoderCleanupOpen = $state(false);
 	let transcoderBusy = $state(false);
 
+	let isReadonly = $derived(listing?.readonly === true);
+
 	let sortedEntries = $derived.by(() => {
 		if (!listing) return [];
 		return [...listing.entries].sort((a, b) => {
@@ -492,7 +494,8 @@
 					<button
 						type="button"
 						onclick={openMoveDialog}
-						class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary hover:bg-primary/90"
+						disabled={isReadonly}
+						class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
 					>
 						<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
@@ -502,7 +505,8 @@
 					<button
 						type="button"
 						onclick={() => (bulkDeleteOpen = true)}
-						class="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700"
+						disabled={isReadonly}
+						class="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 disabled:pointer-events-none"
 					>
 						<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -537,8 +541,9 @@
 				<button
 					type="button"
 					onclick={startNewFolder}
-					class="rounded-lg p-2 text-gray-500 hover:bg-primary/10 dark:text-gray-400 dark:hover:bg-primary/15"
-					title="New folder"
+					disabled={isReadonly}
+					class="rounded-lg p-2 text-gray-500 hover:bg-primary/10 dark:text-gray-400 dark:hover:bg-primary/15 disabled:opacity-30 disabled:pointer-events-none"
+					title={isReadonly ? 'Read-only mount' : 'New folder'}
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
@@ -653,6 +658,7 @@
 								{entry}
 								currentPath={listing.path}
 								selected={selectedPaths.has(listing.path + '/' + entry.name)}
+								readonly={isReadonly}
 								onnavigate={navigate}
 								onrename={handleRename}
 								ondelete={handleDeleteRequest}

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -5,6 +5,7 @@
 	import { fetchJob, retranscodeJob, fetchMusicDetail, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
 	import type { NamingPreviewTrack } from '$lib/api/jobs';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
+	import PosterImage from '$lib/components/PosterImage.svelte';
 	import { fetchStructuredTranscoderLogContent, fetchTranscoderLogForArmJob } from '$lib/api/logs';
 	import type { JobDetail, MusicDetail } from '$lib/types/arm';
 	import JobActions from '$lib/components/JobActions.svelte';
@@ -309,25 +310,12 @@
 			<div class="flex items-start">
 				<!-- Poster -->
 				<div class="shrink-0 border-r border-primary/15 p-4 dark:border-primary/15">
-					{#if job.poster_url}
-						<img
-							src={posterSrc(job.poster_url)}
-							alt={job.title ?? 'Poster'}
-							class="rounded-md object-cover shadow-sm {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
-							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
-							onerror={posterFallback}
-						/>
-					{:else}
-						<div
-							class="flex items-center justify-center rounded-md border border-dashed border-primary/20 bg-primary/5 dark:border-primary/15 dark:bg-primary/5 {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
-							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
-						>
-							<svg class="h-8 w-8 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-								<circle cx="12" cy="12" r="10" />
-								<circle cx="12" cy="12" r="3" />
-							</svg>
-						</div>
-					{/if}
+					<PosterImage
+						url={job.poster_url}
+						alt={job.title ?? 'Poster'}
+						class="rounded-md object-cover shadow-sm {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+						style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+					/>
 				</div>
 
 				<!-- Metadata grid -->

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -5,7 +5,6 @@
 	import { fetchJob, retranscodeJob, fetchMusicDetail, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
 	import type { NamingPreviewTrack } from '$lib/api/jobs';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
-	import PosterImage from '$lib/components/PosterImage.svelte';
 	import { fetchStructuredTranscoderLogContent, fetchTranscoderLogForArmJob } from '$lib/api/logs';
 	import type { JobDetail, MusicDetail } from '$lib/types/arm';
 	import JobActions from '$lib/components/JobActions.svelte';
@@ -310,12 +309,25 @@
 			<div class="flex items-start">
 				<!-- Poster -->
 				<div class="shrink-0 border-r border-primary/15 p-4 dark:border-primary/15">
-					<PosterImage
-						url={job.poster_url}
-						alt={job.title ?? 'Poster'}
-						class="rounded-md object-cover shadow-sm {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
-						style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
-					/>
+					{#if job.poster_url}
+						<img
+							src={posterSrc(job.poster_url)}
+							alt={job.title ?? 'Poster'}
+							class="rounded-md object-cover shadow-sm {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+							onerror={posterFallback}
+						/>
+					{:else}
+						<div
+							class="flex items-center justify-center rounded-md border border-dashed border-primary/20 bg-primary/5 dark:border-primary/15 dark:bg-primary/5 {isMusicDisc ? 'h-[120px] w-[120px]' : 'w-[120px]'}"
+							style={isMusicDisc ? '' : 'aspect-ratio: 2/3'}
+						>
+							<svg class="h-8 w-8 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+								<circle cx="12" cy="12" r="10" />
+								<circle cx="12" cy="12" r="3" />
+							</svg>
+						</div>
+					{/if}
 				</div>
 
 				<!-- Metadata grid -->


### PR DESCRIPTION
## Summary
- Always render stats cards with `—` placeholders instead of hiding behind `{#if jobsStats}`, eliminating top-of-page layout shift
- Gate idle message on `pageReady` (both dashboard AND jobs loaded) so it doesn't flash before job cards appear
- Replace "Loading..." text with a subtle spinner

## Test plan
- [ ] Hard refresh dashboard — stats cards visible immediately with dashes, no layout jump
- [ ] Idle message doesn't flash before jobs load
- [ ] No "Loading..." text visible — spinner shows briefly instead
- [ ] All sections render correctly once data arrives