### PR TITLE
fix: centralize track counts, CD_RIP_TIMEOUT setting, DriveCard null guard

### DIFF
--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -14,9 +14,15 @@
 		driveNames?: Record<string, string>;
 		progress?: number | null;
 		progressStage?: string | null;
+		tracksRipped?: number | null;
+		tracksTotal?: number | null;
 	}
 
-	let { job, driveNames = {}, progress = null, progressStage = null }: Props = $props();
+	let { job, driveNames = {}, progress = null, progressStage = null, tracksRipped = null, tracksTotal = null }: Props = $props();
+
+	// Use progress-polled counts when available (real-time), fall back to DB counts
+	let displayRipped = $derived(tracksRipped ?? job.tracks_ripped ?? 0);
+	let displayTotal = $derived(tracksTotal ?? job.tracks_total ?? 0);
 	let expanded = $state(false);
 
 	let driveName = $derived(job.devpath ? driveNames[job.devpath] : null);
@@ -96,9 +102,9 @@
 		{/if}
 
 		<!-- Track counts -->
-		{#if active && job.tracks_total != null && job.tracks_total > 0 && !isFolderImport}
+		{#if active && displayTotal > 0 && !isFolderImport}
 			<span class="hidden lg:inline shrink-0 text-xs text-gray-500 dark:text-gray-400">
-				{job.tracks_ripped ?? 0}/{job.tracks_total}
+				{displayRipped}/{displayTotal}
 			</span>
 		{/if}
 
@@ -213,8 +219,8 @@
 							<tr>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Tracks</td>
 								<td class="py-1 text-gray-900 dark:text-white">
-									{#if !isFolderImport && job.tracks_total != null && job.tracks_total > 0}
-										{job.tracks_ripped ?? 0} / {job.tracks_total} ripped
+									{#if !isFolderImport && displayTotal > 0}
+										{displayRipped} / {displayTotal} ripped
 									{:else if job.no_of_titles != null}
 										{job.no_of_titles} title{job.no_of_titles === 1 ? '' : 's'}
 									{:else}

--- a/frontend/src/lib/components/DriveCard.svelte
+++ b/frontend/src/lib/components/DriveCard.svelte
@@ -56,7 +56,7 @@
 	] as const;
 
 	async function savePrescanField(field: typeof PRESCAN_FIELDS[number]) {
-		const trimmed = field.input().trim();
+		const trimmed = (field.input() ?? '').trim();
 		let newVal = trimmed === '' ? null : parseInt(trimmed, 10);
 		if (newVal !== null && (isNaN(newVal) || newVal < field.min || newVal > field.max)) return;
 		// If the value matches the global default, store null (use global)
@@ -85,7 +85,7 @@
 	});
 
 	async function saveSpeed() {
-		const trimmed = speedInput.trim();
+		const trimmed = (speedInput ?? '').trim();
 		const newSpeed = trimmed === '' ? null : parseInt(trimmed, 10);
 
 		// Skip save if value hasn't changed

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -376,7 +376,7 @@
 			<SectionFrame variant="full" accent="var(--color-primary)" label="ACTIVE RIPS — {nonWaitingActiveJobs.length} IN PROGRESS">
 				<div class="space-y-2">
 					{#each nonWaitingActiveJobs as job (job.job_id)}
-						<ActiveJobRow {job} driveNames={dash.drive_names} progress={overallProgress(progressMap[job.job_id])} progressStage={progressMap[job.job_id]?.stage} />
+						<ActiveJobRow {job} driveNames={dash.drive_names} progress={overallProgress(progressMap[job.job_id])} progressStage={progressMap[job.job_id]?.stage} tracksRipped={progressMap[job.job_id]?.tracks_ripped} tracksTotal={progressMap[job.job_id]?.tracks_total} />
 					{/each}
 				</div>
 			</SectionFrame>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -737,6 +737,7 @@
 		AUDIO_FORMAT: { label: 'Audio Format', description: 'Output format for music CD ripping (passed to abcde -o)' },
 		ABCDE_CONFIG_FILE: { label: 'abcde Config File', description: 'Path to the abcde configuration file for CD ripping' },
 		RIP_SPEED_PROFILE: { label: 'Rip Speed Profile', description: '"safe" = full paranoia (best for scratched discs), "fast" = less paranoia (~2-4x faster), "fastest" = no error correction (pristine discs only)' },
+		CD_RIP_TIMEOUT: { label: 'CD Rip Timeout', description: 'Seconds to wait for cdparanoia output before killing a stalled rip. Set 0 to disable. Default 600 (10 min).' },
 		MUSIC_MULTI_DISC_SUBFOLDERS: { label: 'Multi-Disc Subfolders', description: 'Create per-disc subfolders for multi-CD sets (e.g. Artist/Album/Disc 1/)' },
 		MUSIC_DISC_FOLDER_PATTERN: { label: 'Disc Folder Pattern', description: 'Folder name for each disc in a multi-disc set. {num} = disc number. Examples: "Disc {num}", "CD {num}"' },
 		// Metadata
@@ -869,8 +870,8 @@
 			{ label: 'Metadata', subpanels: [
 				{ keys: ['GET_AUDIO_TITLE'] },
 			]},
-			{ label: 'Rip Speed', subpanels: [
-				{ keys: ['RIP_SPEED_PROFILE'] },
+			{ label: 'CD Ripping', subpanels: [
+				{ keys: ['RIP_SPEED_PROFILE', 'CD_RIP_TIMEOUT'] },
 			]},
 			{ label: 'Naming Patterns', subpanels: [
 				{ keys: ['MUSIC_TITLE_PATTERN', 'MUSIC_FOLDER_PATTERN'] },


### PR DESCRIPTION
## Summary

Three fixes that were committed after PR #173 merged:

- **Centralize track counts**: ActiveJobRow uses progress-polled tracks_ripped/tracks_total instead of stale DB counts, eliminating the persistent 1-count mismatch
- **CD_RIP_TIMEOUT setting**: Add label and panel placement under Music > CD Ripping
- **DriveCard null guard**: Prevent TypeError when saving null drive settings by guarding `.trim()` calls

## Test plan

- [x] 740 frontend tests pass
- [ ] Verify track counts match progress stage during CD rip
- [ ] Verify drive settings save with null values without error