### PR TITLE
fix: correct track counts for music CD rips on dashboard

### DIFF
--- a/backend/services/arm_db.py
+++ b/backend/services/arm_db.py
@@ -99,8 +99,14 @@ def _minlength(job) -> int:
 
 
 def _rippable_tracks(job) -> list:
-    """Return tracks above minlength (the ones ARM will actually rip)."""
+    """Return tracks above minlength (the ones ARM will actually rip).
+
+    Music discs skip the minlength filter — all CD tracks are ripped
+    regardless of length (MINLENGTH is a video-only setting).
+    """
     tracks = list(job.tracks) if job.tracks else []
+    if getattr(job, "disctype", None) == "music":
+        return tracks
     ml = _minlength(job)
     if ml <= 0:
         return tracks

--- a/backend/services/progress.py
+++ b/backend/services/progress.py
@@ -110,11 +110,14 @@ def get_music_progress(logfile: str | None, total_tracks: int) -> dict:
         return result
 
     total = total_tracks or len(all_seen)
-    completed = len(tagging)
+    # Use encoding count as "completed" — abcde logs "Tagging track N"
+    # at the START of tagging, so len(tagging) overcounts by 1 during rip.
+    # Encoding completes before tagging starts, making it the reliable marker.
+    completed = len(encoding)
     current_track = max(all_seen)
 
     if tagging:
-        phase = "tagged"
+        phase = "tagging"
     elif encoding:
         phase = "encoding"
     else:

--- a/backend/services/progress.py
+++ b/backend/services/progress.py
@@ -121,6 +121,8 @@ def get_music_progress(logfile: str | None, total_tracks: int) -> dict:
         phase = "ripping"
 
     result["stage"] = f"{completed}/{total} - {phase} track {current_track}"
+    result["tracks_ripped"] = completed
+    result["tracks_total"] = total
     if total > 0:
         result["progress"] = round(completed / total * 100, 1)
 

--- a/tests/services/test_arm_db_minlength.py
+++ b/tests/services/test_arm_db_minlength.py
@@ -58,6 +58,17 @@ def test_rippable_tracks_filters_short_tracks():
     assert result[0].track_id == 1
 
 
+def test_rippable_tracks_skips_minlength_for_music():
+    """Music discs return ALL tracks regardless of MINLENGTH."""
+    config = make_config(MINLENGTH="600")
+    track1 = make_track(track_id=1, length=200)
+    track2 = make_track(track_id=2, length=180)
+    track3 = make_track(track_id=3, length=250)
+    job = make_job(config=config, tracks=[track1, track2, track3], disctype="music")
+    result = _rippable_tracks(job)
+    assert len(result) == 3
+
+
 def test_rippable_tracks_keeps_none_length():
     """Tracks with length=None are kept (not filtered)."""
     config = make_config(MINLENGTH="600")

--- a/tests/services/test_progress.py
+++ b/tests/services/test_progress.py
@@ -143,9 +143,9 @@ class TestGetMusicProgress:
             mock_settings.arm_log_path = str(tmp_path)
             result = get_music_progress("music.log", total_tracks=3)
         assert result["progress"] is not None
-        assert result["progress"] == pytest.approx(round(1 / 3 * 100, 1))
-        assert "tagged" in result["stage"]
-        assert "1/3" in result["stage"]
+        assert result["progress"] == pytest.approx(round(2 / 3 * 100, 1))
+        assert "tagging" in result["stage"]
+        assert "2/3" in result["stage"]
 
     def test_grabbing_only_phase_ripping(self, tmp_path):
         """Log with only Grabbing lines returns phase='ripping'."""
@@ -172,7 +172,7 @@ class TestGetMusicProgress:
             mock_settings.arm_log_path = str(tmp_path)
             result = get_music_progress("music.log", total_tracks=2)
         assert "encoding" in result["stage"]
-        assert result["progress"] == pytest.approx(0.0)
+        assert result["progress"] == pytest.approx(50.0)  # 1 encoded / 2 total
 
     def test_empty_log(self, tmp_path):
         """Empty log file returns None/None."""


### PR DESCRIPTION
## Summary

Skip the MINLENGTH filter for music discs in `_rippable_tracks()`. MINLENGTH is a video setting (filter short menu/intro tracks) but was applied to CD tracks too, causing the dashboard to show "0/1 tracks" during a 20-track CD rip because all tracks were shorter than 600s.

## Test plan

- [x] 587 backend tests pass
- [ ] Rip a CD, verify dashboard shows correct track count (e.g. 5/20)