### PR TITLE
fix: replace filter pills with dropdown selects on dashboard

### DIFF
--- a/frontend/src/lib/components/JobFilterBar.svelte
+++ b/frontend/src/lib/components/JobFilterBar.svelte
@@ -23,102 +23,65 @@
 		onsearch
 	}: Props = $props();
 
-	const pillBase = 'px-2.5 py-1 rounded-md text-xs font-semibold cursor-pointer transition-colors';
-	const pillActive =
-		'bg-primary/20 text-primary-text dark:bg-primary/25 dark:text-primary-text-dark outline outline-2 outline-primary/40';
-	const pillInactive =
-		'bg-primary/5 text-gray-500 hover:bg-primary/10 dark:bg-primary/10 dark:text-gray-400 hover:dark:bg-primary/15';
-
-	const statusPills = [
-		{ label: 'All', value: '' },
-		{ label: 'Active', value: 'active' },
-		{ label: 'Success', value: 'success' },
-		{ label: 'Failed', value: 'fail' },
-		{ label: 'Waiting', value: 'waiting' }
-	];
-
-	const typePills = [
-		{ label: 'All', value: '' },
-		{ label: 'Movie', value: 'movie' },
-		{ label: 'Series', value: 'series' },
-		{ label: 'Music', value: 'music' }
-	];
-
-	const discTypes = [
-		{ label: 'All', value: '' },
-		{ label: 'Blu-ray', value: 'bluray' },
-		{ label: 'DVD', value: 'dvd' },
-		{ label: 'CD', value: 'music' },
-		{ label: 'Data', value: 'data' }
-	];
-
-	const daysOptions = [
-		{ label: 'All Time', value: undefined as number | undefined },
-		{ label: '7 days', value: 7 },
-		{ label: '30 days', value: 30 },
-		{ label: '90 days', value: 90 }
-	];
+	const selectClasses = 'rounded-lg border border-primary/25 bg-primary/5 px-3 py-2 text-sm dark:border-primary/30 dark:bg-primary/10 dark:text-white';
 </script>
 
-<!-- Row 1: Search | Status pills | Type pills -->
 <div class="flex flex-wrap items-center gap-3">
 	<input
 		type="text"
 		placeholder="Search titles..."
 		oninput={onsearch}
-		class="lcars-input w-48 rounded-lg border border-primary/25 bg-primary/5 px-3 py-2 text-sm dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+		class="lcars-input w-64 rounded-lg border border-primary/25 bg-primary/5 px-3 py-2 text-sm dark:border-primary/30 dark:bg-primary/10 dark:text-white"
 	/>
 
-	<div class="h-6 w-px bg-gray-300 dark:bg-gray-600"></div>
+	<div class="h-6 w-px bg-primary/20 dark:bg-primary/20"></div>
 
