### PR TITLE
chore: gitignore root-level screenshots and local tooling debris

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,13 @@ docker-compose.override.yml
 # Logs
 *.log
 .superpowers/
+
+# Coverage / test tooling
+.coverage
+.playwright-mcp/
+
+# Local MCP config
+.mcp.json
+
+# Root-level screenshots (keep curated ones under screenshots/)
+/*.png


### PR DESCRIPTION
## Summary
- Gitignores .coverage, .playwright-mcp/, .mcp.json, and root-level PNGs
- Curated screenshots/ directory unaffected

## Why
These files accumulate from local test runs and ad-hoc screenshot sessions. Adding gitignore rules prevents accidental commits going forward. No tracked files are removed - all pre-existing debris was untracked and cleaned up locally.

## Test plan
- [x] `git check-ignore screenshots/01-dashboard.png` exits 1
- [x] `git check-ignore test.png` (root) exits 0