### PR TITLE
fix: stop poster image flicker on dashboard polling

### DIFF
--- a/backend/routers/images.py
+++ b/backend/routers/images.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import time
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Query
 from fastapi.responses import Response
 
 from backend.services import image_cache
+
+_NEGATIVE_CACHE: dict[str, float] = {}
+_NEGATIVE_TTL_SECONDS = 3600
 
 router = APIRouter(prefix="/api", tags=["images"])
 
@@ -25,28 +29,39 @@ _ALLOWED_IMAGE_HOSTS = {
 }
 
 
+def _not_found(detail: str) -> Response:
+    """Return a cacheable 404 so the browser stops re-requesting missing images."""
+    return Response(
+        content=f'{{"detail":"{detail}"}}',
+        status_code=404,
+        media_type="application/json",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
 @router.get("/images/proxy")
 async def proxy_image(url: str = Query(..., description="Image URL to proxy")) -> Response:
     """Proxy and cache external images to avoid browser ORB/CORS issues."""
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
-        raise HTTPException(400, "Only HTTP(S) URLs are allowed")
+        return _not_found("Only HTTP(S) URLs are allowed")
     if parsed.hostname not in _ALLOWED_IMAGE_HOSTS:
-        raise HTTPException(400, "Image host not allowed")
+        return _not_found("Image host not allowed")
 
-    # Use the validated/reconstructed URL to break taint chain
     safe_url = parsed.geturl()
 
-    # Cache hit
     cached = image_cache.retrieve(safe_url)
     if cached is not None:
         content, content_type = cached
-        # Sanitize content_type to known image types
         safe_type = content_type if content_type in _SAFE_CONTENT_TYPES else "application/octet-stream"
         return Response(content=content, media_type=safe_type,
                         headers={"Cache-Control": "public, max-age=604800"})
 
-    # Fetch from origin
+    now = time.time()
+    neg_expiry = _NEGATIVE_CACHE.get(safe_url)
+    if neg_expiry is not None and neg_expiry > now:
+        return _not_found("Image unavailable")
+
     try:
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
             resp = await client.get(safe_url)  # NOSONAR — host validated above
@@ -54,7 +69,9 @@ async def proxy_image(url: str = Query(..., description="Image URL to proxy")) -
             content_type = resp.headers.get("content-type", "image/jpeg")
             safe_type = content_type if content_type in _SAFE_CONTENT_TYPES else "image/jpeg"
             image_cache.store(safe_url, resp.content, safe_type)
+            _NEGATIVE_CACHE.pop(safe_url, None)
             return Response(content=resp.content, media_type=safe_type,
                             headers={"Cache-Control": "public, max-age=604800"})
     except httpx.HTTPError:
-        raise HTTPException(502, "Failed to fetch image")
+        _NEGATIVE_CACHE[safe_url] = now + _NEGATIVE_TTL_SECONDS
+        return _not_found("Failed to fetch image")

--- a/frontend/src/lib/components/PosterImage.svelte
+++ b/frontend/src/lib/components/PosterImage.svelte
@@ -10,16 +10,22 @@
 
 	let { url, alt = '', class: className = 'h-28 w-20 shrink-0 rounded-sm object-cover', style: styleStr = '' }: Props = $props();
 
-	let showFallback = $state(!url);
+	let errored = $state(false);
+	let lastUrl: string | null | undefined = url;
+
+	// Reset error state only when the url value actually changes
+	$effect(() => {
+		if (url !== lastUrl) {
+			lastUrl = url;
+			errored = false;
+		}
+	});
+
+	const showFallback = $derived(!url || errored);
 
 	function onError() {
-		showFallback = true;
+		errored = true;
 	}
-
-	// Reset fallback when url changes
-	$effect(() => {
-		showFallback = !url;
-	});
 </script>
 
 {#if showFallback}

--- a/tests/routers/test_images.py
+++ b/tests/routers/test_images.py
@@ -37,12 +37,12 @@ async def test_proxy_cache_miss_fetches(app_client):
 
 
 async def test_proxy_rejects_bad_host(app_client):
-    """Non-allowlisted host returns 400."""
+    """Non-allowlisted host returns cacheable 404."""
     resp = await app_client.get("/api/images/proxy?url=https://evil.com/img.jpg")
-    assert resp.status_code == 400
+    assert resp.status_code == 404
 
 
 async def test_proxy_rejects_non_http(app_client):
-    """Non-HTTP scheme returns 400."""
+    """Non-HTTP scheme returns cacheable 404."""
     resp = await app_client.get("/api/images/proxy?url=ftp://example.com/img.jpg")
-    assert resp.status_code == 400
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- `PosterImage` remounted its `<img>` every 5s poll because an unconditional `$effect` reset `errored` back to false on each parent re-render, so the fallback SVG never stuck.
- The image proxy returned uncacheable `502`s on upstream failures, so the browser re-fetched every poll and briefly showed alt text before `onerror` swapped in the fallback.
- Fixed both: `PosterImage` now only resets `errored` when `url` actually changes, and the proxy returns a cacheable `404` (`Cache-Control: public, max-age=3600`) with a 1h in-memory negative cache.

## Test plan
- [x] Verified with Playwright: each proxy URL (including the failing Amazon one) fetched exactly once across ~8 poll cycles (43s). No flicker, no remount.
- [x] `npx svelte-check` clean.
- [ ] Smoke test in browser across dashboard + transcoder pages.