### PR TITLE
fix: reduce test code duplication below 3%

### DIFF
--- a/frontend/src/lib/components/DiscReviewWidget.test.ts
+++ b/frontend/src/lib/components/DiscReviewWidget.test.ts
@@ -45,6 +45,18 @@ const mockUpdateJobTitle = vi.mocked(updateJobTitle);
 
 vi.stubGlobal('confirm', vi.fn(() => true));
 
+/** Create a waiting job with common defaults. Merges overrides on top. */
+function waitingJob(overrides: Partial<Parameters<typeof createJob>[0]> = {}) {
+	return createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', ...overrides });
+}
+
+/** Render the widget with a waiting job. Extra props (e.g. ondismiss) can be passed. */
+function renderWidget(jobOverrides: Partial<Parameters<typeof createJob>[0]> = {}, extraProps: Record<string, unknown> = {}) {
+	return renderComponent(DiscReviewWidget, {
+		props: { job: waitingJob(jobOverrides), ...extraProps }
+	});
+}
+
 describe('DiscReviewWidget', () => {
 	afterEach(() => {
 		cleanup();
@@ -54,22 +66,14 @@ describe('DiscReviewWidget', () => {
 
 	describe('rendering', () => {
 		it('renders job title after loading', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' })
-				}
-			});
+			renderWidget();
 			await waitFor(() => {
 				expect(screen.getByText('Test Movie')).toBeInTheDocument();
 			});
 		});
 
 		it('renders Start and Cancel buttons', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' })
-				}
-			});
+			renderWidget();
 			await waitFor(() => {
 				expect(screen.getByText('Start')).toBeInTheDocument();
 				expect(screen.getByText('Cancel')).toBeInTheDocument();
@@ -77,34 +81,21 @@ describe('DiscReviewWidget', () => {
 		});
 
 		it('renders disc type info', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', disctype: 'bluray', wait_start_time: '2025-06-15T11:55:00Z' })
-				}
-			});
+			renderWidget({ disctype: 'bluray' });
 			await waitFor(() => {
 				expect(screen.getByText('Blu-ray')).toBeInTheDocument();
 			});
 		});
 
 		it('renders drive name from driveNames prop', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', devpath: '/dev/sr0' }),
-					driveNames: { '/dev/sr0': 'Main Drive' }
-				}
-			});
+			renderWidget({ devpath: '/dev/sr0' }, { driveNames: { '/dev/sr0': 'Main Drive' } });
 			await waitFor(() => {
 				expect(screen.getByText('Main Drive')).toBeInTheDocument();
 			});
 		});
 
 		it('renders disc label', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', label: 'MOVIE_DISC' })
-				}
-			});
+			renderWidget({ label: 'MOVIE_DISC' });
 			await waitFor(() => {
 				expect(screen.getByText('MOVIE_DISC')).toBeInTheDocument();
 			});
@@ -113,58 +104,19 @@ describe('DiscReviewWidget', () => {
 
 	describe('Episodes button visibility', () => {
 		it('shows Episodes button when video_type is series and imdb_id is set', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', video_type: 'series', disctype: 'bluray', imdb_id: 'tt1234567' })
-				}
-			});
+			renderWidget({ video_type: 'series', disctype: 'bluray', imdb_id: 'tt1234567' });
 			await waitFor(() => {
 				expect(screen.getByText('Episodes')).toBeInTheDocument();
 			});
 		});
 
