### PR TITLE
fix: redirect to home after job delete

### DIFF
--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -204,7 +204,7 @@
 			});
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('404')) {
-				goto('/jobs');
+				goto('/');
 				return;
 			}
 			error = e instanceof Error ? e.message : 'Failed to load job';

--- a/frontend/src/routes/jobs/__tests__/job-detail-page.test.ts
+++ b/frontend/src/routes/jobs/__tests__/job-detail-page.test.ts
@@ -104,4 +104,17 @@ describe('Job Detail Page', () => {
 			expect(container).toBeInTheDocument();
 		});
 	});
+
+	describe('error handling', () => {
+		it('redirects to home on 404', async () => {
+			const { fetchJob } = await import('$lib/api/jobs');
+			const { goto } = await import('$app/navigation');
+			vi.mocked(fetchJob).mockRejectedValueOnce(new Error('404 Not Found'));
+
+			renderComponent(JobDetailPage);
+			await waitFor(() => {
+				expect(goto).toHaveBeenCalledWith('/');
+			});
+		});
+	});
 });


### PR DESCRIPTION
Redirect to / instead of /jobs (removed page) when a job is deleted or returns 404.