-	<!-- Status pills -->
-	<div class="flex flex-wrap gap-1.5">
-		{#each statusPills as pill}
-			<button
-				onclick={() => onstatusfilter(pill.value)}
-				class="{pillBase} {statusFilter === pill.value ? pillActive : pillInactive}"
-			>{pill.label}</button>
-		{/each}
-	</div>
+	<select
+		value={statusFilter}
+		onchange={(e) => onstatusfilter((e.target as HTMLSelectElement).value)}
+		class={selectClasses}
+	>
+		<option value="">All Status</option>
+		<option value="active">Active</option>
+		<option value="success">Success</option>
+		<option value="fail">Failed</option>
+		<option value="waiting">Waiting</option>
+	</select>
 
-	<div class="h-6 w-px bg-gray-300 dark:bg-gray-600"></div>
+	<select
+		value={videoTypeFilter}
+		onchange={(e) => onvideotypefilter((e.target as HTMLSelectElement).value)}
+		class={selectClasses}
+	>
+		<option value="">All Types</option>
+		<option value="movie">Movie</option>
+		<option value="series">Series</option>
+		<option value="music">Music</option>
+	</select>
 
-	<!-- Type pills -->
-	<div class="flex flex-wrap gap-1.5">
-		{#each typePills as pill}
-			<button
-				onclick={() => onvideotypefilter(pill.value)}
-				class="{pillBase} {videoTypeFilter === pill.value ? pillActive : pillInactive}"
-			>{pill.label}</button>
-		{/each}
-	</div>
-</div>
+	<select
+		value={disctypeFilter}
+		onchange={(e) => ondisctypefilter((e.target as HTMLSelectElement).value)}
+		class={selectClasses}
+	>
+		<option value="">All Discs</option>
+		<option value="bluray">Blu-ray</option>
+		<option value="dvd">DVD</option>
+		<option value="music">CD</option>
+		<option value="data">Data</option>
+	</select>
 
-<!-- Row 2: Disc pills | Time range -->
-<div class="flex flex-wrap items-center gap-3">
-	<!-- Disc pills -->
-	<div class="flex flex-wrap gap-1.5">
-		{#each discTypes as disc}
-			<button
-				onclick={() => ondisctypefilter(disc.value)}
-				class="{pillBase} {disctypeFilter === disc.value ? pillActive : pillInactive}"
-			>{disc.label}</button>
-		{/each}
-	</div>
-
-	<div class="h-6 w-px bg-gray-300 dark:bg-gray-600"></div>
-
-	<!-- Time range select -->
 	<select
 		value={daysFilter ?? ''}
 		onchange={(e) => {
 			const val = (e.target as HTMLSelectElement).value;
 			ondaysfilter(val ? Number(val) : undefined);
 		}}
-		class="lcars-input rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-xs dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+		class={selectClasses}
 	>
-		{#each daysOptions as opt}
-			<option value={opt.value ?? ''}>{opt.label}</option>
-		{/each}
+		<option value="">All Time</option>
+		<option value="7">7 days</option>
+		<option value="30">30 days</option>
+		<option value="90">90 days</option>
 	</select>
 </div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -419,54 +419,59 @@
 
 	<!-- All Jobs -->
 	<section id="all-jobs" class="space-y-4">
-			<div class="flex flex-wrap items-center justify-between gap-4">
-				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">All Jobs</h2>
-				<div class="flex gap-2">
-					<button
-						onclick={() => viewMode = 'card'}
-						class="rounded-lg px-3 py-1.5 text-sm {viewMode === 'card' ? 'bg-primary text-on-primary' : 'bg-primary/15 text-gray-700 dark:bg-primary/15 dark:text-gray-300'}"
-					>Cards</button>
-					<button
-						onclick={() => viewMode = 'table'}
-						class="rounded-lg px-3 py-1.5 text-sm {viewMode === 'table' ? 'bg-primary text-on-primary' : 'bg-primary/15 text-gray-700 dark:bg-primary/15 dark:text-gray-300'}"
-					>Table</button>
+			<!-- Controls panel -->
+			<div class="rounded-lg border border-primary/20 bg-surface shadow-xs dark:border-primary/20 dark:bg-surface-dark">
+				<!-- Header: Title + View toggle + Bulk actions -->
+				<div class="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">All Jobs</h2>
+					<div class="flex items-center gap-3">
+						<div class="flex gap-1">
+							<button
+								onclick={() => viewMode = 'card'}
+								class="rounded-md px-3 py-1.5 text-xs font-medium {viewMode === 'card' ? 'bg-primary text-on-primary' : 'bg-primary/10 text-gray-600 hover:bg-primary/15 dark:bg-primary/15 dark:text-gray-300'}"
+							>Cards</button>
+							<button
+								onclick={() => viewMode = 'table'}
+								class="rounded-md px-3 py-1.5 text-xs font-medium {viewMode === 'table' ? 'bg-primary text-on-primary' : 'bg-primary/10 text-gray-600 hover:bg-primary/15 dark:bg-primary/15 dark:text-gray-300'}"
+							>Table</button>
+						</div>
+						<div class="h-5 w-px bg-primary/20 dark:bg-primary/20"></div>
+						<BulkActionsMenu
+							{selectedJobs}
+							{jobsStats}
+							{gearOpen}
+							{bulkBusy}
+							onaction={handleBulkAction}
+							ontoggle={() => (gearOpen = !gearOpen)}
+						/>
+					</div>
 				</div>
+
+				<!-- Filters -->
+				<div class="border-t border-primary/15 px-4 py-3 dark:border-primary/15">
+					<JobFilterBar
+						{statusFilter}
+						{videoTypeFilter}
+						{disctypeFilter}
+						{daysFilter}
+						onstatusfilter={setStatusFilter}
+						onvideotypefilter={setVideoTypeFilter}
+						ondisctypefilter={setDisctypeFilter}
+						ondaysfilter={setDaysFilter}
+						onsearch={onSearch}
+					/>
+				</div>
+
+				<!-- Bulk feedback banner -->
+				{#if bulkFeedback}
+					<div class="border-t border-primary/15 px-4 py-3 text-sm dark:border-primary/15 {bulkFeedback.type === 'success' ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}">
+						{bulkFeedback.message}
+						<button onclick={() => (bulkFeedback = null)} class="ml-2 font-bold opacity-60 hover:opacity-100">&times;</button>
+					</div>
+				{/if}
 			</div>
 
-
-			<JobFilterBar
-				{statusFilter}
-				{videoTypeFilter}
-				{disctypeFilter}
-				{daysFilter}
-				onstatusfilter={setStatusFilter}
-				onvideotypefilter={setVideoTypeFilter}
-				ondisctypefilter={setDisctypeFilter}
-				ondaysfilter={setDaysFilter}
-				onsearch={onSearch}
-			/>
-
-			<!-- Filter Row 2 addons: Selection count | Gear menu -->
-			<div class="flex flex-wrap items-center gap-3">
-				<div class="flex-1"></div>
-				<BulkActionsMenu
-					{selectedJobs}
-					{jobsStats}
-					{gearOpen}
-					{bulkBusy}
-					onaction={handleBulkAction}
-					ontoggle={() => (gearOpen = !gearOpen)}
-				/>
-			</div>
-
-			<!-- Bulk feedback banner -->
-			{#if bulkFeedback}
-				<div class="rounded-lg border px-4 py-3 text-sm {bulkFeedback.type === 'success' ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400' : 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400'}">
-					{bulkFeedback.message}
-					<button onclick={() => (bulkFeedback = null)} class="ml-2 font-bold opacity-60 hover:opacity-100">&times;</button>
-				</div>
-			{/if}
-
+			<div style="min-height: 60vh;">
 			{#if jobsError}
 				<div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
 					{jobsError}
@@ -542,5 +547,6 @@
 					<p class="py-8 text-center text-gray-400">No jobs found.</p>
 				{/if}
 			{/if}
+			</div>
 	</section>
 </div>

--- a/frontend/src/routes/__tests__/dashboard-page.test.ts
+++ b/frontend/src/routes/__tests__/dashboard-page.test.ts
@@ -181,46 +181,54 @@ describe('Dashboard Page', () => {
 		);
 	});
 
-	describe('filter pills', () => {
+	describe('filter dropdowns', () => {
 		afterEach(() => cleanup());
 
-		it.each(['Movie', 'Series', 'Music', 'Blu-ray', 'DVD', 'CD', 'Data'])(
-			'renders %s filter pill', async (label) => {
-				await renderDashboard();
-				expect(screen.getByText(label)).toBeInTheDocument();
-			}
-		);
-
-		it('renders All pill buttons', async () => {
+		it('renders filter dropdowns for status, type, disc, and days', async () => {
 			await renderDashboard();
-			expect(screen.getAllByText('All').length).toBeGreaterThanOrEqual(1);
+			const selects = screen.getAllByRole('combobox');
+			expect(selects.length).toBeGreaterThanOrEqual(4);
 		});
 
-		it.each([
-			['Movie', { video_type: 'movie' }],
-			['Blu-ray', { disctype: 'bluray' }]
-		])('clicking %s pill calls fetchJobs with %o', async (label: string, expectedParams: Record<string, string>) => {
+		it('renders search input', async () => {
+			await renderDashboard();
+			expect(screen.getByPlaceholderText('Search titles...')).toBeInTheDocument();
+		});
+
+		it('changing type dropdown calls fetchJobs with video_type', async () => {
 			const { fetchJobs } = await import('$lib/api/jobs');
 			await renderDashboard();
-			await fireEvent.click(screen.getByText(label));
+			const selects = screen.getAllByRole('combobox');
+			// Type dropdown is the second select
+			const typeSelect = selects[1];
+			await fireEvent.change(typeSelect, { target: { value: 'movie' } });
 			await waitFor(() => {
-				expect(fetchJobs).toHaveBeenCalledWith(expect.objectContaining(expectedParams));
+				expect(fetchJobs).toHaveBeenCalledWith(expect.objectContaining({ video_type: 'movie' }));
 			});
 		});
 
-		it('clicking Failed status pill calls fetchJobs with status filter', async () => {
+		it('changing disc dropdown calls fetchJobs with disctype', async () => {
 			const { fetchJobs } = await import('$lib/api/jobs');
 			await renderDashboard();
-			const failedPills = screen.getAllByText('Failed');
-			const failedPill = failedPills.find(el => el.tagName === 'BUTTON' && el.closest(String.raw`.flex.flex-wrap.gap-1\.5`));
-			if (failedPill) {
-				await fireEvent.click(failedPill);
-				await waitFor(() => {
-					expect(fetchJobs).toHaveBeenCalledWith(
-						expect.objectContaining({ status: 'fail', page: 1 })
-					);
-				});
-			}
+			const selects = screen.getAllByRole('combobox');
+			// Disc dropdown is the third select
+			const discSelect = selects[2];
+			await fireEvent.change(discSelect, { target: { value: 'bluray' } });
+			await waitFor(() => {
+				expect(fetchJobs).toHaveBeenCalledWith(expect.objectContaining({ disctype: 'bluray' }));
+			});
+		});
+
+		it('changing status dropdown calls fetchJobs with status', async () => {
+			const { fetchJobs } = await import('$lib/api/jobs');
+			await renderDashboard();
+			const selects = screen.getAllByRole('combobox');
+			// Status dropdown is the first select
+			const statusSelect = selects[0];
+			await fireEvent.change(statusSelect, { target: { value: 'fail' } });
+			await waitFor(() => {
+				expect(fetchJobs).toHaveBeenCalledWith(expect.objectContaining({ status: 'fail' }));
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Replace filter pill buttons with `<select>` dropdowns for status, video type, disc type, and days
- Cleaner, more compact filter bar
- Wider search input
- Updated dashboard tests for dropdown interactions

## Test plan

- [x] 46 dashboard tests pass
- [x] Build succeeds
- [ ] Verify dropdowns filter correctly on live dashboard