-		it('does NOT show Episodes button for movie type even with imdb_id', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', video_type: 'movie', disctype: 'bluray', imdb_id: 'tt1234567' })
-				}
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Start')).toBeInTheDocument();
-			});
-			expect(screen.queryByText('Episodes')).not.toBeInTheDocument();
-		});
-
-		it('does NOT show Episodes button for series without imdb_id', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', video_type: 'series', disctype: 'bluray', imdb_id: null })
-				}
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Start')).toBeInTheDocument();
-			});
-			expect(screen.queryByText('Episodes')).not.toBeInTheDocument();
-		});
-
-		it('does NOT show Episodes button for music discs', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', disctype: 'music', video_type: 'music' })
-				}
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Start')).toBeInTheDocument();
-			});
-			expect(screen.queryByText('Episodes')).not.toBeInTheDocument();
-		});
-
-		it('does NOT show Episodes button for video disc with no series type and no imdb_id', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', video_type: 'movie', disctype: 'bluray', imdb_id: null })
-				}
-			});
+		it.each([
+			{ desc: 'movie type even with imdb_id', overrides: { video_type: 'movie', disctype: 'bluray', imdb_id: 'tt1234567' } },
+			{ desc: 'series without imdb_id', overrides: { video_type: 'series', disctype: 'bluray', imdb_id: null } },
+			{ desc: 'music discs', overrides: { disctype: 'music', video_type: 'music' } },
+			{ desc: 'movie disc with no imdb_id', overrides: { video_type: 'movie', disctype: 'bluray', imdb_id: null } }
+		])('does NOT show Episodes button for $desc', async ({ overrides }) => {
+			renderWidget(overrides);
 			await waitFor(() => {
 				expect(screen.getByText('Start')).toBeInTheDocument();
 			});
@@ -174,11 +126,7 @@ describe('DiscReviewWidget', () => {
 
 	describe('interactions', () => {
 		it('calls startWaitingJob when Start is clicked', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' })
-				}
-			});
+			renderWidget();
 			await waitFor(() => expect(screen.getByText('Start')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Start'));
 			await waitFor(() => {
@@ -187,11 +135,7 @@ describe('DiscReviewWidget', () => {
 		});
 
 		it('calls cancelWaitingJob when Cancel is clicked', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' })
-				}
-			});
+			renderWidget();
 			await waitFor(() => expect(screen.getByText('Cancel')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Cancel'));
 			await waitFor(() => {
@@ -201,12 +145,7 @@ describe('DiscReviewWidget', () => {
 
 		it('calls ondismiss after cancel', async () => {
 			const ondismiss = vi.fn();
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' }),
-					ondismiss
-				}
-			});
+			renderWidget({}, { ondismiss });
 			await waitFor(() => expect(screen.getByText('Cancel')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Cancel'));
 			await waitFor(() => {
@@ -216,12 +155,7 @@ describe('DiscReviewWidget', () => {
 
 		it('calls onrefresh after start', async () => {
 			const onrefresh = vi.fn();
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' }),
-					onrefresh
-				}
-			});
+			renderWidget({}, { onrefresh });
 			await waitFor(() => expect(screen.getByText('Start')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Start'));
 			await waitFor(() => {
@@ -233,23 +167,11 @@ describe('DiscReviewWidget', () => {
 	describe('rendered filenames', () => {
 		it('fetches naming preview on load and displays rendered titles in track table', async () => {
 			mockFetchJob.mockResolvedValue({
-				job_id: 1,
-				title: 'Kolchak',
-				status: 'waiting',
-				video_type: 'series',
-				disctype: 'bluray',
-				label: 'TEST',
-				year: '1974',
-				no_of_titles: 2,
-				crc_id: null,
-				logfile: null,
-				start_time: '2025-06-15T10:00:00Z',
-				wait_start_time: '2025-06-15T11:55:00Z',
-				devpath: '/dev/sr0',
-				imdb_id: 'tt0071003',
-				poster_url: null,
-				errors: null,
-				multi_title: false,
+				job_id: 1, title: 'Kolchak', status: 'waiting', video_type: 'series',
+				disctype: 'bluray', label: 'TEST', year: '1974', no_of_titles: 2,
+				crc_id: null, logfile: null, start_time: '2025-06-15T10:00:00Z',
+				wait_start_time: '2025-06-15T11:55:00Z', devpath: '/dev/sr0',
+				imdb_id: 'tt0071003', poster_url: null, errors: null, multi_title: false,
 				tracks: [
 					{ track_id: 1, track_number: '0', length: 3012, filename: 'Kolchak_t00.mkv', enabled: true, aspect_ratio: '16:9', fps: '23.976', ripped: false, basename: null, title: 'Demon in Lace', year: null, video_type: null, poster_url: null, episode_number: '16', episode_name: 'Demon in Lace' }
 				],
@@ -264,48 +186,28 @@ describe('DiscReviewWidget', () => {
 				]
 			} as any);
 
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', video_type: 'series', disctype: 'bluray', imdb_id: 'tt0071003' })
-				}
-			});
+			renderWidget({ video_type: 'series', disctype: 'bluray', imdb_id: 'tt0071003' });
 
-			// Wait for detail to load, then open Info panel to see tracks
 			await waitFor(() => expect(screen.getByText('Info')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Info'));
 
-			// fetchNamingPreview should have been called
 			await waitFor(() => {
 				expect(mockFetchNamingPreview).toHaveBeenCalledWith(1);
 			});
 
-			// Rendered filename should show instead of raw MakeMKV filename
 			await waitFor(() => {
 				expect(screen.getByText('Demon in Lace S01E16')).toBeInTheDocument();
 			});
-			// Raw MakeMKV filename should NOT appear
 			expect(screen.queryByText('Kolchak_t00.mkv')).not.toBeInTheDocument();
 		});
 
 		it('falls back to raw filename when naming preview fails', async () => {
 			mockFetchJob.mockResolvedValue({
-				job_id: 1,
-				title: 'Test Movie',
-				status: 'waiting',
-				video_type: 'movie',
-				disctype: 'bluray',
-				label: 'TEST',
-				year: '2024',
-				no_of_titles: 1,
-				crc_id: null,
-				logfile: null,
-				start_time: '2025-06-15T10:00:00Z',
-				wait_start_time: '2025-06-15T11:55:00Z',
-				devpath: '/dev/sr0',
-				imdb_id: null,
-				poster_url: null,
-				errors: null,
-				multi_title: false,
+				job_id: 1, title: 'Test Movie', status: 'waiting', video_type: 'movie',
+				disctype: 'bluray', label: 'TEST', year: '2024', no_of_titles: 1,
+				crc_id: null, logfile: null, start_time: '2025-06-15T10:00:00Z',
+				wait_start_time: '2025-06-15T11:55:00Z', devpath: '/dev/sr0',
+				imdb_id: null, poster_url: null, errors: null, multi_title: false,
 				tracks: [
 					{ track_id: 1, track_number: '0', length: 7200, filename: 'title_t00.mkv', enabled: true, aspect_ratio: '16:9', fps: '23.976', ripped: false, basename: null, title: null, year: null, video_type: null, poster_url: null, episode_number: null, episode_name: null }
 				],
@@ -313,16 +215,11 @@ describe('DiscReviewWidget', () => {
 			} as any);
 			mockFetchNamingPreview.mockRejectedValue(new Error('API down'));
 
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z' })
-				}
-			});
+			renderWidget();
 
 			await waitFor(() => expect(screen.getByText('Info')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Info'));
 
-			// Falls back to raw filename
 			await waitFor(() => {
 				expect(screen.getByText('title_t00.mkv')).toBeInTheDocument();
 			});
@@ -331,11 +228,7 @@ describe('DiscReviewWidget', () => {
 
 	describe('multi-title toggle', () => {
 		it('renders Movie/Series buttons when multi_title=true', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'movie', disctype: 'dvd' })
-				}
-			});
+			renderWidget({ multi_title: true, video_type: 'movie', disctype: 'dvd' });
 			await waitFor(() => {
 				expect(screen.getByText('Movie')).toBeInTheDocument();
 				expect(screen.getByText('Series')).toBeInTheDocument();
@@ -343,11 +236,7 @@ describe('DiscReviewWidget', () => {
 		});
 
 		it('does NOT render Movie/Series toggle when multi_title=false', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: false, video_type: 'movie', disctype: 'dvd' })
-				}
-			});
+			renderWidget({ multi_title: false, video_type: 'movie', disctype: 'dvd' });
 			await waitFor(() => {
 				expect(screen.getByText('Test Movie')).toBeInTheDocument();
 			});
@@ -356,11 +245,7 @@ describe('DiscReviewWidget', () => {
 
 		it('calls updateJobTitle on toggle click', async () => {
 			mockUpdateJobTitle.mockResolvedValue(undefined as any);
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'movie', disctype: 'dvd' })
-				}
-			});
+			renderWidget({ multi_title: true, video_type: 'movie', disctype: 'dvd' });
 			await waitFor(() => expect(screen.getByText('Series')).toBeInTheDocument());
 			await fireEvent.click(screen.getByText('Series'));
 			await waitFor(() => {
@@ -372,49 +257,19 @@ describe('DiscReviewWidget', () => {
 	describe('auto-default video_type', () => {
 		it('fires updateJobTitle({video_type:"movie"}) for unknown+multi_title+dvd', async () => {
 			mockUpdateJobTitle.mockResolvedValue(undefined as any);
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'unknown', disctype: 'dvd' })
-				}
-			});
+			renderWidget({ multi_title: true, video_type: 'unknown', disctype: 'dvd' });
 			await waitFor(() => {
 				expect(mockUpdateJobTitle).toHaveBeenCalledWith(1, { video_type: 'movie' });
 			});
 		});
 
-		it('does NOT auto-default for series', async () => {
+		it.each([
+			{ desc: 'series', overrides: { multi_title: true, video_type: 'series', disctype: 'dvd' } },
+			{ desc: 'single-title', overrides: { multi_title: false, video_type: 'unknown', disctype: 'dvd' } },
+			{ desc: 'null disctype', overrides: { multi_title: true, video_type: 'unknown', disctype: null } }
+		])('does NOT auto-default for $desc', async ({ overrides }) => {
 			mockUpdateJobTitle.mockClear();
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'series', disctype: 'dvd' })
-				}
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Test Movie')).toBeInTheDocument();
-			});
-			expect(mockUpdateJobTitle).not.toHaveBeenCalledWith(1, { video_type: 'movie' });
-		});
-
-		it('does NOT auto-default for single-title', async () => {
-			mockUpdateJobTitle.mockClear();
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: false, video_type: 'unknown', disctype: 'dvd' })
-				}
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Test Movie')).toBeInTheDocument();
-			});
-			expect(mockUpdateJobTitle).not.toHaveBeenCalledWith(1, { video_type: 'movie' });
-		});
-
-		it('does NOT auto-default for null disctype', async () => {
-			mockUpdateJobTitle.mockClear();
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'unknown', disctype: null })
-				}
-			});
+			renderWidget(overrides);
 			await waitFor(() => {
 				expect(screen.getByText('Test Movie')).toBeInTheDocument();
 			});
@@ -424,34 +279,18 @@ describe('DiscReviewWidget', () => {
 
 	describe('field visibility for multi-title', () => {
 		it('hides Search button for multi-title movie', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'movie', disctype: 'dvd' })
-				}
-			});
+			renderWidget({ multi_title: true, video_type: 'movie', disctype: 'dvd' });
 			await waitFor(() => {
 				expect(screen.getByText('Start')).toBeInTheDocument();
 			});
 			expect(screen.queryByText('Search')).not.toBeInTheDocument();
 		});
 
-		it('shows Search button for multi-title series', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: true, video_type: 'series', disctype: 'dvd' })
-				}
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Search')).toBeInTheDocument();
-			});
-		});
-
-		it('shows Search button for single-title movie', async () => {
-			renderComponent(DiscReviewWidget, {
-				props: {
-					job: createJob({ status: 'waiting', wait_start_time: '2025-06-15T11:55:00Z', multi_title: false, video_type: 'movie', disctype: 'dvd' })
-				}
-			});
+		it.each([
+			{ desc: 'multi-title series', overrides: { multi_title: true, video_type: 'series', disctype: 'dvd' } },
+			{ desc: 'single-title movie', overrides: { multi_title: false, video_type: 'movie', disctype: 'dvd' } }
+		])('shows Search button for $desc', async ({ overrides }) => {
+			renderWidget(overrides);
 			await waitFor(() => {
 				expect(screen.getByText('Search')).toBeInTheDocument();
 			});

--- a/frontend/src/lib/components/EpisodeMatch.test.ts
+++ b/frontend/src/lib/components/EpisodeMatch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderComponent, screen, cleanup } from '$lib/test-utils';
 import EpisodeMatch from './EpisodeMatch.svelte';
-import type { JobDetail, Track } from '$lib/types/arm';
+import { createJobDetail, createTrack } from './__fixtures__/job';
 
 vi.mock('$lib/api/jobs', () => ({
 	tvdbMatch: vi.fn(() => Promise.resolve({
@@ -18,83 +18,12 @@ vi.mock('$lib/api/jobs', () => ({
 	fetchNamingPreview: vi.fn(() => Promise.resolve({ success: true, tracks: [] }))
 }));
 
-function createJobDetail(overrides: Partial<JobDetail> = {}): JobDetail {
-	return {
-		job_id: 1,
-		arm_version: '2.0',
-		crc_id: null,
-		logfile: null,
-		start_time: '2025-06-15T10:00:00Z',
-		stop_time: null,
-		job_length: null,
-		status: 'waiting',
-		stage: null,
-		no_of_titles: 3,
-		title: 'Test Show',
-		title_auto: null,
-		title_manual: null,
-		year: '2024',
-		year_auto: null,
-		year_manual: null,
-		video_type: 'series',
-		video_type_auto: null,
-		video_type_manual: null,
-		imdb_id: 'tt1234567',
-		imdb_id_auto: null,
-		imdb_id_manual: null,
-		poster_url: null,
-		poster_url_auto: null,
-		poster_url_manual: null,
-		devpath: '/dev/sr0',
-		mountpoint: null,
-		hasnicetitle: null,
-		errors: null,
-		disctype: 'bluray',
-		label: 'TEST_SHOW',
-		path: null,
-		raw_path: null,
-		transcode_path: null,
-		artist: null,
-		artist_auto: null,
-		artist_manual: null,
-		album: null,
-		album_auto: null,
-		album_manual: null,
-		season: null,
-		season_auto: null,
-		season_manual: null,
-		episode: null,
-		episode_auto: null,
-		episode_manual: null,
-		transcode_overrides: null,
-		multi_title: null,
-		title_pattern_override: null,
-		folder_pattern_override: null,
-		disc_number: null,
-		disc_total: null,
-		ejected: null,
-		pid: null,
-		manual_pause: null,
-		wait_start_time: null,
-		tracks_total: null,
-		tracks_ripped: null,
-		tvdb_id: null,
-		tracks: [],
-		config: null,
-		...overrides
-	};
-}
-
-function createTrack(overrides: Partial<Track> = {}): Track {
-	return {
-		track_id: 1, job_id: 1, track_number: '0', length: 2750,
-		filename: 't00.mkv', orig_filename: null, new_filename: null,
-		status: null, error: null, source: null, enabled: true,
-		aspect_ratio: '16:9', fps: 23.976, ripped: false, basename: null,
-		title: null, year: null, imdb_id: null, video_type: null,
-		poster_url: null, episode_number: null, episode_name: null, custom_filename: null,
-		...overrides
-	};
+/** Create a series JobDetail with common defaults for EpisodeMatch tests. */
+function seriesJob(overrides: Partial<Parameters<typeof createJobDetail>[0]> = {}) {
+	return createJobDetail({
+		title: 'Test Show', video_type: 'series', imdb_id: 'tt1234567',
+		label: 'TEST_SHOW', status: 'waiting', ...overrides
+	});
 }
 
 describe('EpisodeMatch', () => {
@@ -106,14 +35,14 @@ describe('EpisodeMatch', () => {
 	describe('empty states', () => {
 		it('renders "No IMDB or TVDB ID" message when both are null', () => {
 			renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ tvdb_id: null, imdb_id: null, tracks: [] }) }
+				props: { job: seriesJob({ tvdb_id: null, imdb_id: null, tracks: [] }) }
 			});
 			expect(screen.getByText(/No IMDB or TVDB ID set/)).toBeInTheDocument();
 		});
 
 		it('renders "No tracks found" when tvdb_id set but empty tracks', () => {
 			renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ tvdb_id: 12345, tracks: [] }) }
+				props: { job: seriesJob({ tvdb_id: 12345, tracks: [] }) }
 			});
 			expect(screen.getByText(/No tracks found/)).toBeInTheDocument();
 		});
@@ -122,7 +51,7 @@ describe('EpisodeMatch', () => {
 	describe('controls bar', () => {
 		it('renders Season, Disc, Tolerance labels', () => {
 			renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail() }
+				props: { job: seriesJob() }
 			});
 			expect(screen.getByText('Season')).toBeInTheDocument();
 			expect(screen.getByText('Disc')).toBeInTheDocument();
@@ -131,14 +60,14 @@ describe('EpisodeMatch', () => {
 
 		it('renders Match button', () => {
 			renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail() }
+				props: { job: seriesJob() }
 			});
 			expect(screen.getByText('Match')).toBeInTheDocument();
 		});
 
 		it('season input prefills from job.season', () => {
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ season: '3' }) }
+				props: { job: seriesJob({ season: '3' }) }
 			});
 			const inputs = container.querySelectorAll('input[type="number"]');
 			expect((inputs[0] as HTMLInputElement).value).toBe('3');
@@ -146,7 +75,7 @@ describe('EpisodeMatch', () => {
 
 		it('season input prefills from job.season_auto when season is null', () => {
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ season: null, season_auto: '2' }) }
+				props: { job: seriesJob({ season: null, season_auto: '2' }) }
 			});
 			const inputs = container.querySelectorAll('input[type="number"]');
 			expect((inputs[0] as HTMLInputElement).value).toBe('2');
@@ -154,7 +83,7 @@ describe('EpisodeMatch', () => {
 
 		it('disc input prefills from job.disc_number', () => {
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ disc_number: 4 }) }
+				props: { job: seriesJob({ disc_number: 4 }) }
 			});
 			const inputs = container.querySelectorAll('input[type="number"]');
 			expect((inputs[1] as HTMLInputElement).value).toBe('4');
@@ -162,7 +91,7 @@ describe('EpisodeMatch', () => {
 
 		it('disc total input prefills from job.disc_total', () => {
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ disc_total: 6 }) }
+				props: { job: seriesJob({ disc_total: 6 }) }
 			});
 			const inputs = container.querySelectorAll('input[type="number"]');
 			expect((inputs[2] as HTMLInputElement).value).toBe('6');
@@ -170,7 +99,7 @@ describe('EpisodeMatch', () => {
 
 		it('tolerance defaults to 600', () => {
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail() }
+				props: { job: seriesJob() }
 			});
 			const inputs = container.querySelectorAll('input[type="number"]');
 			expect((inputs[3] as HTMLInputElement).value).toBe('600');
@@ -202,7 +131,7 @@ describe('EpisodeMatch', () => {
 			});
 
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ imdb_id: 'tt1234567', tracks: [createTrack()] }) }
+				props: { job: seriesJob({ imdb_id: 'tt1234567', tracks: [createTrack()] }) }
 			});
 
 			// Wait for auto-match to complete
@@ -245,7 +174,7 @@ describe('EpisodeMatch', () => {
 			});
 
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ imdb_id: 'tt1234567', tracks: [createTrack()] }) }
+				props: { job: seriesJob({ imdb_id: 'tt1234567', tracks: [createTrack()] }) }
 			});
 
 			await vi.waitFor(() => {
@@ -283,7 +212,7 @@ describe('EpisodeMatch', () => {
 			];
 
 			const { container } = renderComponent(EpisodeMatch, {
-				props: { job: createJobDetail({ imdb_id: 'tt1234567', tracks }) }
+				props: { job: seriesJob({ imdb_id: 'tt1234567', tracks }) }
 			});
 
 			await vi.waitFor(() => {

--- a/frontend/src/lib/components/__fixtures__/files.ts
+++ b/frontend/src/lib/components/__fixtures__/files.ts
@@ -1,0 +1,41 @@
+/** Shared factory for directory/file entry objects used across file-browser tests. */
+export interface DirEntry {
+	name: string;
+	type: 'file' | 'directory';
+	size: number;
+	modified: string;
+	extension: string;
+	category: string;
+	permissions: string;
+	owner: string;
+	group: string;
+}
+
+const entryDefaults: DirEntry = {
+	name: 'untitled',
+	type: 'file',
+	size: 0,
+	modified: '2025-06-15T12:00:00Z',
+	extension: '',
+	category: 'directory',
+	permissions: 'rwxr-xr-x',
+	owner: 'arm',
+	group: 'arm'
+};
+
+export function createDirEntry(overrides: Partial<DirEntry> = {}): DirEntry {
+	const entry = { ...entryDefaults, ...overrides };
+	// Auto-set category from type if not explicitly overridden
+	if (!overrides.category) {
+		entry.category = entry.type === 'directory' ? 'directory' : 'video';
+	}
+	return entry;
+}
+
+export function createFileEntry(name: string, size: number, ext = 'mkv'): DirEntry {
+	return createDirEntry({ name, type: 'file', size, extension: ext, category: 'video' });
+}
+
+export function createFolderEntry(name: string, modified?: string): DirEntry {
+	return createDirEntry({ name, type: 'directory', size: 0, ...(modified ? { modified } : {}) });
+}

--- a/frontend/src/lib/components/__fixtures__/job.ts
+++ b/frontend/src/lib/components/__fixtures__/job.ts
@@ -1,6 +1,6 @@
-import type { Job } from '$lib/types/arm';
+import type { Job, JobDetail, Track } from '$lib/types/arm';
 
-const defaults: Job = {
+const jobDefaults: Job = {
 	job_id: 1,
 	arm_version: '2.0',
 	crc_id: null,
@@ -63,5 +63,40 @@ const defaults: Job = {
 };
 
 export function createJob(overrides: Partial<Job> = {}): Job {
-	return { ...defaults, ...overrides };
+	return { ...jobDefaults, ...overrides };
+}
+
+const trackDefaults: Track = {
+	track_id: 1,
+	job_id: 1,
+	track_number: '0',
+	length: 2750,
+	filename: 't00.mkv',
+	orig_filename: null,
+	new_filename: null,
+	status: null,
+	error: null,
+	source: null,
+	enabled: true,
+	aspect_ratio: '16:9',
+	fps: 23.976,
+	ripped: false,
+	basename: null,
+	title: null,
+	year: null,
+	imdb_id: null,
+	video_type: null,
+	poster_url: null,
+	episode_number: null,
+	episode_name: null,
+	custom_filename: null
+};
+
+export function createTrack(overrides: Partial<Track> = {}): Track {
+	return { ...trackDefaults, ...overrides };
+}
+
+export function createJobDetail(overrides: Partial<JobDetail> = {}): JobDetail {
+	const { tracks = [], config = null, ...jobOverrides } = overrides;
+	return { ...createJob(jobOverrides), tracks, config };
 }

--- a/frontend/src/lib/components/__tests__/BottomStatsBar.test.ts
+++ b/frontend/src/lib/components/__tests__/BottomStatsBar.test.ts
@@ -39,40 +39,46 @@ const gpuData = {
 const hwInfo = { cpu: 'Intel i7-12700', memory_total_gb: 16 };
 const transcoderInfo = { cpu: 'AMD Ryzen 9', memory_total_gb: 32 };
 
+/** Render BottomStatsBar with ripper defaults. Extra props merged on top. */
+function renderBar(extraProps: Record<string, unknown> = {}) {
+	return renderComponent(BottomStatsBar, {
+		props: { systemInfo: hwInfo, systemStats, ...extraProps }
+	});
+}
+
+/** Render with full transcoder props (optionally with GPU). */
+function renderWithTranscoder(gpu: typeof gpuData | null = null) {
+	return renderBar({
+		transcoderInfo,
+		transcoderStats: gpu ? { ...transcoderStats, gpu } : transcoderStats
+	});
+}
+
 describe('BottomStatsBar', () => {
 	afterEach(() => cleanup());
 
 	it('renders Ripper and Transcoder toggle buttons', () => {
-		renderComponent(BottomStatsBar, {
-			props: { systemInfo: hwInfo, systemStats }
-		});
+		renderBar();
 		expect(screen.getByText('Ripper')).toBeInTheDocument();
 		expect(screen.getByText('Transcoder')).toBeInTheDocument();
 	});
 
 	it('shows CPU percentage when systemStats provided', () => {
-		renderComponent(BottomStatsBar, {
-			props: { systemInfo: hwInfo, systemStats }
-		});
+		renderBar();
 		expect(screen.getByText('CPU')).toBeInTheDocument();
 		expect(screen.getByText('25%')).toBeInTheDocument();
 	});
 
 	it('shows memory stats when systemStats provided', () => {
-		renderComponent(BottomStatsBar, {
-			props: { systemInfo: hwInfo, systemStats }
-		});
+		renderBar();
 		expect(screen.getByText('Mem')).toBeInTheDocument();
 		expect(screen.getByText('4 / 16 GB')).toBeInTheDocument();
 	});
 
 	it('shows storage volumes with links when ripper panel active', () => {
-		renderComponent(BottomStatsBar, {
-			props: { systemInfo: hwInfo, systemStats }
-		});
+		renderBar();
 		expect(screen.getByText('Raw')).toBeInTheDocument();
 		expect(screen.getByText('Completed')).toBeInTheDocument();
-		// Storage items should be links in ripper panel
 		const rawLink = screen.getByText('Raw').closest('a');
 		expect(rawLink).toBeInTheDocument();
 		expect(rawLink).toHaveAttribute('href', '/files?path=%2Fhome%2Farm%2Fmedia%2Fraw');
@@ -82,58 +88,33 @@ describe('BottomStatsBar', () => {
 	});
 
 	it('shows free GB for storage volumes', () => {
-		renderComponent(BottomStatsBar, {
-			props: { systemInfo: hwInfo, systemStats }
-		});
+		renderBar();
 		expect(screen.getByText('900 GB')).toBeInTheDocument();
 		expect(screen.getByText('800 GB')).toBeInTheDocument();
 	});
 
 	it('shows offline message when armOnline is false', () => {
-		renderComponent(BottomStatsBar, {
-			props: { systemInfo: hwInfo, systemStats, armOnline: false }
-		});
+		renderBar({ armOnline: false });
 		expect(screen.getByText('Cannot reach the ARM ripping service')).toBeInTheDocument();
 	});
 
 	it('switches to transcoder panel and shows transcoder stats', async () => {
-		renderComponent(BottomStatsBar, {
-			props: {
-				systemInfo: hwInfo,
-				systemStats,
-				transcoderInfo,
-				transcoderStats
-			}
-		});
+		renderWithTranscoder();
 		await fireEvent.click(screen.getByText('Transcoder'));
 		expect(screen.getByText('60%')).toBeInTheDocument();
 		expect(screen.getByText('8 / 32 GB')).toBeInTheDocument();
 	});
 
 	it('shows transcoder storage as plain text (not links)', async () => {
-		renderComponent(BottomStatsBar, {
-			props: {
-				systemInfo: hwInfo,
-				systemStats,
-				transcoderInfo,
-				transcoderStats
-			}
-		});
+		renderWithTranscoder();
 		await fireEvent.click(screen.getByText('Transcoder'));
 		expect(screen.getByText('Work')).toBeInTheDocument();
-		// Storage items should NOT be links in transcoder panel
 		const workEl = screen.getByText('Work');
 		expect(workEl.closest('a')).toBeNull();
 	});
 
 	it('shows transcoder offline message when transcoderOnline is false', async () => {
-		renderComponent(BottomStatsBar, {
-			props: {
-				systemInfo: hwInfo,
-				systemStats,
-				transcoderOnline: false
-			}
-		});
+		renderBar({ transcoderOnline: false });
 		await fireEvent.click(screen.getByText('Transcoder'));
 		expect(screen.getByText('Cannot reach the transcoder service')).toBeInTheDocument();
 	});
@@ -142,47 +123,24 @@ describe('BottomStatsBar', () => {
 		renderComponent(BottomStatsBar, {
 			props: { systemInfo: null, systemStats: null }
 		});
-		// Toggle buttons should still render
 		expect(screen.getByText('Ripper')).toBeInTheDocument();
-		// But no CPU/Mem/Storage
 		expect(screen.queryByText('CPU')).not.toBeInTheDocument();
 		expect(screen.queryByText('Mem')).not.toBeInTheDocument();
 	});
 
 	describe('GPU tab', () => {
 		it('shows GPU toggle when transcoder has GPU data', () => {
-			renderComponent(BottomStatsBar, {
-				props: {
-					systemInfo: hwInfo,
-					systemStats,
-					transcoderInfo,
-					transcoderStats: { ...transcoderStats, gpu: gpuData }
-				}
-			});
+			renderWithTranscoder(gpuData);
 			expect(screen.getByText('GPU')).toBeInTheDocument();
 		});
 
 		it('does not show GPU toggle when gpu is null', () => {
-			renderComponent(BottomStatsBar, {
-				props: {
-					systemInfo: hwInfo,
-					systemStats,
-					transcoderInfo,
-					transcoderStats
-				}
-			});
+			renderWithTranscoder();
 			expect(screen.queryByRole('button', { name: 'GPU' })).not.toBeInTheDocument();
 		});
 
 		it('shows GPU metrics when GPU tab clicked', async () => {
-			renderComponent(BottomStatsBar, {
-				props: {
-					systemInfo: hwInfo,
-					systemStats,
-					transcoderInfo,
-					transcoderStats: { ...transcoderStats, gpu: gpuData }
-				}
-			});
+			renderWithTranscoder(gpuData);
 			await fireEvent.click(screen.getByText('GPU'));
 			expect(screen.getByText('nvidia')).toBeInTheDocument();
 			expect(screen.getByText('Load')).toBeInTheDocument();
@@ -194,14 +152,7 @@ describe('BottomStatsBar', () => {
 		});
 
 		it('shows power and clock on GPU tab', async () => {
-			renderComponent(BottomStatsBar, {
-				props: {
-					systemInfo: hwInfo,
-					systemStats,
-					transcoderInfo,
-					transcoderStats: { ...transcoderStats, gpu: gpuData }
-				}
-			});
+			renderWithTranscoder(gpuData);
 			await fireEvent.click(screen.getByText('GPU'));
 			expect(screen.getByText(/220W/)).toBeInTheDocument();
 			expect(screen.getByText(/300W/)).toBeInTheDocument();
@@ -209,14 +160,7 @@ describe('BottomStatsBar', () => {
 		});
 
 		it('shows GPU temperature on GPU tab', async () => {
-			renderComponent(BottomStatsBar, {
-				props: {
-					systemInfo: hwInfo,
-					systemStats,
-					transcoderInfo,
-					transcoderStats: { ...transcoderStats, gpu: gpuData }
-				}
-			});
+			renderWithTranscoder(gpuData);
 			await fireEvent.click(screen.getByText('GPU'));
 			expect(screen.getByText(/72/)).toBeInTheDocument();
 		});

--- a/frontend/src/lib/components/__tests__/DiscReviewWidget.test.ts
+++ b/frontend/src/lib/components/__tests__/DiscReviewWidget.test.ts
@@ -38,6 +38,25 @@ function renderWidget(overrides = {}) {
 	});
 }
 
+/** Open the Info panel and wait for the Title field to appear. */
+async function openInfoPanel() {
+	await fireEvent.click(screen.getByText('Info'));
+	await waitFor(() => {
+		expect(screen.getByText('Title')).toBeInTheDocument();
+	});
+}
+
+/** Open Info panel and edit the title field, triggering the save bar. */
+async function editTitleField(newValue = 'Changed Title') {
+	await openInfoPanel();
+	const titleLabel = screen.getByText('Title');
+	const titleInput = titleLabel.closest('label')!.querySelector('input')!;
+	await fireEvent.input(titleInput, { target: { value: newValue } });
+	await waitFor(() => {
+		expect(screen.queryAllByText('Unsaved changes').length).toBeGreaterThanOrEqual(1);
+	});
+}
+
 describe('DiscReviewWidget', () => {
 	afterEach(() => {
 		cleanup();
@@ -47,42 +66,18 @@ describe('DiscReviewWidget', () => {
 	describe('save bar', () => {
 		it('does not show save bar on initial load', async () => {
 			renderWidget();
-			// Click "Info" to open the info panel
-			await fireEvent.click(screen.getByText('Info'));
-			await waitFor(() => {
-				expect(screen.getByText('Title')).toBeInTheDocument();
-			});
-			// Save bar should not appear since nothing is edited
+			await openInfoPanel();
 			expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
 		});
 
 		it('shows save bar when field is edited', async () => {
 			renderWidget();
-			await fireEvent.click(screen.getByText('Info'));
-			await waitFor(() => {
-				expect(screen.getByText('Title')).toBeInTheDocument();
-			});
-			// Find the title input and type in it
-			const titleLabel = screen.getByText('Title');
-			const titleInput = titleLabel.closest('label')!.querySelector('input')!;
-			await fireEvent.input(titleInput, { target: { value: 'Changed Title' } });
-			await waitFor(() => {
-				expect(screen.queryAllByText('Unsaved changes').length).toBeGreaterThanOrEqual(1);
-			});
+			await editTitleField();
 		});
 
 		it('save bar has Reset and Save buttons', async () => {
 			renderWidget();
-			await fireEvent.click(screen.getByText('Info'));
-			await waitFor(() => {
-				expect(screen.getByText('Title')).toBeInTheDocument();
-			});
-			const titleLabel = screen.getByText('Title');
-			const titleInput = titleLabel.closest('label')!.querySelector('input')!;
-			await fireEvent.input(titleInput, { target: { value: 'Changed Title' } });
-			await waitFor(() => {
-				expect(screen.queryAllByText('Unsaved changes').length).toBeGreaterThanOrEqual(1);
-			});
+			await editTitleField();
 			expect(screen.queryAllByText('Reset').length).toBeGreaterThanOrEqual(1);
 			expect(screen.queryAllByText('Save').length).toBeGreaterThanOrEqual(1);
 		});

--- a/frontend/src/lib/components/__tests__/FolderBrowser.test.ts
+++ b/frontend/src/lib/components/__tests__/FolderBrowser.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderComponent, screen, fireEvent, cleanup, waitFor } from '$lib/test-utils';
 import FolderBrowser from '../FolderBrowser.svelte';
+import { createFolderEntry } from '../__fixtures__/files';
 
 import { fetchIngressRoot, fetchIngressDirectory } from '$lib/api/folder';
+
+const movieFolder = createFolderEntry('Movie_Folder');
+const tvShowFolder = createFolderEntry('TV_Show', '2025-06-14T10:00:00Z');
+const subFolder = createFolderEntry('Subfolder');
 
 vi.mock('$lib/api/folder', () => ({
 	fetchIngressRoot: vi.fn(() => Promise.resolve([
@@ -10,10 +15,7 @@ vi.mock('$lib/api/folder', () => ({
 	])),
 	fetchIngressDirectory: vi.fn(() => Promise.resolve({
 		path: '/home/arm/ingress',
-		entries: [
-			{ name: 'Movie_Folder', type: 'directory', size: 4294967296, modified: '2025-06-15T12:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' },
-			{ name: 'TV_Show', type: 'directory', size: 2147483648, modified: '2025-06-14T10:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' }
-		]
+		entries: [movieFolder, tvShowFolder]
 	}))
 }));
 
@@ -29,6 +31,35 @@ const mockFetchIngressDirectory = vi.mocked(fetchIngressDirectory);
 // jsdom does not implement scrollTo
 HTMLElement.prototype.scrollTo = vi.fn();
 
+function renderBrowser() {
+	return renderComponent(FolderBrowser, { onselect: vi.fn() });
+}
+
+async function waitForEntries() {
+	await waitFor(() => {
+		expect(screen.getByText('Movie_Folder')).toBeInTheDocument();
+	});
+}
+
+/** Navigate into Movie_Folder and wait for the ".." back-row to appear. */
+async function navigateIntoSubfolder() {
+	mockFetchIngressDirectory.mockResolvedValueOnce({
+		path: '/home/arm/ingress',
+		entries: [{ ...movieFolder, size: 4294967296 }]
+	} as any).mockResolvedValueOnce({
+		path: '/home/arm/ingress/Movie_Folder',
+		entries: [{ ...subFolder, size: 1024 }]
+	} as any);
+
+	renderBrowser();
+	await waitForEntries();
+
+	await fireEvent.dblClick(screen.getByText('Movie_Folder'));
+	await waitFor(() => {
+		expect(screen.getByText('..')).toBeInTheDocument();
+	});
+}
+
 describe('FolderBrowser', () => {
 	afterEach(() => {
 		cleanup();
@@ -36,14 +67,14 @@ describe('FolderBrowser', () => {
 	});
 
 	it('renders path bar with current path', async () => {
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
+		renderBrowser();
 		await waitFor(() => {
 			expect(screen.getByText('/home/arm/ingress')).toBeInTheDocument();
 		});
 	});
 
 	it('renders directory entries in table', async () => {
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
+		renderBrowser();
 		await waitFor(() => {
 			expect(screen.getByText('Movie_Folder')).toBeInTheDocument();
 			expect(screen.getByText('TV_Show')).toBeInTheDocument();
@@ -51,54 +82,13 @@ describe('FolderBrowser', () => {
 	});
 
 	it('shows .. row when navigated past root', async () => {
-		mockFetchIngressDirectory.mockResolvedValueOnce({
-			path: '/home/arm/ingress',
-			entries: [
-				{ name: 'Movie_Folder', type: 'directory', size: 4294967296, modified: '2025-06-15T12:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' }
-			]
-		} as any).mockResolvedValueOnce({
-			path: '/home/arm/ingress/Movie_Folder',
-			entries: [
-				{ name: 'Subfolder', type: 'directory', size: 1024, modified: '2025-06-15T12:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' }
-			]
-		} as any);
-
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
-		await waitFor(() => {
-			expect(screen.getByText('Movie_Folder')).toBeInTheDocument();
-		});
-
-		// Double-click to navigate into Movie_Folder
-		await fireEvent.dblClick(screen.getByText('Movie_Folder'));
-		await waitFor(() => {
-			expect(screen.getByText('..')).toBeInTheDocument();
-		});
+		await navigateIntoSubfolder();
+		// ".." is already asserted inside navigateIntoSubfolder
 	});
 
 	it('clicking .. navigates up', async () => {
-		mockFetchIngressDirectory.mockResolvedValueOnce({
-			path: '/home/arm/ingress',
-			entries: [
-				{ name: 'Movie_Folder', type: 'directory', size: 4294967296, modified: '2025-06-15T12:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' }
-			]
-		} as any).mockResolvedValueOnce({
-			path: '/home/arm/ingress/Movie_Folder',
-			entries: [
-				{ name: 'Subfolder', type: 'directory', size: 1024, modified: '2025-06-15T12:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' }
-			]
-		} as any);
+		await navigateIntoSubfolder();
 
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
-		await waitFor(() => {
-			expect(screen.getByText('Movie_Folder')).toBeInTheDocument();
-		});
-
-		await fireEvent.dblClick(screen.getByText('Movie_Folder'));
-		await waitFor(() => {
-			expect(screen.getByText('..')).toBeInTheDocument();
-		});
-
-		// Click the .. row to go back
 		await fireEvent.click(screen.getByText('..'));
 		await waitFor(() => {
 			expect(mockFetchIngressDirectory).toHaveBeenCalledWith('/home/arm/ingress');
@@ -106,20 +96,15 @@ describe('FolderBrowser', () => {
 	});
 
 	it('filter input is disabled when 5 or fewer directories', async () => {
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
-		await waitFor(() => {
-			expect(screen.getByText('Movie_Folder')).toBeInTheDocument();
-		});
+		renderBrowser();
+		await waitForEntries();
 		const filterInput = screen.getByPlaceholderText('Filter folders...');
 		expect(filterInput).toBeDisabled();
 	});
 
 	it('sort buttons render in table header', async () => {
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
-		await waitFor(() => {
-			expect(screen.getByText('Movie_Folder')).toBeInTheDocument();
-		});
-		// Sort buttons contain the text Name, Size, Modified (possibly with sort indicator)
+		renderBrowser();
+		await waitForEntries();
 		expect(screen.getByText(/^Name/)).toBeInTheDocument();
 		expect(screen.getByText(/^Size/)).toBeInTheDocument();
 		expect(screen.getByText(/^Modified/)).toBeInTheDocument();
@@ -131,17 +116,16 @@ describe('FolderBrowser', () => {
 			entries: []
 		} as any);
 
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
+		renderBrowser();
 		await waitFor(() => {
 			expect(screen.getByText('No subdirectories found.')).toBeInTheDocument();
 		});
 	});
 
 	it('shows loading text before directory loads', async () => {
-		// Make the directory fetch hang indefinitely
 		mockFetchIngressDirectory.mockImplementationOnce(() => new Promise(() => {}));
 
-		renderComponent(FolderBrowser, { onselect: vi.fn() });
+		renderBrowser();
 
 		await waitFor(() => {
 			expect(screen.getByText('Loading...')).toBeInTheDocument();

--- a/frontend/src/routes/files/__tests__/files-page.test.ts
+++ b/frontend/src/routes/files/__tests__/files-page.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderComponent, screen, fireEvent, cleanup, waitFor } from '$lib/test-utils';
 import FilesPage from '../+page.svelte';
+import { createFileEntry, createFolderEntry } from '$lib/components/__fixtures__/files';
 
 import { fetchRoots, fetchDirectory } from '$lib/api/files';
 import { fetchOrphanFolders, cleanupTranscoder } from '$lib/api/maintenance';
+
+const defaultEntries = [
+	createFileEntry('movie.mkv', 4294967296),
+	createFolderEntry('subfolder', '2025-06-14T10:00:00Z'),
+	createFileEntry('show.mkv', 2147483648, 'mkv')
+];
 
 vi.mock('$app/stores', async () => {
 	const { readable } = await import('svelte/store');
@@ -21,9 +28,9 @@ vi.mock('$lib/api/files', () => ({
 		path: '/media/raw',
 		parent: null,
 		entries: [
-			{ name: 'movie.mkv', type: 'file', size: 4294967296, modified: '2025-06-15T12:00:00Z', extension: 'mkv', category: 'video', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' },
-			{ name: 'subfolder', type: 'directory', size: 0, modified: '2025-06-14T10:00:00Z', extension: '', category: 'directory', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' },
-			{ name: 'show.mkv', type: 'file', size: 2147483648, modified: '2025-06-13T08:00:00Z', extension: 'mkv', category: 'video', permissions: 'rwxr-xr-x', owner: 'arm', group: 'arm' }
+			createFileEntry('movie.mkv', 4294967296),
+			createFolderEntry('subfolder', '2025-06-14T10:00:00Z'),
+			createFileEntry('show.mkv', 2147483648, 'mkv')
 		]
 	})),
 	renameFile: vi.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Summary

- SonarCloud reported 3.2% duplication on new code (gate requires <= 3%)
- Extracted shared test factories into `__fixtures__/job.ts` and new `__fixtures__/files.ts`
- Extracted repeated render helpers in each test file
- Converted repetitive assertions to `it.each` parameterized tests
- Net reduction: ~226 fewer lines, eliminating ~100 duplicated lines across 7 files

## Test plan

- [x] Full vitest suite passes (740 tests, 74 files, 0 failures)
- [ ] SonarCloud reports duplication below 3% on PR analysis