### PR TITLE
fix: topnav shows ripping+transcoding for same job

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -16,6 +16,10 @@
 	let sidebarOpen = $state(false);
 	let togglingPause = $state(false);
 	let quickMenuOpen = $state(false);
+	const rippingCount = $derived($dashboard.active_jobs.filter(j => {
+		const s = j.status?.toLowerCase();
+		return s !== 'transcoding' && s !== 'waiting_transcode';
+	}).length);
 
 	function closeQuickMenu() {
 		quickMenuOpen = false;
@@ -165,8 +169,8 @@
 				<!-- Live activity -->
 				<div class="flex items-center gap-3 text-xs">
 					<a href="/settings#drives" class="text-gray-600 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">{$dashboard.db_available ? $dashboard.drives_online : '--'} drive{$dashboard.drives_online !== 1 ? 's' : ''}</a>
-					{#if $dashboard.active_jobs.length > 0}
-						<span class="font-semibold text-blue-600 dark:text-blue-400">{$dashboard.active_jobs.length} ripping</span>
+					{#if rippingCount > 0}
+						<span class="font-semibold text-blue-600 dark:text-blue-400">{rippingCount} ripping</span>
 					{/if}
 					{#if $dashboard.active_transcodes.length > 0}
 						<span class="font-semibold text-indigo-600 dark:text-indigo-400">{$dashboard.active_transcodes.length} transcoding</span>

--- a/frontend/src/routes/__tests__/layout.test.ts
+++ b/frontend/src/routes/__tests__/layout.test.ts
@@ -64,4 +64,30 @@ describe('Layout', () => {
 		const logos = screen.getAllByAltText('ARM');
 		expect(logos.length).toBeGreaterThanOrEqual(1);
 	});
+
+	it('topnav ripping count excludes transcoding jobs', async () => {
+		const { dashboard } = await import('$lib/stores/dashboard');
+
+		// Set active_jobs with one ripping and one transcoding job
+		dashboard.update(() => ({
+			db_available: true, arm_online: true,
+			active_jobs: [
+				{ job_id: 1, status: 'ripping', title: 'Movie A' },
+				{ job_id: 2, status: 'transcoding', title: 'Movie B' },
+			] as never[],
+			system_info: null, drives_online: 1, drive_names: {},
+			notification_count: 0, ripping_enabled: true,
+			makemkv_key_valid: null, makemkv_key_checked_at: null,
+			transcoder_online: false, transcoder_stats: null,
+			transcoder_system_stats: null, active_transcodes: [],
+			system_stats: null, transcoder_info: null
+		}));
+
+		renderComponent(Layout, { props: { children: childSnippet() } });
+
+		// Should show "1 ripping", not "2 ripping"
+		const rippingBadges = screen.getAllByText(/ripping/i);
+		const rippingBadge = rippingBadges.find(el => el.textContent?.match(/^\d+ ripping$/));
+		expect(rippingBadge?.textContent).toBe('1 ripping');
+	});
 });


### PR DESCRIPTION
## Summary
- The topnav activity badges showed `active_jobs.length` as "N ripping" without filtering out jobs that have transitioned to transcoding status
- A single job in `transcoding` state appeared as both "1 ripping" and "1 transcoding"
- Filter out `transcoding` and `waiting_transcode` statuses from the ripping count, matching the same logic the dashboard page uses for its "ACTIVE RIPS" section

## Test plan
- [x] All 744 frontend tests pass
- [ ] Rip a disc, confirm topnav shows "1 ripping" during rip, then "1 transcoding" after handoff (not both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)