### PR TITLE
feat: scheme-aware preset picker for transcoder settings

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -154,6 +154,52 @@ async def get_transcoder_presets():
     return result
 
 
+def _raise_from_http_status_error(exc: httpx.HTTPStatusError) -> None:
+    """Re-raise an httpx HTTPStatusError as a FastAPI HTTPException, forwarding detail."""
+    detail = "Preset operation failed"
+    try:
+        detail = exc.response.json().get("detail", detail)
+    except Exception:
+        pass
+    raise HTTPException(status_code=exc.response.status_code, detail=detail)
+
+
+@router.post("/settings/transcoder/presets", status_code=201,
+             responses={409: {"description": "Slug conflict"}, 502: {"description": "Transcoder unreachable"}})
+async def create_transcoder_preset(body: dict):
+    try:
+        result = await transcoder_client.create_preset(body)
+    except httpx.HTTPStatusError as exc:
+        _raise_from_http_status_error(exc)
+    if result is None:
+        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+    return result
+
+
+@router.patch("/settings/transcoder/presets/{slug}",
+              responses={404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
+async def update_transcoder_preset(slug: str, body: dict):
+    try:
+        result = await transcoder_client.update_preset(slug, body)
+    except httpx.HTTPStatusError as exc:
+        _raise_from_http_status_error(exc)
+    if result is None:
+        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+    return result
+
+
+@router.delete("/settings/transcoder/presets/{slug}",
+               responses={404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
+async def delete_transcoder_preset(slug: str):
+    try:
+        result = await transcoder_client.delete_preset(slug)
+    except httpx.HTTPStatusError as exc:
+        _raise_from_http_status_error(exc)
+    if result is None:
+        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+    return result
+
+
 @router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, 502: {"description": "Transcoder service unreachable"}})
 async def update_transcoder_config(body: dict):
     result = await transcoder_client.update_config(body)

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+from typing import NoReturn
 
 from fastapi import APIRouter, HTTPException
 import httpx
@@ -154,7 +155,7 @@ async def get_transcoder_presets():
     return result
 
 
-def _raise_from_http_status_error(exc: httpx.HTTPStatusError) -> None:
+def _raise_from_http_status_error(exc: httpx.HTTPStatusError) -> NoReturn:
     """Re-raise an httpx HTTPStatusError as a FastAPI HTTPException, forwarding detail."""
     detail = "Preset operation failed"
     try:

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -15,6 +15,9 @@ from backend.services import arm_client, arm_db, transcoder_client
 router = APIRouter(prefix="/api", tags=["settings"])
 log = logging.getLogger(__name__)
 
+_TRANSCODER_UNREACHABLE = "Transcoder service unreachable"
+_TRANSCODER_UNREACHABLE_RESPONSE = {502: {"description": _TRANSCODER_UNREACHABLE}}
+
 
 def _read_hb_presets() -> list[str] | None:
     """Read HandBrake presets from the JSON file written by the init container."""
@@ -139,19 +142,19 @@ async def test_metadata_key(key: str | None = None, provider: str | None = None)
         return {"success": False, "message": "ARM service unreachable", "provider": "unknown"}
 
 
-@router.get("/settings/transcoder/scheme")
+@router.get("/settings/transcoder/scheme", responses=_TRANSCODER_UNREACHABLE_RESPONSE)
 async def get_transcoder_scheme():
     result = await transcoder_client.get_scheme()
     if result is None:
-        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+        raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     return result
 
 
-@router.get("/settings/transcoder/presets")
+@router.get("/settings/transcoder/presets", responses=_TRANSCODER_UNREACHABLE_RESPONSE)
 async def get_transcoder_presets():
     result = await transcoder_client.get_presets()
     if result is None:
-        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+        raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     return result
 
 
@@ -173,7 +176,7 @@ async def create_transcoder_preset(body: dict):
     except httpx.HTTPStatusError as exc:
         _raise_from_http_status_error(exc)
     if result is None:
-        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+        raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     return result
 
 
@@ -185,7 +188,7 @@ async def update_transcoder_preset(slug: str, body: dict):
     except httpx.HTTPStatusError as exc:
         _raise_from_http_status_error(exc)
     if result is None:
-        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+        raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     return result
 
 
@@ -197,15 +200,15 @@ async def delete_transcoder_preset(slug: str):
     except httpx.HTTPStatusError as exc:
         _raise_from_http_status_error(exc)
     if result is None:
-        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+        raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     return result
 
 
-@router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, 502: {"description": "Transcoder service unreachable"}})
+@router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, **_TRANSCODER_UNREACHABLE_RESPONSE})
 async def update_transcoder_config(body: dict):
     result = await transcoder_client.update_config(body)
     if result is None:
-        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+        raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     if not result.get("success"):
         raise HTTPException(status_code=400, detail=result.get("detail", "Unknown error"))
     return result

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -181,10 +181,12 @@ async def create_transcoder_preset(body: dict):
 
 
 @router.patch("/settings/transcoder/presets/{slug}",
-              responses={404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
+              responses={400: {"description": "Invalid slug"}, 404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
 async def update_transcoder_preset(slug: str, body: dict):
     try:
         result = await transcoder_client.update_preset(slug, body)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     except httpx.HTTPStatusError as exc:
         _raise_from_http_status_error(exc)
     if result is None:
@@ -193,10 +195,12 @@ async def update_transcoder_preset(slug: str, body: dict):
 
 
 @router.delete("/settings/transcoder/presets/{slug}",
-               responses={404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
+               responses={400: {"description": "Invalid slug"}, 404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
 async def delete_transcoder_preset(slug: str):
     try:
         result = await transcoder_client.delete_preset(slug)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     except httpx.HTTPStatusError as exc:
         _raise_from_http_status_error(exc)
     if result is None:

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -210,7 +210,10 @@ async def delete_transcoder_preset(slug: str):
 
 @router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, **_TRANSCODER_UNREACHABLE_RESPONSE})
 async def update_transcoder_config(body: dict):
-    result = await transcoder_client.update_config(body)
+    try:
+        result = await transcoder_client.update_config(body)
+    except httpx.HTTPStatusError as exc:
+        _raise_from_http_status_error(exc)
     if result is None:
         raise HTTPException(status_code=502, detail=_TRANSCODER_UNREACHABLE)
     if not result.get("success"):

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -138,6 +138,22 @@ async def test_metadata_key(key: str | None = None, provider: str | None = None)
         return {"success": False, "message": "ARM service unreachable", "provider": "unknown"}
 
 
+@router.get("/settings/transcoder/scheme")
+async def get_transcoder_scheme():
+    result = await transcoder_client.get_scheme()
+    if result is None:
+        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+    return result
+
+
+@router.get("/settings/transcoder/presets")
+async def get_transcoder_presets():
+    result = await transcoder_client.get_presets()
+    if result is None:
+        raise HTTPException(status_code=502, detail="Transcoder service unreachable")
+    return result
+
+
 @router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, 502: {"description": "Transcoder service unreachable"}})
 async def update_transcoder_config(body: dict):
     result = await transcoder_client.update_config(body)

--- a/backend/services/arm_db.py
+++ b/backend/services/arm_db.py
@@ -584,9 +584,10 @@ def get_job_retranscode_info(job_id: int) -> dict | None:
 
 
 TRANSCODE_OVERRIDE_KEYS = {
-    "video_encoder", "video_quality", "audio_encoder", "subtitle_mode",
-    "handbrake_preset", "handbrake_preset_4k", "handbrake_preset_dvd",
-    "handbrake_preset_file", "delete_source", "output_extension",
+    "preset_slug",
+    "overrides",
+    "delete_source",
+    "output_extension",
 }
 
 
@@ -594,14 +595,16 @@ def _coerce_override(key: str, value) -> tuple[str, object] | None:
     """Coerce a single transcode override value. Returns None to skip."""
     if value is None or value == "":
         return None
-    if key == "video_quality":
-        return key, int(value)
     if key == "delete_source":
         if isinstance(value, bool):
             return key, value
         if isinstance(value, str):
             return key, value.lower() in ("true", "1", "yes")
         return key, bool(value)
+    if key == "overrides":
+        if isinstance(value, dict):
+            return key, value
+        return None
     return key, str(value)
 
 

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -278,6 +278,36 @@ async def get_presets() -> dict[str, Any] | None:
         return None
 
 
+async def create_preset(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Create a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
+    try:
+        resp = await get_client().post("/api/v1/presets", json=body)
+    except (httpx.ConnectError, RuntimeError, OSError):
+        return None
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def update_preset(slug: str, body: dict[str, Any]) -> dict[str, Any] | None:
+    """Update a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
+    try:
+        resp = await get_client().patch(f"/api/v1/presets/{slug}", json=body)
+    except (httpx.ConnectError, RuntimeError, OSError):
+        return None
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def delete_preset(slug: str) -> dict[str, Any] | None:
+    """Delete a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
+    try:
+        resp = await get_client().delete(f"/api/v1/presets/{slug}")
+    except (httpx.ConnectError, RuntimeError, OSError):
+        return None
+    resp.raise_for_status()
+    return resp.json()
+
+
 async def get_config() -> dict[str, Any] | None:
     """Fetch transcoder config with valid option lists. Returns None if offline."""
     try:

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -258,6 +258,26 @@ async def restart_transcoder() -> dict[str, Any] | None:
         return None
 
 
+async def get_scheme() -> dict[str, Any] | None:
+    """Fetch active scheme from transcoder. Returns None if offline."""
+    try:
+        resp = await get_client().get("/api/v1/scheme")
+        resp.raise_for_status()
+        return resp.json()
+    except (httpx.HTTPError, httpx.ConnectError, RuntimeError, OSError):
+        return None
+
+
+async def get_presets() -> dict[str, Any] | None:
+    """Fetch all presets from transcoder. Returns None if offline."""
+    try:
+        resp = await get_client().get("/api/v1/presets")
+        resp.raise_for_status()
+        return resp.json()
+    except (httpx.HTTPError, httpx.ConnectError, RuntimeError, OSError):
+        return None
+
+
 async def get_config() -> dict[str, Any] | None:
     """Fetch transcoder config with valid option lists. Returns None if offline."""
     try:

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -15,6 +15,18 @@ from backend.config import settings
 _TS_FIELDS = {"created_at", "started_at", "completed_at"}
 _ISO_NO_TZ = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
 
+# Preset slugs must match what the transcoder's _slugify() produces:
+# lowercase alphanumerics separated by single hyphens, 1-100 chars.
+# Validating here prevents path traversal / query-string smuggling when the
+# slug is interpolated into an outbound URL.
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def _validate_slug(slug: str) -> str:
+    if not isinstance(slug, str) or not (1 <= len(slug) <= 100) or not _SLUG_RE.fullmatch(slug):
+        raise ValueError(f"Invalid preset slug: {slug!r}")
+    return slug
+
 
 def _normalize_timestamps(data: Any) -> Any:
     """Append 'Z' to bare ISO timestamps in transcoder responses."""
@@ -292,8 +304,9 @@ async def create_preset(body: dict[str, Any]) -> dict[str, Any] | None:
 
 async def update_preset(slug: str, body: dict[str, Any]) -> dict[str, Any] | None:
     """Update a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
+    safe_slug = _validate_slug(slug)
     try:
-        resp = await get_client().patch(f"/api/v1/presets/{slug}", json=body)
+        resp = await get_client().patch(f"/api/v1/presets/{safe_slug}", json=body)
         resp.raise_for_status()
         return resp.json()
     except httpx.HTTPStatusError:
@@ -304,8 +317,9 @@ async def update_preset(slug: str, body: dict[str, Any]) -> dict[str, Any] | Non
 
 async def delete_preset(slug: str) -> dict[str, Any] | None:
     """Delete a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
+    safe_slug = _validate_slug(slug)
     try:
-        resp = await get_client().delete(f"/api/v1/presets/{slug}")
+        resp = await get_client().delete(f"/api/v1/presets/{safe_slug}")
         resp.raise_for_status()
         return resp.json()
     except httpx.HTTPStatusError:

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -339,13 +339,18 @@ async def get_config() -> dict[str, Any] | None:
 
 
 async def update_config(config: dict[str, Any]) -> dict[str, Any] | None:
-    """Patch transcoder config. Returns response dict or None if offline."""
+    """Patch transcoder config.
+
+    Returns parsed response on 2xx, None if transcoder is unreachable.
+    Raises httpx.HTTPStatusError on 4xx/5xx so the caller can surface
+    the real error (e.g. validation 422) instead of a generic offline message.
+    """
     try:
         resp = await get_client().patch(_CONFIG_ENDPOINT, json=config)
-        resp.raise_for_status()
-        return resp.json()
-    except (httpx.HTTPError, httpx.ConnectError, RuntimeError, OSError):
+    except (httpx.ConnectError, httpx.TimeoutException, RuntimeError, OSError):
         return None
+    resp.raise_for_status()
+    return resp.json()
 
 
 async def get_jobs(

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -282,30 +282,36 @@ async def create_preset(body: dict[str, Any]) -> dict[str, Any] | None:
     """Create a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
     try:
         resp = await get_client().post("/api/v1/presets", json=body)
-    except (httpx.ConnectError, RuntimeError, OSError):
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError:
+        raise
+    except (httpx.HTTPError, RuntimeError, OSError):
         return None
-    resp.raise_for_status()
-    return resp.json()
 
 
 async def update_preset(slug: str, body: dict[str, Any]) -> dict[str, Any] | None:
     """Update a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
     try:
         resp = await get_client().patch(f"/api/v1/presets/{slug}", json=body)
-    except (httpx.ConnectError, RuntimeError, OSError):
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError:
+        raise
+    except (httpx.HTTPError, RuntimeError, OSError):
         return None
-    resp.raise_for_status()
-    return resp.json()
 
 
 async def delete_preset(slug: str) -> dict[str, Any] | None:
     """Delete a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
     try:
         resp = await get_client().delete(f"/api/v1/presets/{slug}")
-    except (httpx.ConnectError, RuntimeError, OSError):
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError:
+        raise
+    except (httpx.HTTPError, RuntimeError, OSError):
         return None
-    resp.raise_for_status()
-    return resp.json()
 
 
 async def get_config() -> dict[str, Any] | None:

--- a/frontend/src/lib/__tests__/settings-api-extra.test.ts
+++ b/frontend/src/lib/__tests__/settings-api-extra.test.ts
@@ -7,7 +7,7 @@ function jsonResponse(data: unknown, ok = true) {
 	return { ok, status: ok ? 200 : 500, statusText: ok ? 'OK' : 'Error', json: () => Promise.resolve(data) };
 }
 
-import { fetchAbcdeConfig, saveAbcdeConfig, testTranscoderConnection, testTranscoderWebhook, fetchSystemInfo } from '../api/settings';
+import { fetchAbcdeConfig, saveAbcdeConfig, testTranscoderConnection, testTranscoderWebhook, fetchSystemInfo, fetchTranscoderScheme, fetchTranscoderPresets, createCustomPreset } from '../api/settings';
 
 beforeEach(() => mockFetch.mockReset());
 
@@ -56,5 +56,95 @@ describe('fetchSystemInfo', () => {
 		mockFetch.mockResolvedValue(jsonResponse({ versions: {}, endpoints: {}, paths: [], database: {}, drives: [] }));
 		const result = await fetchSystemInfo();
 		expect(result.versions).toBeDefined();
+	});
+});
+
+describe('fetchTranscoderScheme', () => {
+	it('GETs /api/settings/transcoder/scheme and returns scheme', async () => {
+		const scheme = {
+			slug: 'nvidia',
+			name: 'NVIDIA NVENC',
+			supported_encoders: [],
+			supported_audio_encoders: [],
+			supported_subtitle_modes: [],
+			advanced_fields: {}
+		};
+		mockFetch.mockResolvedValue(jsonResponse(scheme));
+		const result = await fetchTranscoderScheme();
+		expect(result).toEqual(scheme);
+		expect(mockFetch).toHaveBeenCalledWith('/api/settings/transcoder/scheme', expect.any(Object));
+	});
+
+	it('returns null when backend returns 502 unreachable', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 502,
+			statusText: 'Bad Gateway',
+			json: () => Promise.resolve({ detail: 'Transcoder service unreachable' })
+		});
+		const result = await fetchTranscoderScheme();
+		expect(result).toBeNull();
+	});
+
+	it('rethrows non-502 errors', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 500,
+			statusText: 'Internal Server Error',
+			json: () => Promise.resolve({ detail: 'boom' })
+		});
+		await expect(fetchTranscoderScheme()).rejects.toThrow(/boom/);
+	});
+});
+
+describe('fetchTranscoderPresets', () => {
+	it('GETs /api/settings/transcoder/presets', async () => {
+		mockFetch.mockResolvedValue(jsonResponse({ presets: [{ slug: 'a', name: 'A', builtin: true, shared: {}, tiers: {}, scheme: 'nvidia', description: '' }] }));
+		const result = await fetchTranscoderPresets();
+		expect(result?.presets).toHaveLength(1);
+		expect(mockFetch).toHaveBeenCalledWith('/api/settings/transcoder/presets', expect.any(Object));
+	});
+
+	it('returns null when backend returns 502 unreachable', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 502,
+			statusText: 'Bad Gateway',
+			json: () => Promise.resolve({ detail: 'Transcoder service unreachable' })
+		});
+		const result = await fetchTranscoderPresets();
+		expect(result).toBeNull();
+	});
+
+	it('rethrows non-502 errors', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 500,
+			statusText: 'Internal Server Error',
+			json: () => Promise.resolve({ detail: 'db error' })
+		});
+		await expect(fetchTranscoderPresets()).rejects.toThrow(/db error/);
+	});
+});
+
+describe('createCustomPreset', () => {
+	it('POSTs the body to /api/settings/transcoder/presets', async () => {
+		const created = {
+			slug: 'my-anime', name: 'My Anime', scheme: 'nvidia',
+			description: '', builtin: false, parent_slug: 'nvidia_balanced',
+			shared: {}, tiers: { dvd: {}, bluray: {}, uhd: {} }
+		};
+		mockFetch.mockResolvedValue(jsonResponse(created));
+		const body = {
+			name: 'My Anime',
+			parent_slug: 'nvidia_balanced',
+			overrides: { shared: { audio_encoder: 'aac' }, tiers: {} }
+		};
+		const result = await createCustomPreset(body);
+		expect(result.slug).toBe('my-anime');
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/api/settings/transcoder/presets',
+			expect.objectContaining({ method: 'POST', body: JSON.stringify(body) })
+		);
 	});
 });

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -1,4 +1,5 @@
 import type { SettingsData } from '$lib/types/arm';
+import type { Scheme, Preset, Overrides } from '$lib/types/presets';
 import { apiFetch } from './client';
 
 export function fetchSettings(): Promise<SettingsData> {
@@ -104,4 +105,29 @@ export interface SystemInfoData {
 
 export function fetchSystemInfo(): Promise<SystemInfoData> {
 	return apiFetch<SystemInfoData>('/api/settings/system-info');
+}
+
+export async function fetchTranscoderScheme(): Promise<Scheme | null> {
+	try {
+		return await apiFetch<Scheme>('/api/settings/transcoder/scheme');
+	} catch (e: unknown) {
+		if (e instanceof Error && (e.message.includes('502') || e.message.includes('Transcoder service unreachable'))) return null;
+		throw e;
+	}
+}
+
+export async function fetchTranscoderPresets(): Promise<{ presets: Preset[] } | null> {
+	try {
+		return await apiFetch<{ presets: Preset[] }>('/api/settings/transcoder/presets');
+	} catch (e: unknown) {
+		if (e instanceof Error && (e.message.includes('502') || e.message.includes('Transcoder service unreachable'))) return null;
+		throw e;
+	}
+}
+
+export function createCustomPreset(body: { name: string; parent_slug: string; overrides: Overrides }): Promise<Preset> {
+	return apiFetch<Preset>('/api/settings/transcoder/presets', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	});
 }

--- a/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -867,7 +867,7 @@
 														{/if}
 													</td>
 												{/if}
-												{#if job.multi_title && !isMusic}
+												{#if job.multi_title && !isMusic && !tooShort}
 													<td class="px-1 py-1.5">
 														<button
 															onclick={() => toggleTrackSearch(track.track_id)}
@@ -881,7 +881,7 @@
 													</td>
 												{/if}
 											</tr>
-											{#if job.multi_title && openSearchTrackIds.has(track.track_id)}
+											{#if job.multi_title && !tooShort && openSearchTrackIds.has(track.track_id)}
 												<tr>
 													<td colspan="99" class="px-3 py-2">
 														<TrackTitleSearch jobId={job.job_id} {track} onapply={() => handleTrackTitleApply(track.track_id)} onclear={() => { onrefresh?.(); loadDetail(); }} onclose={() => toggleTrackSearch(track.track_id)} />

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -126,7 +126,7 @@
 
     function handleSave() {
         if (!canSave) return;
-        onSave({ preset_slug: selectedSlug, overrides });
+        onSave({ preset_slug: selectedSlug, overrides: $state.snapshot(overrides) as Overrides });
     }
 
     function handleRevert() {
@@ -138,7 +138,11 @@
         if (!onSaveAsNew || !newPresetName.trim()) return;
         saveAsNewError = '';
         try {
-            await onSaveAsNew({ name: newPresetName.trim(), parent_slug: selectedSlug, overrides });
+            await onSaveAsNew({
+                name: newPresetName.trim(),
+                parent_slug: selectedSlug,
+                overrides: $state.snapshot(overrides) as Overrides,
+            });
             saveAsModalOpen = false;
             newPresetName = '';
         } catch (e: unknown) {

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -77,6 +77,36 @@
     let saveAsModalOpen = $state(false);
     let newPresetName = $state('');
 
+    let undoToast = $state<{ message: string; previous: { slug: string; overrides: Overrides } } | null>(null);
+    let undoTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function handleDropdownChange(newSlug: string) {
+        const wasDirty = dirty;
+        const previousSlug = selectedSlug;
+        const previousName = selectedPreset?.name ?? previousSlug;
+        const previousOverrides: Overrides = JSON.parse(JSON.stringify(overrides));
+        selectedSlug = newSlug;
+        overrides = { shared: {}, tiers: {} };
+        if (wasDirty) {
+            const totalCleared = Object.keys(previousOverrides.shared).length +
+                Object.values(previousOverrides.tiers).reduce((n, t) => n + Object.keys(t).length, 0);
+            undoToast = {
+                message: `Cleared ${totalCleared} ${totalCleared === 1 ? 'change' : 'changes'} from ${previousName}`,
+                previous: { slug: previousSlug, overrides: previousOverrides }
+            };
+            if (undoTimer) clearTimeout(undoTimer);
+            undoTimer = setTimeout(() => { undoToast = null; }, 5000);
+        }
+    }
+
+    function handleUndo() {
+        if (!undoToast) return;
+        selectedSlug = undoToast.previous.slug;
+        overrides = undoToast.previous.overrides;
+        undoToast = null;
+        if (undoTimer) { clearTimeout(undoTimer); undoTimer = null; }
+    }
+
     function handleSave() {
         if (!canSave) return;
         onSave({ preset_slug: selectedSlug, overrides });
@@ -118,6 +148,11 @@
     </div>
 {:else}
     <div class="space-y-4">
+        {#if isUnavailable}
+            <div class="rounded-lg border border-amber-500/40 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/30 dark:text-amber-200">
+                This preset was built for scheme <strong>{selectedPreset?.scheme}</strong> but the active scheme is <strong>{scheme.slug}</strong>. Pick a compatible preset to save changes.
+            </div>
+        {/if}
         <div class="flex items-baseline justify-between border-b border-gray-200 pb-2 dark:border-gray-700">
             <div>
                 <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Active scheme</p>
@@ -129,8 +164,9 @@
             <label for="preset-select" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Preset</label>
             <select
                 id="preset-select"
-                bind:value={selectedSlug}
-                onchange={() => { overrides = { shared: {}, tiers: {} }; }}
+                value={selectedSlug}
+                onchange={(e) => handleDropdownChange((e.target as HTMLSelectElement).value)}
+                disabled={saving}
                 class="mt-1 w-full rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
             >
                 <optgroup label="Built-in">
@@ -179,6 +215,7 @@
                                 <select
                                     value={effectiveShared('audio_encoder')}
                                     onchange={(e) => setShared('audio_encoder', (e.target as HTMLSelectElement).value)}
+                                    disabled={saving || isUnavailable}
                                     class="{inputClass} w-full"
                                 >
                                     {#each scheme.supported_audio_encoders as enc}
@@ -193,6 +230,7 @@
                                 <select
                                     value={effectiveShared('subtitle_mode')}
                                     onchange={(e) => setShared('subtitle_mode', (e.target as HTMLSelectElement).value)}
+                                    disabled={saving || isUnavailable}
                                     class="{inputClass} w-full"
                                 >
                                     {#each scheme.supported_subtitle_modes as mode}
@@ -216,6 +254,7 @@
                                     <select
                                         value={effectiveTier(tier, 'video_encoder')}
                                         onchange={(e) => setTier(tier, 'video_encoder', (e.target as HTMLSelectElement).value)}
+                                        disabled={saving || isUnavailable}
                                         class="{inputClass} w-full"
                                     >
                                         {#each scheme.supported_encoders as enc}
@@ -232,6 +271,7 @@
                                         data-testid="tier-{tier}-quality"
                                         value={effectiveTier(tier, 'video_quality')}
                                         oninput={(e) => setTier(tier, 'video_quality', Number((e.target as HTMLInputElement).value))}
+                                        disabled={saving || isUnavailable}
                                         class="{inputClass} w-full"
                                     />
                                 </div>
@@ -243,6 +283,7 @@
                                         type="text"
                                         value={effectiveTier(tier, 'handbrake_preset')}
                                         oninput={(e) => setTier(tier, 'handbrake_preset', (e.target as HTMLInputElement).value)}
+                                        disabled={saving || isUnavailable}
                                         class="{inputClass} w-full"
                                     />
                                 </div>
@@ -255,6 +296,7 @@
                                             <select
                                                 value={effectiveTier(tier, key) || def.default || ''}
                                                 onchange={(e) => setTier(tier, key, (e.target as HTMLSelectElement).value)}
+                                                disabled={saving || isUnavailable}
                                                 class="{inputClass} w-full"
                                             >
                                                 {#each def.values as v}
@@ -266,6 +308,7 @@
                                                 type="text"
                                                 value={effectiveTier(tier, key)}
                                                 oninput={(e) => setTier(tier, key, (e.target as HTMLInputElement).value)}
+                                                disabled={saving || isUnavailable}
                                                 class="{inputClass} w-full"
                                             />
                                         {/if}
@@ -313,6 +356,13 @@
             </button>
         </div>
     </div>
+
+    {#if undoToast}
+        <div class="fixed bottom-4 left-1/2 z-40 -translate-x-1/2 rounded-lg bg-gray-900 px-4 py-2 text-sm text-white shadow-xl dark:bg-gray-700">
+            {undoToast.message}
+            <button onclick={handleUndo} class="ml-3 underline">Undo</button>
+        </div>
+    {/if}
 
     {#if saveAsModalOpen}
         <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -288,10 +288,9 @@
                     onclick={handleSave}
                     disabled={!canSave}
                     title={disabledSaveReason()}
-                    aria-label="Save changes"
                     class="rounded-lg bg-primary px-4 py-1.5 text-sm font-semibold text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                    {saving ? 'Saving...' : 'Save'}
+                    {saving ? 'Saving...' : 'Save changes'}
                 </button>
                 {#if scope === 'global' && onSaveAsNew}
                     <button

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -50,5 +50,37 @@
             </div>
             <p class="text-xs text-gray-500 dark:text-gray-400">{builtinCount} built-in · {customCount} custom</p>
         </div>
+        <div>
+            <label for="preset-select" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Preset</label>
+            <select
+                id="preset-select"
+                bind:value={selectedSlug}
+                onchange={() => { overrides = { shared: {}, tiers: {} }; }}
+                class="mt-1 w-full rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+            >
+                <optgroup label="Built-in">
+                    {#each presets.filter(p => p.builtin && !p.unavailable) as p (p.slug)}
+                        <option value={p.slug}>{p.name}</option>
+                    {/each}
+                </optgroup>
+                {#if presets.some(p => !p.builtin && !p.unavailable)}
+                    <optgroup label="Custom">
+                        {#each presets.filter(p => !p.builtin && !p.unavailable) as p (p.slug)}
+                            <option value={p.slug}>{p.name}</option>
+                        {/each}
+                    </optgroup>
+                {/if}
+                {#if presets.some(p => p.unavailable)}
+                    <optgroup label="Unavailable (other scheme)">
+                        {#each presets.filter(p => p.unavailable) as p (p.slug)}
+                            <option value={p.slug} disabled title={p.reason}>{p.name} ({p.scheme})</option>
+                        {/each}
+                    </optgroup>
+                {/if}
+            </select>
+            {#if selectedPreset?.description}
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{selectedPreset.description}</p>
+            {/if}
+        </div>
     </div>
 {/if}

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -364,7 +364,7 @@
                         type="button"
                         onclick={() => { saveAsModalOpen = true; newPresetName = ''; saveAsNewError = ''; }}
                         disabled={!dirty}
-                        class="text-sm text-primary underline-offset-2 hover:underline disabled:opacity-50"
+                        class="rounded-lg border border-primary px-4 py-2 text-sm font-semibold text-primary hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         Save as new preset
                     </button>

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+    import type { Scheme, Preset, Overrides, PresetEditorState } from '$lib/types/presets';
+
+    interface Props {
+        scope: 'global' | 'job';
+        initialState: PresetEditorState;
+        scheme: Scheme | null;
+        presets: Preset[];
+        offline: boolean;
+        saving: boolean;
+        onSave: (state: PresetEditorState) => Promise<void>;
+        onSaveAsNew?: (state: { name: string; parent_slug: string; overrides: Overrides }) => Promise<void>;
+        onRetry?: () => void;
+    }
+
+    let { scope, initialState, scheme, presets, offline, saving, onSave, onSaveAsNew, onRetry }: Props = $props();
+
+    const initialSlug = initialState.preset_slug;
+    let selectedSlug = $state<string>(initialSlug);
+    let overrides = $state<Overrides>(structuredClone(initialState.overrides));
+
+    const dirty = $derived(
+        Object.keys(overrides.shared).length +
+        Object.values(overrides.tiers).reduce((n, t) => n + Object.keys(t).length, 0) > 0
+    );
+    const selectedPreset = $derived(presets.find(p => p.slug === selectedSlug));
+    const isUnavailable = $derived(selectedPreset?.unavailable === true);
+    const canSave = $derived(!saving && !isUnavailable && (dirty || selectedSlug !== initialSlug));
+
+    const builtinCount = $derived(presets.filter(p => p.builtin && !p.unavailable).length);
+    const customCount = $derived(presets.filter(p => !p.builtin && !p.unavailable).length);
+</script>
+
+{#if offline || !scheme}
+    <div class="rounded-lg border border-amber-500/40 bg-amber-50 p-4 text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/30 dark:text-amber-200">
+        <p class="font-semibold">Transcoder service unavailable</p>
+        <p class="mt-1 text-sm">Cannot load preset options. Check that arm-transcoder is running.</p>
+        {#if onRetry}
+            <button onclick={onRetry} class="mt-2 rounded-md bg-amber-600 px-3 py-1 text-sm font-medium text-white hover:bg-amber-700">
+                Retry
+            </button>
+        {/if}
+    </div>
+{:else}
+    <div class="space-y-4">
+        <div class="flex items-baseline justify-between border-b border-gray-200 pb-2 dark:border-gray-700">
+            <div>
+                <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Active scheme</p>
+                <p class="text-base font-semibold text-gray-900 dark:text-white">{scheme.name}</p>
+            </div>
+            <p class="text-xs text-gray-500 dark:text-gray-400">{builtinCount} built-in · {customCount} custom</p>
+        </div>
+    </div>
+{/if}

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -18,7 +18,18 @@
 
     const initialSlug = initialState.preset_slug;
     let selectedSlug = $state<string>(initialSlug);
-    let overrides = $state<Overrides>(structuredClone(initialState.overrides));
+    let overrides = $state<Overrides>({
+        shared: structuredClone(initialState.overrides?.shared ?? {}),
+        tiers: structuredClone(initialState.overrides?.tiers ?? {})
+    });
+
+    // Once presets are loaded, default to the first built-in if no slug was preselected
+    $effect(() => {
+        if (selectedSlug === '' && presets.length > 0) {
+            const firstBuiltin = presets.find(p => p.builtin && !p.unavailable);
+            if (firstBuiltin) selectedSlug = firstBuiltin.slug;
+        }
+    });
 
     const dirtyCount = $derived(
         Object.keys(overrides.shared).length +

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -73,6 +73,37 @@
 
     const dirtyRing = 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50';
     const inputClass = 'rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white';
+
+    let saveAsModalOpen = $state(false);
+    let newPresetName = $state('');
+
+    function handleSave() {
+        if (!canSave) return;
+        onSave({ preset_slug: selectedSlug, overrides });
+    }
+
+    function handleRevert() {
+        overrides = { shared: {}, tiers: {} };
+        selectedSlug = initialSlug;
+    }
+
+    function handleSaveAsConfirm() {
+        if (!onSaveAsNew || !newPresetName.trim()) return;
+        onSaveAsNew({ name: newPresetName.trim(), parent_slug: selectedSlug, overrides });
+        saveAsModalOpen = false;
+        newPresetName = '';
+    }
+
+    function disabledSaveReason(): string {
+        if (saving) return 'Saving...';
+        if (isUnavailable) return 'Selected preset is not available in the active scheme';
+        if (!dirty && selectedSlug === initialSlug) return 'No changes to save';
+        return '';
+    }
+
+    function slugify(name: string): string {
+        return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'custom';
+    }
 </script>
 
 {#if offline || !scheme}
@@ -249,5 +280,72 @@
                 {/each}
             </div>
         </div>
+
+        <div class="flex items-center justify-between border-t border-gray-200 pt-3 dark:border-gray-700">
+            <div class="flex items-center gap-3">
+                <button
+                    type="button"
+                    onclick={handleSave}
+                    disabled={!canSave}
+                    title={disabledSaveReason()}
+                    aria-label="Save changes"
+                    class="rounded-lg bg-primary px-4 py-1.5 text-sm font-semibold text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                    {saving ? 'Saving...' : 'Save'}
+                </button>
+                {#if scope === 'global' && onSaveAsNew}
+                    <button
+                        type="button"
+                        onclick={() => { saveAsModalOpen = true; newPresetName = ''; }}
+                        disabled={!dirty}
+                        class="text-sm text-primary underline-offset-2 hover:underline disabled:opacity-50"
+                    >
+                        Save as new preset
+                    </button>
+                {/if}
+            </div>
+            <button
+                type="button"
+                onclick={handleRevert}
+                disabled={!dirty && selectedSlug === initialSlug}
+                class="text-sm text-gray-500 hover:text-gray-700 disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-200"
+            >
+                Revert
+            </button>
+        </div>
     </div>
+
+    {#if saveAsModalOpen}
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+            <div class="w-full max-w-md rounded-lg bg-white p-5 shadow-xl dark:bg-gray-800">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Save as new preset</h3>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    Saves your current customizations as a new preset based on <strong>{selectedPreset?.name}</strong>.
+                </p>
+                <label class="mt-3 block">
+                    <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Name</span>
+                    <input
+                        type="text"
+                        bind:value={newPresetName}
+                        placeholder="e.g. Weekend Rips"
+                        class="{inputClass} mt-1 w-full"
+                    />
+                    {#if newPresetName.trim()}
+                        <span class="mt-1 block text-xs text-gray-500 dark:text-gray-400">Will be saved as: <code>{slugify(newPresetName)}</code></span>
+                    {/if}
+                </label>
+                <div class="mt-4 flex justify-end gap-2">
+                    <button type="button" onclick={() => { saveAsModalOpen = false; }}
+                            class="rounded-lg px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                        Cancel
+                    </button>
+                    <button type="button" onclick={handleSaveAsConfirm}
+                            disabled={!newPresetName.trim()}
+                            class="rounded-lg bg-primary px-3 py-1.5 text-sm font-semibold text-white hover:bg-primary/90 disabled:opacity-50">
+                        Create preset
+                    </button>
+                </div>
+            </div>
+        </div>
+    {/if}
 {/if}

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onDestroy } from 'svelte';
     import type { Scheme, Preset, Overrides, PresetEditorState } from '$lib/types/presets';
 
     interface Props {
@@ -19,10 +20,11 @@
     let selectedSlug = $state<string>(initialSlug);
     let overrides = $state<Overrides>(structuredClone(initialState.overrides));
 
-    const dirty = $derived(
+    const dirtyCount = $derived(
         Object.keys(overrides.shared).length +
-        Object.values(overrides.tiers).reduce((n, t) => n + Object.keys(t).length, 0) > 0
+        Object.values(overrides.tiers).reduce((n, t) => n + Object.keys(t).length, 0)
     );
+    const dirty = $derived(dirtyCount > 0);
     const selectedPreset = $derived(presets.find(p => p.slug === selectedSlug));
     const isUnavailable = $derived(selectedPreset?.unavailable === true);
     const canSave = $derived(!saving && !isUnavailable && (dirty || selectedSlug !== initialSlug));
@@ -76,9 +78,11 @@
 
     let saveAsModalOpen = $state(false);
     let newPresetName = $state('');
+    let saveAsNewError = $state<string>('');
 
     let undoToast = $state<{ message: string; previous: { slug: string; overrides: Overrides } } | null>(null);
     let undoTimer: ReturnType<typeof setTimeout> | null = null;
+    onDestroy(() => { if (undoTimer) clearTimeout(undoTimer); });
 
     function handleDropdownChange(newSlug: string) {
         const wasDirty = dirty;
@@ -117,11 +121,16 @@
         selectedSlug = initialSlug;
     }
 
-    function handleSaveAsConfirm() {
+    async function handleSaveAsConfirm() {
         if (!onSaveAsNew || !newPresetName.trim()) return;
-        onSaveAsNew({ name: newPresetName.trim(), parent_slug: selectedSlug, overrides });
-        saveAsModalOpen = false;
-        newPresetName = '';
+        saveAsNewError = '';
+        try {
+            await onSaveAsNew({ name: newPresetName.trim(), parent_slug: selectedSlug, overrides });
+            saveAsModalOpen = false;
+            newPresetName = '';
+        } catch (e: unknown) {
+            saveAsNewError = e instanceof Error ? e.message : 'Save failed';
+        }
     }
 
     function disabledSaveReason(): string {
@@ -198,9 +207,8 @@
             <div class="flex items-center justify-between">
                 <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Customize</h4>
                 {#if dirty}
-                    {@const total = Object.keys(overrides.shared).length + Object.values(overrides.tiers).reduce((n, t) => n + Object.keys(t).length, 0)}
                     <span class="rounded-full bg-primary/20 px-2 py-0.5 text-xs font-medium text-primary dark:text-primary-300">
-                        {total} {total === 1 ? 'change' : 'changes'}
+                        {dirtyCount} {dirtyCount === 1 ? 'change' : 'changes'}
                     </span>
                 {/if}
             </div>
@@ -270,7 +278,10 @@
                                         type="number" min="0" max="51" step="1"
                                         data-testid="tier-{tier}-quality"
                                         value={effectiveTier(tier, 'video_quality')}
-                                        oninput={(e) => setTier(tier, 'video_quality', Number((e.target as HTMLInputElement).value))}
+                                        oninput={(e) => {
+                                            const raw = (e.target as HTMLInputElement).value;
+                                            setTier(tier, 'video_quality', raw === '' ? '' : Number(raw));
+                                        }}
                                         disabled={saving || isUnavailable}
                                         class="{inputClass} w-full"
                                     />
@@ -338,7 +349,7 @@
                 {#if scope === 'global' && onSaveAsNew}
                     <button
                         type="button"
-                        onclick={() => { saveAsModalOpen = true; newPresetName = ''; }}
+                        onclick={() => { saveAsModalOpen = true; newPresetName = ''; saveAsNewError = ''; }}
                         disabled={!dirty}
                         class="text-sm text-primary underline-offset-2 hover:underline disabled:opacity-50"
                     >
@@ -365,9 +376,9 @@
     {/if}
 
     {#if saveAsModalOpen}
-        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true" aria-labelledby="save-as-heading">
             <div class="w-full max-w-md rounded-lg bg-white p-5 shadow-xl dark:bg-gray-800">
-                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Save as new preset</h3>
+                <h3 id="save-as-heading" class="text-lg font-semibold text-gray-900 dark:text-white">Save as new preset</h3>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                     Saves your current customizations as a new preset based on <strong>{selectedPreset?.name}</strong>.
                 </p>
@@ -381,6 +392,9 @@
                     />
                     {#if newPresetName.trim()}
                         <span class="mt-1 block text-xs text-gray-500 dark:text-gray-400">Will be saved as: <code>{slugify(newPresetName)}</code></span>
+                    {/if}
+                    {#if saveAsNewError}
+                        <span class="mt-1 block text-xs text-red-600 dark:text-red-400">{saveAsNewError}</span>
                     {/if}
                 </label>
                 <div class="mt-4 flex justify-end gap-2">

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -70,7 +70,9 @@
 
     function effectiveTier(tier: string, key: string): unknown {
         if (overrides.tiers[tier]?.[key] !== undefined) return overrides.tiers[tier][key];
-        return selectedPreset?.tiers[tier as 'dvd' | 'bluray' | 'uhd']?.[key] ?? '';
+        const tierVal = selectedPreset?.tiers[tier as 'dvd' | 'bluray' | 'uhd']?.[key];
+        if (tierVal !== undefined) return tierVal;
+        return selectedPreset?.shared?.[key] ?? '';
     }
 
     function isSharedDirty(key: string): boolean {

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -29,6 +29,50 @@
 
     const builtinCount = $derived(presets.filter(p => p.builtin && !p.unavailable).length);
     const customCount = $derived(presets.filter(p => !p.builtin && !p.unavailable).length);
+
+    function setShared(key: string, value: unknown) {
+        if (value === '' || value === null || value === undefined) {
+            delete overrides.shared[key];
+        } else {
+            overrides.shared[key] = value;
+        }
+        overrides = { ...overrides };
+    }
+
+    function setTier(tier: string, key: string, value: unknown) {
+        if (!overrides.tiers[tier]) overrides.tiers[tier] = {};
+        if (value === '' || value === null || value === undefined) {
+            delete overrides.tiers[tier][key];
+            if (Object.keys(overrides.tiers[tier]).length === 0) delete overrides.tiers[tier];
+        } else {
+            overrides.tiers[tier][key] = value;
+        }
+        overrides = { ...overrides };
+    }
+
+    function effectiveShared(key: string): unknown {
+        if (key in overrides.shared) return overrides.shared[key];
+        return selectedPreset?.shared[key] ?? '';
+    }
+
+    function effectiveTier(tier: string, key: string): unknown {
+        if (overrides.tiers[tier]?.[key] !== undefined) return overrides.tiers[tier][key];
+        return selectedPreset?.tiers[tier as 'dvd' | 'bluray' | 'uhd']?.[key] ?? '';
+    }
+
+    function isSharedDirty(key: string): boolean {
+        return key in overrides.shared;
+    }
+
+    function isTierDirty(tier: string, key: string): boolean {
+        return overrides.tiers[tier]?.[key] !== undefined;
+    }
+
+    const TIER_LABELS: Record<string, string> = { dvd: 'DVD', bluray: 'Blu-ray', uhd: 'UHD' };
+    const TIER_HINTS: Record<string, string> = { dvd: '< 720p', bluray: '720p–1080p', uhd: '> 1080p' };
+
+    const dirtyRing = 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50';
+    const inputClass = 'rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white';
 </script>
 
 {#if offline || !scheme}
@@ -81,6 +125,129 @@
             {#if selectedPreset?.description}
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{selectedPreset.description}</p>
             {/if}
+        </div>
+
+        <div>
+            <div class="flex items-center justify-between">
+                <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Customize</h4>
+                {#if dirty}
+                    {@const total = Object.keys(overrides.shared).length + Object.values(overrides.tiers).reduce((n, t) => n + Object.keys(t).length, 0)}
+                    <span class="rounded-full bg-primary/20 px-2 py-0.5 text-xs font-medium text-primary dark:text-primary-300">
+                        {total} {total === 1 ? 'change' : 'changes'}
+                    </span>
+                {/if}
+            </div>
+
+            <div class="mt-3 space-y-3">
+                <div class="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+                    <p class="mb-2 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Shared</p>
+                    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <label class="space-y-1">
+                            <span class="text-xs text-gray-600 dark:text-gray-400">Audio encoder</span>
+                            <div class={isSharedDirty('audio_encoder') ? dirtyRing : ''}>
+                                <select
+                                    value={effectiveShared('audio_encoder')}
+                                    onchange={(e) => setShared('audio_encoder', (e.target as HTMLSelectElement).value)}
+                                    class="{inputClass} w-full"
+                                >
+                                    {#each scheme.supported_audio_encoders as enc}
+                                        <option value={enc}>{enc}</option>
+                                    {/each}
+                                </select>
+                            </div>
+                        </label>
+                        <label class="space-y-1">
+                            <span class="text-xs text-gray-600 dark:text-gray-400">Subtitle mode</span>
+                            <div class={isSharedDirty('subtitle_mode') ? dirtyRing : ''}>
+                                <select
+                                    value={effectiveShared('subtitle_mode')}
+                                    onchange={(e) => setShared('subtitle_mode', (e.target as HTMLSelectElement).value)}
+                                    class="{inputClass} w-full"
+                                >
+                                    {#each scheme.supported_subtitle_modes as mode}
+                                        <option value={mode}>{mode}</option>
+                                    {/each}
+                                </select>
+                            </div>
+                        </label>
+                    </div>
+                </div>
+
+                {#each ['dvd', 'bluray', 'uhd'] as tier}
+                    <div class="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+                        <p class="mb-2 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                            {TIER_LABELS[tier]} <span class="text-gray-400">· {TIER_HINTS[tier]}</span>
+                        </p>
+                        <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                            <label class="space-y-1">
+                                <span class="text-xs text-gray-600 dark:text-gray-400">Encoder</span>
+                                <div class={isTierDirty(tier, 'video_encoder') ? dirtyRing : ''}>
+                                    <select
+                                        value={effectiveTier(tier, 'video_encoder')}
+                                        onchange={(e) => setTier(tier, 'video_encoder', (e.target as HTMLSelectElement).value)}
+                                        class="{inputClass} w-full"
+                                    >
+                                        {#each scheme.supported_encoders as enc}
+                                            <option value={enc.slug}>{enc.name}</option>
+                                        {/each}
+                                    </select>
+                                </div>
+                            </label>
+                            <label class="space-y-1">
+                                <span class="text-xs text-gray-600 dark:text-gray-400">Quality (CRF 0-51)</span>
+                                <div class={isTierDirty(tier, 'video_quality') ? dirtyRing : ''}>
+                                    <input
+                                        type="number" min="0" max="51" step="1"
+                                        data-testid="tier-{tier}-quality"
+                                        value={effectiveTier(tier, 'video_quality')}
+                                        oninput={(e) => setTier(tier, 'video_quality', Number((e.target as HTMLInputElement).value))}
+                                        class="{inputClass} w-full"
+                                    />
+                                </div>
+                            </label>
+                            <label class="space-y-1 lg:col-span-2">
+                                <span class="text-xs text-gray-600 dark:text-gray-400">HandBrake preset</span>
+                                <div class={isTierDirty(tier, 'handbrake_preset') ? dirtyRing : ''}>
+                                    <input
+                                        type="text"
+                                        value={effectiveTier(tier, 'handbrake_preset')}
+                                        oninput={(e) => setTier(tier, 'handbrake_preset', (e.target as HTMLInputElement).value)}
+                                        class="{inputClass} w-full"
+                                    />
+                                </div>
+                            </label>
+                            {#each Object.entries(scheme.advanced_fields) as [key, def]}
+                                <label class="space-y-1">
+                                    <span class="text-xs text-gray-600 dark:text-gray-400">{key}</span>
+                                    <div class={isTierDirty(tier, key) ? dirtyRing : ''}>
+                                        {#if def.type === 'enum' && def.values}
+                                            <select
+                                                value={effectiveTier(tier, key) || def.default || ''}
+                                                onchange={(e) => setTier(tier, key, (e.target as HTMLSelectElement).value)}
+                                                class="{inputClass} w-full"
+                                            >
+                                                {#each def.values as v}
+                                                    <option value={v}>{v}</option>
+                                                {/each}
+                                            </select>
+                                        {:else}
+                                            <input
+                                                type="text"
+                                                value={effectiveTier(tier, key)}
+                                                oninput={(e) => setTier(tier, key, (e.target as HTMLInputElement).value)}
+                                                class="{inputClass} w-full"
+                                            />
+                                        {/if}
+                                    </div>
+                                    {#if def.description}
+                                        <span class="block text-xs text-gray-400">{def.description}</span>
+                                    {/if}
+                                </label>
+                            {/each}
+                        </div>
+                    </div>
+                {/each}
+            </div>
         </div>
     </div>
 {/if}

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -137,3 +137,61 @@ describe('PresetEditor customize panel', () => {
         expect(screen.getByText(/1 change/i)).toBeInTheDocument();
     });
 });
+
+describe('PresetEditor save bar', () => {
+    afterEach(() => cleanup());
+
+    const baseProps = {
+        scope: 'global' as const,
+        initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+        scheme: mockScheme,
+        presets: mockPresets,
+        offline: false,
+        saving: false
+    };
+
+    it('Save button disabled when not dirty and slug unchanged', () => {
+        renderComponent(PresetEditor, { props: { ...baseProps, onSave: async () => {} } });
+        const btn = screen.getByRole('button', { name: /Save changes/i }) as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+    });
+
+    it('Save button enabled when dirty', async () => {
+        const { container } = renderComponent(PresetEditor, { props: { ...baseProps, onSave: async () => {} } });
+        const qualityInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(qualityInput, { target: { value: '18' } });
+        const btn = screen.getByRole('button', { name: /Save changes/i }) as HTMLButtonElement;
+        expect(btn.disabled).toBe(false);
+    });
+
+    it('calls onSave with current state when Save clicked', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        const { container } = renderComponent(PresetEditor, { props: { ...baseProps, onSave } });
+        const qualityInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(qualityInput, { target: { value: '18' } });
+        await fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+            preset_slug: 'software_balanced',
+            overrides: expect.objectContaining({ tiers: expect.objectContaining({ bluray: { video_quality: 18 } }) })
+        }));
+    });
+
+    it('Revert clears overrides', async () => {
+        const { container } = renderComponent(PresetEditor, { props: { ...baseProps, onSave: async () => {} } });
+        const qualityInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(qualityInput, { target: { value: '18' } });
+        expect(screen.getByText(/1 change/i)).toBeInTheDocument();
+        await fireEvent.click(screen.getByRole('button', { name: /Revert/i }));
+        expect(screen.queryByText(/change/i)).toBeNull();
+    });
+
+    it('hides "Save as new preset" when scope=job', () => {
+        renderComponent(PresetEditor, { props: { ...baseProps, scope: 'job', onSave: async () => {} } });
+        expect(screen.queryByText(/Save as new preset/i)).toBeNull();
+    });
+
+    it('shows "Save as new preset" when scope=global with onSaveAsNew handler', () => {
+        renderComponent(PresetEditor, { props: { ...baseProps, onSave: async () => {}, onSaveAsNew: async () => {} } });
+        expect(screen.getByText(/Save as new preset/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -136,6 +136,35 @@ describe('PresetEditor customize panel', () => {
         // Visual: dirty pill should show "1 change"
         expect(screen.getByText(/1 change/i)).toBeInTheDocument();
     });
+
+    it('writes to overrides.shared[key] when shared field changes', async () => {
+        const { container } = renderComponent(PresetEditor, { props });
+        // The audio encoder select is the first select inside the Shared section
+        const allSelects = container.querySelectorAll('label > div > select');
+        const audioEncoderSelect = allSelects[0] as HTMLSelectElement;
+        await fireEvent.change(audioEncoderSelect, { target: { value: 'aac' } });
+        expect(screen.getByText(/1 change/i)).toBeInTheDocument();
+    });
+
+    it('renders advanced enum fields per scheme.advanced_fields', () => {
+        const schemeWithAdvanced: Scheme = {
+            ...mockScheme,
+            advanced_fields: {
+                x265_preset: {
+                    type: 'enum',
+                    values: ['ultrafast', 'medium', 'placebo'],
+                    default: 'medium',
+                    description: 'x265 speed/quality tradeoff'
+                }
+            }
+        };
+        renderComponent(PresetEditor, { props: { ...props, scheme: schemeWithAdvanced } });
+        // The label text from the advanced field key should appear (one per tier = 3 occurrences)
+        const labels = screen.getAllByText(/x265_preset/);
+        expect(labels.length).toBeGreaterThanOrEqual(3);
+        // The description should appear
+        expect(screen.getAllByText(/speed\/quality tradeoff/).length).toBeGreaterThanOrEqual(1);
+    });
 });
 
 describe('PresetEditor save bar', () => {

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -182,7 +182,7 @@ describe('PresetEditor save bar', () => {
         await fireEvent.input(qualityInput, { target: { value: '18' } });
         expect(screen.getByText(/1 change/i)).toBeInTheDocument();
         await fireEvent.click(screen.getByRole('button', { name: /Revert/i }));
-        expect(screen.queryByText(/change/i)).toBeNull();
+        expect(screen.queryByText(/^\d+ changes?$/i)).toBeNull();
     });
 
     it('hides "Save as new preset" when scope=job', () => {

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import PresetEditor from './PresetEditor.svelte';
+import type { Scheme, Preset } from '$lib/types/presets';
+
+const mockScheme: Scheme = {
+    slug: 'software',
+    name: 'Software (CPU)',
+    supported_encoders: [
+        { slug: 'x265', name: 'x265', tuning_presets: [] },
+        { slug: 'x264', name: 'x264', tuning_presets: [] }
+    ],
+    supported_audio_encoders: ['copy', 'aac'],
+    supported_subtitle_modes: ['all', 'first', 'none'],
+    advanced_fields: {}
+};
+
+const mockPresets: Preset[] = [
+    {
+        slug: 'software_balanced', name: 'Balanced', scheme: 'software',
+        description: 'Balanced encoding', builtin: true,
+        shared: { audio_encoder: 'copy', subtitle_mode: 'all' },
+        tiers: {
+            dvd: { video_encoder: 'x265', video_quality: 22 },
+            bluray: { video_encoder: 'x265', video_quality: 22 },
+            uhd: { video_encoder: 'x265', video_quality: 22 }
+        }
+    }
+];
+
+describe('PresetEditor', () => {
+    afterEach(() => cleanup());
+
+    it('renders the active scheme name in the header', () => {
+        renderComponent(PresetEditor, {
+            props: {
+                scope: 'global',
+                initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+                scheme: mockScheme,
+                presets: mockPresets,
+                offline: false,
+                saving: false,
+                onSave: async () => {}
+            }
+        });
+        expect(screen.getByText(/Software \(CPU\)/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -195,3 +195,64 @@ describe('PresetEditor save bar', () => {
         expect(screen.getByText(/Save as new preset/i)).toBeInTheDocument();
     });
 });
+
+describe('PresetEditor edge cases', () => {
+    afterEach(() => cleanup());
+
+    const baseProps = {
+        scope: 'global' as const,
+        initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+        scheme: mockScheme,
+        presets: mockPresets,
+        offline: false,
+        onSave: async () => {}
+    };
+
+    it('disables form fields while saving=true', () => {
+        const { container } = renderComponent(PresetEditor, { props: { ...baseProps, saving: true } });
+        const select = container.querySelector('#preset-select') as HTMLSelectElement;
+        expect(select.disabled).toBe(true);
+    });
+
+    it('shows offline banner when scheme is null', () => {
+        const onRetry = vi.fn();
+        renderComponent(PresetEditor, { props: { ...baseProps, scheme: null, presets: [], offline: true, saving: false, onRetry } });
+        expect(screen.getByText(/Transcoder service unavailable/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument();
+    });
+
+    it('Retry button calls onRetry callback', async () => {
+        const onRetry = vi.fn();
+        renderComponent(PresetEditor, { props: { ...baseProps, scheme: null, presets: [], offline: true, saving: false, onRetry } });
+        await fireEvent.click(screen.getByRole('button', { name: /Retry/i }));
+        expect(onRetry).toHaveBeenCalled();
+    });
+
+    it('disables Save and shows warning when selected preset is unavailable', () => {
+        const propsWithUnavailable = {
+            ...baseProps,
+            saving: false,
+            initialState: { preset_slug: 'nvidia-imp', overrides: { shared: {}, tiers: {} } },
+            presets: [...mockPresets, unavailablePreset]
+        };
+        renderComponent(PresetEditor, { props: propsWithUnavailable });
+        const btn = screen.getByRole('button', { name: /Save changes/i }) as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+        expect(btn.title).toMatch(/not available/i);
+    });
+
+    it('shows undo toast for 5 seconds after dropdown switch with pending changes', async () => {
+        vi.useFakeTimers();
+        const second: Preset = { ...mockPresets[0], slug: 'software_quality', name: 'Quality' };
+        const { container } = renderComponent(PresetEditor, { props: { ...baseProps, saving: false, presets: [mockPresets[0], second] } });
+        const qualityInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(qualityInput, { target: { value: '18' } });
+        const select = container.querySelector('#preset-select') as HTMLSelectElement;
+        await fireEvent.change(select, { target: { value: 'software_quality' } });
+        expect(screen.getByText(/Cleared.*from/i)).toBeInTheDocument();
+        vi.advanceTimersByTime(5500);
+        await Promise.resolve();
+        expect(screen.queryByText(/Cleared.*from/i)).toBeNull();
+        vi.useRealTimers();
+    });
+});

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -89,9 +89,51 @@ describe('PresetEditor dropdown', () => {
 
     it('updates selectedSlug when dropdown changes', async () => {
         const second: Preset = { ...mockPresets[0], slug: 'software_quality', name: 'Quality' };
-        renderComponent(PresetEditor, { props: { ...baseProps, presets: [mockPresets[0], second] } });
-        const select = screen.getByRole('combobox') as HTMLSelectElement;
+        const { container } = renderComponent(PresetEditor, { props: { ...baseProps, presets: [mockPresets[0], second] } });
+        const select = container.querySelector('#preset-select') as HTMLSelectElement;
         await fireEvent.change(select, { target: { value: 'software_quality' } });
         expect(select.value).toBe('software_quality');
+    });
+});
+
+describe('PresetEditor customize panel', () => {
+    afterEach(() => cleanup());
+
+    const props = {
+        scope: 'global' as const,
+        initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+        scheme: mockScheme,
+        presets: mockPresets,
+        offline: false,
+        saving: false,
+        onSave: async () => {}
+    };
+
+    it('renders Shared row with audio_encoder and subtitle_mode dropdowns', () => {
+        renderComponent(PresetEditor, { props });
+        expect(screen.getByText(/Audio encoder/i)).toBeInTheDocument();
+        expect(screen.getByText(/Subtitle mode/i)).toBeInTheDocument();
+    });
+
+    it('renders three tier sections', () => {
+        renderComponent(PresetEditor, { props });
+        expect(screen.getByText(/^DVD/)).toBeInTheDocument();
+        expect(screen.getByText(/Blu-ray/)).toBeInTheDocument();
+        expect(screen.getByText(/^UHD/)).toBeInTheDocument();
+    });
+
+    it('only shows scheme-supported encoders (no nvenc options)', () => {
+        renderComponent(PresetEditor, { props });
+        // mockScheme has x265 and x264 only - no nvenc options should appear
+        expect(screen.queryByRole('option', { name: /nvenc/i })).toBeNull();
+    });
+
+    it('writes to overrides.tiers[tier][key] when a tier field changes', async () => {
+        const { container } = renderComponent(PresetEditor, { props });
+        const qualityInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        expect(qualityInput).toBeTruthy();
+        await fireEvent.input(qualityInput, { target: { value: '18' } });
+        // Visual: dirty pill should show "1 change"
+        expect(screen.getByText(/1 change/i)).toBeInTheDocument();
     });
 });

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -285,3 +285,148 @@ describe('PresetEditor edge cases', () => {
         vi.useRealTimers();
     });
 });
+
+describe('PresetEditor save-as-new flow', () => {
+    afterEach(() => cleanup());
+
+    const twoPresetScheme: Scheme = {
+        ...mockScheme,
+        slug: 'software',
+    };
+    const twoPresets: Preset[] = [
+        ...mockPresets,
+        {
+            slug: 'software_quality', name: 'High Quality', scheme: 'software',
+            description: 'Higher quality', builtin: true,
+            shared: { audio_encoder: 'copy', subtitle_mode: 'all' },
+            tiers: {
+                dvd: { video_encoder: 'x265', video_quality: 18 },
+                bluray: { video_encoder: 'x265', video_quality: 18 },
+                uhd: { video_encoder: 'x265', video_quality: 20 }
+            }
+        }
+    ];
+
+    function renderWithSaveAs(onSaveAsNew: ReturnType<typeof vi.fn>) {
+        return renderComponent(PresetEditor, {
+            props: {
+                scope: 'global' as const,
+                initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+                scheme: twoPresetScheme,
+                presets: twoPresets,
+                offline: false,
+                saving: false,
+                onSave: async () => {},
+                onSaveAsNew
+            }
+        });
+    }
+
+    async function makeDirty(container: HTMLElement) {
+        const input = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(input, { target: { value: '18' } });
+    }
+
+    it('Save as new preset button disabled until form is dirty', () => {
+        const { getByRole } = renderWithSaveAs(vi.fn());
+        const btn = getByRole('button', { name: /Save as new preset/i }) as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+    });
+
+    it('opens modal, creates preset, closes modal', async () => {
+        const onSaveAsNew = vi.fn().mockResolvedValue(undefined);
+        const { container, getByRole } = renderWithSaveAs(onSaveAsNew);
+        await makeDirty(container);
+
+        await fireEvent.click(getByRole('button', { name: /Save as new preset/i }));
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        const nameInput = container.querySelector('input[placeholder*="Weekend Rips"]') as HTMLInputElement;
+        await fireEvent.input(nameInput, { target: { value: 'My Preset' } });
+        await fireEvent.click(getByRole('button', { name: /Create preset/i }));
+
+        expect(onSaveAsNew).toHaveBeenCalledWith(expect.objectContaining({
+            name: 'My Preset',
+            parent_slug: 'software_balanced',
+            overrides: expect.objectContaining({
+                tiers: expect.objectContaining({ bluray: { video_quality: 18 } })
+            })
+        }));
+    });
+
+    it('shows error when onSaveAsNew throws', async () => {
+        const onSaveAsNew = vi.fn().mockRejectedValue(new Error('Slug already exists'));
+        const { container, getByRole } = renderWithSaveAs(onSaveAsNew);
+        await makeDirty(container);
+        await fireEvent.click(getByRole('button', { name: /Save as new preset/i }));
+        const nameInput = container.querySelector('input[placeholder*="Weekend Rips"]') as HTMLInputElement;
+        await fireEvent.input(nameInput, { target: { value: 'Dup' } });
+        await fireEvent.click(getByRole('button', { name: /Create preset/i }));
+        await screen.findByText(/Slug already exists/);
+    });
+
+    it('Cancel closes modal without calling handler', async () => {
+        const onSaveAsNew = vi.fn();
+        const { container, getByRole } = renderWithSaveAs(onSaveAsNew);
+        await makeDirty(container);
+        await fireEvent.click(getByRole('button', { name: /Save as new preset/i }));
+        await fireEvent.click(getByRole('button', { name: /Cancel/i }));
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(onSaveAsNew).not.toHaveBeenCalled();
+    });
+
+    it('Create preset button disabled until name is entered', async () => {
+        const { container, getByRole } = renderWithSaveAs(vi.fn());
+        await makeDirty(container);
+        await fireEvent.click(getByRole('button', { name: /Save as new preset/i }));
+        const createBtn = getByRole('button', { name: /Create preset/i }) as HTMLButtonElement;
+        expect(createBtn.disabled).toBe(true);
+        const nameInput = container.querySelector('input[placeholder*="Weekend Rips"]') as HTMLInputElement;
+        await fireEvent.input(nameInput, { target: { value: 'Foo' } });
+        expect(createBtn.disabled).toBe(false);
+    });
+});
+
+describe('PresetEditor undo', () => {
+    afterEach(() => cleanup());
+
+    const twoPresets: Preset[] = [
+        ...mockPresets,
+        {
+            slug: 'software_quality', name: 'High Quality', scheme: 'software',
+            description: '', builtin: true,
+            shared: { audio_encoder: 'copy', subtitle_mode: 'all' },
+            tiers: {
+                dvd: { video_encoder: 'x265', video_quality: 18 },
+                bluray: { video_encoder: 'x265', video_quality: 18 },
+                uhd: { video_encoder: 'x265', video_quality: 20 }
+            }
+        }
+    ];
+
+    it('Undo restores the previous preset and overrides', async () => {
+        const { container } = renderComponent(PresetEditor, {
+            props: {
+                scope: 'global' as const,
+                initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+                scheme: mockScheme,
+                presets: twoPresets,
+                offline: false,
+                saving: false,
+                onSave: async () => {}
+            }
+        });
+        // Make a change
+        const qInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(qInput, { target: { value: '17' } });
+        // Switch preset to trigger the undo toast
+        const select = container.querySelector('#preset-select') as HTMLSelectElement;
+        await fireEvent.change(select, { target: { value: 'software_quality' } });
+        expect(select.value).toBe('software_quality');
+        // Click Undo
+        await fireEvent.click(screen.getByRole('button', { name: /Undo/i }));
+        expect(select.value).toBe('software_balanced');
+        // Toast cleared
+        expect(screen.queryByText(/Cleared.*from/i)).toBeNull();
+    });
+});

--- a/frontend/src/lib/components/PresetEditor.test.ts
+++ b/frontend/src/lib/components/PresetEditor.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderComponent, screen, fireEvent, cleanup } from '$lib/test-utils';
 import PresetEditor from './PresetEditor.svelte';
 import type { Scheme, Preset } from '$lib/types/presets';
 
@@ -44,5 +44,54 @@ describe('PresetEditor', () => {
             }
         });
         expect(screen.getByText(/Software \(CPU\)/i)).toBeInTheDocument();
+    });
+});
+
+const customPreset: Preset = {
+    slug: 'my-custom', name: 'My Custom', scheme: 'software',
+    description: '', builtin: false, parent_slug: 'software_balanced',
+    shared: {}, tiers: { dvd: {}, bluray: {}, uhd: {} }
+};
+
+const unavailablePreset: Preset = {
+    slug: 'nvidia-imp', name: 'Nvidia Import', scheme: 'nvidia',
+    description: '', builtin: false, parent_slug: 'nvidia_balanced',
+    shared: {}, tiers: { dvd: {}, bluray: {}, uhd: {} },
+    unavailable: true, reason: 'scheme mismatch'
+};
+
+describe('PresetEditor dropdown', () => {
+    afterEach(() => cleanup());
+
+    const baseProps = {
+        scope: 'global' as const,
+        initialState: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } },
+        scheme: mockScheme,
+        offline: false,
+        saving: false,
+        onSave: async () => {}
+    };
+
+    it('renders built-in, custom, and unavailable groups', () => {
+        renderComponent(PresetEditor, {
+            props: { ...baseProps, presets: [...mockPresets, customPreset, unavailablePreset] }
+        });
+        expect(screen.getByRole('option', { name: /Balanced/ })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /My Custom/ })).toBeInTheDocument();
+        const unavail = screen.getByRole('option', { name: /Nvidia Import/ }) as HTMLOptionElement;
+        expect(unavail.disabled).toBe(true);
+    });
+
+    it('shows preset description below the dropdown', () => {
+        renderComponent(PresetEditor, { props: { ...baseProps, presets: mockPresets } });
+        expect(screen.getByText(/Balanced encoding/)).toBeInTheDocument();
+    });
+
+    it('updates selectedSlug when dropdown changes', async () => {
+        const second: Preset = { ...mockPresets[0], slug: 'software_quality', name: 'Quality' };
+        renderComponent(PresetEditor, { props: { ...baseProps, presets: [mockPresets[0], second] } });
+        const select = screen.getByRole('combobox') as HTMLSelectElement;
+        await fireEvent.change(select, { target: { value: 'software_quality' } });
+        expect(select.value).toBe('software_quality');
     });
 });

--- a/frontend/src/lib/components/TranscodeOverrides.svelte
+++ b/frontend/src/lib/components/TranscodeOverrides.svelte
@@ -20,14 +20,20 @@
     let feedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
     let loaded = $state(false);
 
-    const initialState = $derived<PresetEditorState>(
-        job.transcode_overrides && typeof job.transcode_overrides === 'object' && 'preset_slug' in (job.transcode_overrides as object)
-            ? {
-                preset_slug: ((job.transcode_overrides as Record<string, unknown>).preset_slug as string) ?? '',
-                overrides: (((job.transcode_overrides as Record<string, unknown>).overrides as Overrides) ?? { shared: {}, tiers: {} })
-              }
-            : { preset_slug: '', overrides: { shared: {}, tiers: {} } }
-    );
+    const initialState = $derived.by<PresetEditorState>(() => {
+        const o = job.transcode_overrides as Record<string, unknown> | null | undefined;
+        if (!o || typeof o !== 'object' || !('preset_slug' in o)) {
+            return { preset_slug: '', overrides: { shared: {}, tiers: {} } };
+        }
+        const raw = o.overrides as Partial<Overrides> | undefined;
+        return {
+            preset_slug: (o.preset_slug as string) ?? '',
+            overrides: {
+                shared: raw?.shared ?? {},
+                tiers: raw?.tiers ?? {}
+            }
+        };
+    });
 
     async function loadData() {
         offline = false;

--- a/frontend/src/lib/components/TranscodeOverrides.svelte
+++ b/frontend/src/lib/components/TranscodeOverrides.svelte
@@ -1,241 +1,89 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import type { Job, SettingsData, TranscoderConfig } from '$lib/types/arm';
-	import { updateJobTranscodeConfig } from '$lib/api/jobs';
-	import { fetchSettings } from '$lib/api/settings';
+    import { onMount } from 'svelte';
+    import type { Job } from '$lib/types/arm';
+    import type { Scheme, Preset, Overrides, PresetEditorState } from '$lib/types/presets';
+    import { fetchTranscoderScheme, fetchTranscoderPresets } from '$lib/api/settings';
+    import { updateJobTranscodeConfig } from '$lib/api/jobs';
+    import PresetEditor from './PresetEditor.svelte';
 
-	interface Props {
-		job: Job;
-		onsaved?: () => void;
-	}
+    interface Props {
+        job: Job;
+        onsaved?: () => void;
+    }
 
-	let { job, onsaved }: Props = $props();
+    let { job, onsaved }: Props = $props();
 
-	let loading = $state(true);
-	let saving = $state(false);
-	let feedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
-	let tcConfig = $state<TranscoderConfig | null>(null);
+    let scheme = $state<Scheme | null>(null);
+    let presets = $state<Preset[]>([]);
+    let offline = $state(false);
+    let saving = $state(false);
+    let feedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
+    let loaded = $state(false);
 
-	// Override form state
-	let videoEncoder = $state('');
-	let videoQuality = $state('');
-	let audioEncoder = $state('');
-	let subtitleMode = $state('');
-	let handbrakePreset = $state('');
-	let handbrakePreset4k = $state('');
-	let handbrakePresetDvd = $state('');
-	let handbrakePresetFile = $state('');
-	let deleteSource = $state<'' | 'true' | 'false'>('');
-	let outputExtension = $state('');
+    const initialState = $derived<PresetEditorState>(
+        job.transcode_overrides && typeof job.transcode_overrides === 'object' && 'preset_slug' in (job.transcode_overrides as object)
+            ? {
+                preset_slug: ((job.transcode_overrides as Record<string, unknown>).preset_slug as string) ?? '',
+                overrides: (((job.transcode_overrides as Record<string, unknown>).overrides as Overrides) ?? { shared: {}, tiers: {} })
+              }
+            : { preset_slug: '', overrides: { shared: {}, tiers: {} } }
+    );
 
-	function globalDefault(key: string): string {
-		if (!tcConfig?.config) return '?';
-		const val = tcConfig.config[key];
-		if (val === null || val === undefined) return '?';
-		if (typeof val === 'boolean') return val ? 'true' : 'false';
-		return String(val);
-	}
+    async function loadData() {
+        offline = false;
+        const [s, p] = await Promise.all([fetchTranscoderScheme(), fetchTranscoderPresets()]);
+        if (s === null || p === null) {
+            offline = true;
+            return;
+        }
+        scheme = s;
+        presets = p.presets;
+    }
 
-	onMount(async () => {
-		try {
-			const settings: SettingsData = await fetchSettings();
-			tcConfig = settings.transcoder_config;
-		} catch {
-			tcConfig = null;
-		} finally {
-			loading = false;
-		}
+    async function handleSave(state: PresetEditorState) {
+        saving = true;
+        feedback = null;
+        try {
+            await updateJobTranscodeConfig(job.job_id, {
+                preset_slug: state.preset_slug,
+                overrides: state.overrides
+            });
+            feedback = { type: 'success', message: 'Overrides saved' };
+            onsaved?.();
+        } catch (e) {
+            feedback = { type: 'error', message: e instanceof Error ? e.message : 'Save failed' };
+        } finally {
+            saving = false;
+        }
+    }
 
-		// Pre-fill from existing overrides
-		const o = job.transcode_overrides;
-		if (o && typeof o === 'object') {
-			videoEncoder = o.video_encoder != null ? String(o.video_encoder) : '';
-			videoQuality = o.video_quality != null ? String(o.video_quality) : '';
-			audioEncoder = o.audio_encoder != null ? String(o.audio_encoder) : '';
-			subtitleMode = o.subtitle_mode != null ? String(o.subtitle_mode) : '';
-			handbrakePreset = o.handbrake_preset != null ? String(o.handbrake_preset) : '';
-			handbrakePreset4k = o.handbrake_preset_4k != null ? String(o.handbrake_preset_4k) : '';
-			handbrakePresetDvd = o.handbrake_preset_dvd != null ? String(o.handbrake_preset_dvd) : '';
-			handbrakePresetFile = o.handbrake_preset_file != null ? String(o.handbrake_preset_file) : '';
-			deleteSource = o.delete_source != null ? (o.delete_source ? 'true' : 'false') : '';
-			outputExtension = o.output_extension != null ? String(o.output_extension) : '';
-		}
-	});
-
-	async function handleSave() {
-		saving = true;
-		feedback = null;
-		try {
-			const overrides: Record<string, unknown> = {};
-			if (videoEncoder) overrides.video_encoder = videoEncoder;
-			if (videoQuality) overrides.video_quality = Number(videoQuality);
-			if (audioEncoder) overrides.audio_encoder = audioEncoder;
-			if (subtitleMode) overrides.subtitle_mode = subtitleMode;
-			if (handbrakePreset) overrides.handbrake_preset = handbrakePreset;
-			if (handbrakePreset4k) overrides.handbrake_preset_4k = handbrakePreset4k;
-			if (handbrakePresetDvd) overrides.handbrake_preset_dvd = handbrakePresetDvd;
-			if (handbrakePresetFile) overrides.handbrake_preset_file = handbrakePresetFile;
-			if (deleteSource) overrides.delete_source = deleteSource === 'true';
-			if (outputExtension) overrides.output_extension = outputExtension;
-
-			await updateJobTranscodeConfig(job.job_id, overrides);
-			feedback = { type: 'success', message: Object.keys(overrides).length > 0 ? 'Overrides saved' : 'Overrides cleared' };
-			onsaved?.();
-		} catch (e) {
-			feedback = { type: 'error', message: e instanceof Error ? e.message : 'Save failed' };
-		} finally {
-			saving = false;
-		}
-	}
-
-	const inputClass =
-		'rounded-lg border border-primary/25 bg-primary/5 px-3 py-1.5 text-sm text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white';
-	const labelClass = 'text-sm font-medium text-gray-700 dark:text-gray-300';
-	const btnBase =
-		'rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 transition-colors';
+    onMount(async () => {
+        await loadData();
+        loaded = true;
+    });
 </script>
 
-{#if loading}
-	<p class="text-sm text-gray-400">Loading transcoder settings...</p>
-{:else if !tcConfig}
-	<p class="text-sm text-gray-500 dark:text-gray-400">Transcoder not configured. Set up the transcoder in Settings to enable per-job overrides.</p>
+{#if !loaded}
+    <p class="text-sm text-gray-400">Loading transcoder settings...</p>
 {:else}
-	<div class="space-y-4">
-		<p class="text-xs text-gray-500 dark:text-gray-400">
-			Override transcoder settings for this job only. Leave blank to use the global default.
-		</p>
-
-		<!-- Encoding -->
-		<h4 class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Encoding</h4>
-		<div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-			<label class="space-y-1">
-				<span class={labelClass}>Video Encoder</span>
-				<select bind:value={videoEncoder} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('video_encoder')})</option>
-					{#each tcConfig.valid_video_encoders ?? [] as enc}
-						<option value={enc}>{enc}</option>
-					{/each}
-				</select>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>Video Quality</span>
-				<input
-					type="number"
-					bind:value={videoQuality}
-					min="0"
-					max="51"
-					placeholder={globalDefault('video_quality')}
-					class="{inputClass} w-full"
-				/>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>Audio Encoder</span>
-				<select bind:value={audioEncoder} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('audio_encoder')})</option>
-					{#each tcConfig.valid_audio_encoders ?? [] as enc}
-						<option value={enc}>{enc}</option>
-					{/each}
-				</select>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>Subtitle Mode</span>
-				<select bind:value={subtitleMode} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('subtitle_mode')})</option>
-					{#each tcConfig.valid_subtitle_modes ?? [] as mode}
-						<option value={mode}>{mode}</option>
-					{/each}
-				</select>
-			</label>
-		</div>
-
-		<!-- Presets -->
-		<h4 class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Presets</h4>
-		<div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-			<label class="space-y-1">
-				<span class={labelClass}>HB Preset</span>
-				<select bind:value={handbrakePreset} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('handbrake_preset')})</option>
-					{#each tcConfig.valid_handbrake_presets ?? [] as p}
-						<option value={p}>{p}</option>
-					{/each}
-				</select>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>HB Preset (4K)</span>
-				<select bind:value={handbrakePreset4k} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('handbrake_preset_4k')})</option>
-					{#each tcConfig.valid_handbrake_presets ?? [] as p}
-						<option value={p}>{p}</option>
-					{/each}
-				</select>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>HB Preset (DVD)</span>
-				<select bind:value={handbrakePresetDvd} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('handbrake_preset_dvd')})</option>
-					{#each tcConfig.valid_handbrake_presets ?? [] as p}
-						<option value={p}>{p}</option>
-					{/each}
-				</select>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>Preset File</span>
-				<select bind:value={handbrakePresetFile} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('handbrake_preset_file')})</option>
-					{#each tcConfig.valid_preset_files ?? [] as f}
-						<option value={f}>{f}</option>
-					{/each}
-				</select>
-			</label>
-		</div>
-
-		<!-- Output -->
-		<h4 class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">Output</h4>
-		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
-			<label class="space-y-1">
-				<span class={labelClass}>Delete Source</span>
-				<select bind:value={deleteSource} class="{inputClass} w-full">
-					<option value="">(Global: {globalDefault('delete_source')})</option>
-					<option value="true">Yes</option>
-					<option value="false">No</option>
-				</select>
-			</label>
-
-			<label class="space-y-1">
-				<span class={labelClass}>Output Extension</span>
-				<input
-					type="text"
-					bind:value={outputExtension}
-					placeholder={globalDefault('output_extension')}
-					class="{inputClass} w-full"
-				/>
-			</label>
-		</div>
-
-		<!-- Save -->
-		<div class="flex items-center gap-2">
-			<button
-				onclick={handleSave}
-				disabled={saving}
-				class="{btnBase} bg-green-600 text-white hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600"
-			>
-				{saving ? 'Saving...' : 'Save Overrides'}
-			</button>
-			{#if feedback}
-				<span
-					class="text-xs {feedback.type === 'success'
-						? 'text-green-600 dark:text-green-400'
-						: 'text-red-600 dark:text-red-400'}"
-				>
-					{feedback.message}
-				</span>
-			{/if}
-		</div>
-	</div>
+    <div class="space-y-3">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+            Override transcoder settings for this job only. Changes apply to this job's transcode.
+        </p>
+        <PresetEditor
+            scope="job"
+            initialState={initialState}
+            scheme={scheme}
+            presets={presets}
+            offline={offline}
+            saving={saving}
+            onSave={handleSave}
+            onRetry={loadData}
+        />
+        {#if feedback}
+            <span class="text-xs {feedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
+                {feedback.message}
+            </span>
+        {/if}
+    </div>
 {/if}

--- a/frontend/src/lib/components/TranscodeOverrides.test.ts
+++ b/frontend/src/lib/components/TranscodeOverrides.test.ts
@@ -1,69 +1,56 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { renderComponent, screen, cleanup, waitFor } from '$lib/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderComponent, screen, waitFor, cleanup } from '$lib/test-utils';
+import { fireEvent } from '@testing-library/svelte';
 import TranscodeOverrides from './TranscodeOverrides.svelte';
-import { createJob } from './__fixtures__/job';
-
-vi.mock('$lib/api/jobs', () => ({
-	updateJobTranscodeConfig: vi.fn(() => Promise.resolve())
-}));
+import type { Job } from '$lib/types/arm';
 
 vi.mock('$lib/api/settings', () => ({
-	fetchSettings: vi.fn(() => Promise.resolve({
-		transcoder_config: {
-			config: {
-				video_encoder: 'x265',
-				video_quality: 20,
-				audio_encoder: 'aac',
-				subtitle_mode: 'none',
-				handbrake_preset: 'HQ 1080p30 Surround',
-				handbrake_preset_4k: null,
-				handbrake_preset_dvd: null,
-				handbrake_preset_file: null,
-				delete_source: false,
-				output_extension: 'mkv'
-			}
-		}
-	}))
+    fetchTranscoderScheme: vi.fn().mockResolvedValue({
+        slug: 'software', name: 'Software (CPU)',
+        supported_encoders: [{ slug: 'x265', name: 'x265', tuning_presets: [] }],
+        supported_audio_encoders: ['copy', 'aac'],
+        supported_subtitle_modes: ['all'],
+        advanced_fields: {}
+    }),
+    fetchTranscoderPresets: vi.fn().mockResolvedValue({
+        presets: [{
+            slug: 'software_balanced', name: 'Balanced', scheme: 'software',
+            description: '', builtin: true,
+            shared: {}, tiers: { dvd: {}, bluray: {}, uhd: {} }
+        }]
+    })
 }));
 
+const updateMock = vi.fn().mockResolvedValue({ success: true });
+vi.mock('$lib/api/jobs', () => ({
+    updateJobTranscodeConfig: (...args: unknown[]) => updateMock(...args)
+}));
+
+const baseJob = {
+    job_id: 1,
+    transcode_overrides: { preset_slug: 'software_balanced', overrides: { shared: {}, tiers: {} } }
+} as unknown as Job;
+
+beforeEach(() => updateMock.mockClear());
+afterEach(() => cleanup());
+
 describe('TranscodeOverrides', () => {
-	afterEach(() => cleanup());
+    it('renders PresetEditor and submits new-shape overrides on save', async () => {
+        const { container } = renderComponent(TranscodeOverrides, { props: { job: baseJob } });
+        await waitFor(() => screen.getByText(/Software \(CPU\)/));
+        const qualityInput = container.querySelector('input[data-testid="tier-bluray-quality"]') as HTMLInputElement;
+        await fireEvent.input(qualityInput, { target: { value: '18' } });
+        await fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+        await waitFor(() => expect(updateMock).toHaveBeenCalled());
+        expect(updateMock).toHaveBeenCalledWith(1, expect.objectContaining({
+            preset_slug: 'software_balanced',
+            overrides: expect.objectContaining({ tiers: expect.objectContaining({ bluray: { video_quality: 18 } }) })
+        }));
+    });
 
-	describe('rendering', () => {
-		it('shows loading state initially', () => {
-			renderComponent(TranscodeOverrides, {
-				props: { job: createJob() }
-			});
-			expect(screen.getByText('Loading transcoder settings...')).toBeInTheDocument();
-		});
-
-		it('renders form fields after settings load', async () => {
-			renderComponent(TranscodeOverrides, {
-				props: { job: createJob() }
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Video Encoder')).toBeInTheDocument();
-				expect(screen.getByText('Video Quality')).toBeInTheDocument();
-				expect(screen.getByText('Audio Encoder')).toBeInTheDocument();
-			});
-		});
-
-		it('shows save button', async () => {
-			renderComponent(TranscodeOverrides, {
-				props: { job: createJob() }
-			});
-			await waitFor(() => {
-				expect(screen.getByText('Save Overrides')).toBeInTheDocument();
-			});
-		});
-
-		it('shows global defaults', async () => {
-			renderComponent(TranscodeOverrides, {
-				props: { job: createJob() }
-			});
-			await waitFor(() => {
-				expect(screen.getByText(/x265/)).toBeInTheDocument();
-			});
-		});
-	});
+    it('does not show "Save as new preset" (scope=job)', async () => {
+        renderComponent(TranscodeOverrides, { props: { job: baseJob } });
+        await waitFor(() => screen.getByText(/Software \(CPU\)/));
+        expect(screen.queryByText(/Save as new preset/i)).toBeNull();
+    });
 });

--- a/frontend/src/lib/components/TranscodeOverrides.test.ts
+++ b/frontend/src/lib/components/TranscodeOverrides.test.ts
@@ -53,4 +53,29 @@ describe('TranscodeOverrides', () => {
         await waitFor(() => screen.getByText(/Software \(CPU\)/));
         expect(screen.queryByText(/Save as new preset/i)).toBeNull();
     });
+
+    it('defaults to empty preset state when job has no transcode_overrides', async () => {
+        const jobWithoutOverrides = { job_id: 2, transcode_overrides: null } as unknown as Job;
+        renderComponent(TranscodeOverrides, { props: { job: jobWithoutOverrides } });
+        // Scheme name renders from the active scheme (line 26 branch: empty initial state)
+        await waitFor(() => screen.getByText(/Software \(CPU\)/));
+    });
+
+    it('defaults to empty preset state when legacy flat overrides lack preset_slug', async () => {
+        const legacyJob = {
+            job_id: 3,
+            transcode_overrides: { video_encoder: 'x265', video_quality: 22 },
+        } as unknown as Job;
+        renderComponent(TranscodeOverrides, { props: { job: legacyJob } });
+        await waitFor(() => screen.getByText(/Software \(CPU\)/));
+    });
+
+    it('shows offline state when transcoder is unreachable', async () => {
+        const settingsApi = await import('$lib/api/settings');
+        vi.mocked(settingsApi.fetchTranscoderScheme).mockResolvedValueOnce(null);
+        vi.mocked(settingsApi.fetchTranscoderPresets).mockResolvedValueOnce(null);
+        renderComponent(TranscodeOverrides, { props: { job: baseJob } });
+        // offline=true triggers the offline UI instead of the preset editor (line 42 branch)
+        await waitFor(() => expect(screen.queryByText(/Software \(CPU\)/)).toBeNull());
+    });
 });

--- a/frontend/src/lib/types/presets.ts
+++ b/frontend/src/lib/types/presets.ts
@@ -1,0 +1,46 @@
+export interface Encoder {
+    slug: string;
+    name: string;
+    tuning_presets: string[];
+}
+
+export interface AdvancedField {
+    type: 'enum' | 'int' | 'string';
+    values?: string[];
+    default?: string;
+    description?: string;
+    min?: number;
+    max?: number;
+}
+
+export interface Scheme {
+    slug: string;
+    name: string;
+    supported_encoders: Encoder[];
+    supported_audio_encoders: string[];
+    supported_subtitle_modes: string[];
+    advanced_fields: Record<string, AdvancedField>;
+}
+
+export interface Preset {
+    slug: string;
+    name: string;
+    scheme: string;
+    description: string;
+    builtin: boolean;
+    shared: Record<string, unknown>;
+    tiers: Record<'dvd' | 'bluray' | 'uhd', Record<string, unknown>>;
+    parent_slug?: string;
+    unavailable?: boolean;
+    reason?: string;
+}
+
+export interface Overrides {
+    shared: Record<string, unknown>;
+    tiers: Record<string, Record<string, unknown>>;
+}
+
+export interface PresetEditorState {
+    preset_slug: string;
+    overrides: Overrides;
+}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -43,9 +43,16 @@
 	let presetOffline = $state(false);
 	let presetSaving = $state(false);
 
-	const presetInitialState = $derived<PresetEditorState>({
-		preset_slug: ((settings?.transcoder_config?.config as Record<string, unknown> | undefined)?.selected_preset_slug as string) ?? '',
-		overrides: (((settings?.transcoder_config?.config as Record<string, unknown> | undefined)?.global_overrides as Overrides) ?? { shared: {}, tiers: {} })
+	const presetInitialState = $derived.by<PresetEditorState>(() => {
+		const cfg = settings?.transcoder_config?.config as Record<string, unknown> | undefined;
+		const raw = cfg?.global_overrides as Partial<Overrides> | undefined;
+		return {
+			preset_slug: (cfg?.selected_preset_slug as string) ?? '',
+			overrides: {
+				shared: raw?.shared ?? {},
+				tiers: raw?.tiers ?? {}
+			}
+		};
 	});
 
 	async function loadPresetData() {
@@ -633,6 +640,9 @@
 		'audio_subdir',
 		'output_extension',
 		'delete_source',
+		// Preset-managed keys (rendered in the PresetEditor section, not as raw fields)
+		'global_overrides',
+		'selected_preset_slug',
 	]);
 
 	// Transcoder number fields: key → [min, max, step?]

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -16,6 +16,9 @@
 	import { fetchImageCacheStats, clearImageCache, type ImageCacheStats } from '$lib/api/maintenance';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import SystemHealth from '$lib/components/settings/SystemHealth.svelte';
+	import PresetEditor from '$lib/components/PresetEditor.svelte';
+	import { fetchTranscoderScheme, fetchTranscoderPresets, createCustomPreset } from '$lib/api/settings';
+	import type { Scheme, Preset, Overrides, PresetEditorState } from '$lib/types/presets';
 
 	let settings = $state<SettingsData | null>(null);
 	let error = $state<string | null>(null);
@@ -33,6 +36,56 @@
 	let armFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 	let armRevealedKeys = $state<Set<string>>(new Set());
 	let armCollapsed = $state<Record<string, boolean>>({});
+
+	// --- Preset editor state ---
+	let presetScheme = $state<Scheme | null>(null);
+	let presets = $state<Preset[]>([]);
+	let presetOffline = $state(false);
+	let presetSaving = $state(false);
+
+	const presetInitialState = $derived<PresetEditorState>({
+		preset_slug: ((settings?.transcoder_config?.config as Record<string, unknown> | undefined)?.selected_preset_slug as string) ?? '',
+		overrides: (((settings?.transcoder_config?.config as Record<string, unknown> | undefined)?.global_overrides as Overrides) ?? { shared: {}, tiers: {} })
+	});
+
+	async function loadPresetData() {
+		presetOffline = false;
+		const [s, p] = await Promise.all([fetchTranscoderScheme(), fetchTranscoderPresets()]);
+		if (s === null || p === null) {
+			presetOffline = true;
+			return;
+		}
+		presetScheme = s;
+		presets = p.presets;
+	}
+
+	async function handlePresetSave(state: PresetEditorState) {
+		presetSaving = true;
+		try {
+			await saveTranscoderConfig({
+				selected_preset_slug: state.preset_slug,
+				global_overrides: state.overrides
+			});
+			await loadSettings();
+		} finally {
+			presetSaving = false;
+		}
+	}
+
+	async function handlePresetSaveAsNew(body: { name: string; parent_slug: string; overrides: Overrides }) {
+		presetSaving = true;
+		try {
+			const newPreset = await createCustomPreset(body);
+			await loadPresetData();
+			await saveTranscoderConfig({
+				selected_preset_slug: newPreset.slug,
+				global_overrides: { shared: {}, tiers: {} }
+			});
+			await loadSettings();
+		} finally {
+			presetSaving = false;
+		}
+	}
 
 	// --- Restart state ---
 	let armRestarting = $state(false);
@@ -413,6 +466,7 @@
 				pendingPanel = null;
 			}
 		});
+		loadPresetData();
 		// Handle initial hash tab (trigger side effects)
 		if (activeTab === 'music') loadAbcdeConfig();
 		if (activeTab === 'system') loadSystemInfo();
@@ -555,14 +609,6 @@
 
 	// --- Transcoder field labels ---
 	const TC_LABELS: Record<string, string> = {
-		video_encoder: 'Video Encoder',
-		video_quality: 'Video Quality (CRF)',
-		audio_encoder: 'Audio Encoder',
-		subtitle_mode: 'Subtitle Mode',
-		handbrake_preset: 'HandBrake Preset (Default)',
-		handbrake_preset_4k: 'HandBrake Preset (4K)',
-		handbrake_preset_dvd: 'HandBrake Preset (DVD)',
-		handbrake_preset_file: 'Custom Preset File',
 		delete_source: 'Delete Source After Transcode',
 		output_extension: 'Output Extension',
 		movies_subdir: 'Movies Subdirectory',
@@ -579,15 +625,8 @@
 	// Transcoder boolean fields rendered as toggle switches
 	const TC_BOOL_KEYS = new Set(['delete_source']);
 
-	// Preset keys rendered in their own 3-column row
-	const TC_PRESET_KEYS = ['handbrake_preset', 'handbrake_preset_4k', 'handbrake_preset_dvd'];
+	// Keys rendered in their own sub-panels (excluded from the Operational loop)
 	const TC_PRESET_SET = new Set([
-		...TC_PRESET_KEYS,
-		'handbrake_preset_file',
-		'video_encoder',
-		// Audio panel keys
-		'audio_encoder',
-		'subtitle_mode',
 		// Directory panel keys
 		'movies_subdir',
 		'tv_subdir',
@@ -596,23 +635,8 @@
 		'delete_source',
 	]);
 
-	// Video encoder options — canonical encoders only (no aliases), with labels
-	const VIDEO_ENCODER_OPTIONS: { value: string; label: string }[] = [
-		{ value: 'nvenc_h265', label: 'NVENC H.265 (Nvidia)' },
-		{ value: 'nvenc_h264', label: 'NVENC H.264 (Nvidia)' },
-		{ value: 'qsv_h265', label: 'QSV H.265 (Intel)' },
-		{ value: 'qsv_h264', label: 'QSV H.264 (Intel)' },
-		{ value: 'vaapi_h265', label: 'VAAPI H.265 (AMD/Intel)' },
-		{ value: 'vaapi_h264', label: 'VAAPI H.264 (AMD/Intel)' },
-		{ value: 'amf_h265', label: 'AMF H.265 (AMD)' },
-		{ value: 'amf_h264', label: 'AMF H.264 (AMD)' },
-		{ value: 'x265', label: 'Software H.265' },
-		{ value: 'x264', label: 'Software H.264' },
-	];
-
 	// Transcoder number fields: key → [min, max, step?]
 	const TC_NUMBER_FIELDS: Record<string, [number, number, number?]> = {
-		video_quality: [0, 51],
 		max_concurrent: [1, 10],
 		stabilize_seconds: [10, 600],
 		minimum_free_space_gb: [1, 500, 0.5],
@@ -621,75 +645,18 @@
 
 	// Help text for transcoder fields
 	const TC_HELP: Record<string, string> = {
-		video_encoder: 'Auto-detected from GPU at startup. NVENC (Nvidia), QSV (Intel), VCN/VAAPI (AMD), or x265 (software).',
-		handbrake_preset: 'Default preset for sources 720p–1080p. Auto-detected from GPU at startup.',
-		handbrake_preset_4k: 'Used for 4K UHD sources (>1080p). Auto-detected from GPU at startup.',
-		handbrake_preset_dvd: 'Used for DVD/low-res sources (<720p). Falls back to the default preset if empty.',
-		handbrake_preset_file:
-			'Imports custom presets from a JSON file. When set, those preset names become available alongside built-in presets.',
 		log_level_libraries:
 			'Log level for third-party libraries (aiosqlite, httpcore, httpx, uvicorn). Defaults to WARNING to reduce noise.',
 	};
-
-	// Preset options: custom presets from selected file first, then built-in.
-	// Always includes custom presets from valid_handbrake_presets so current values are selectable.
-	let presetOptions = $derived.by<string[]>(() => {
-		const builtin = settings?.arm_handbrake_presets ?? [];
-		const tcCustom = settings?.transcoder_config?.valid_handbrake_presets ?? [];
-		const byFile = settings?.transcoder_config?.presets_by_file ?? {};
-		const selectedFile = tcForm.handbrake_preset_file as string;
-
-		// When a file is selected, show its presets first
-		const filePresets = selectedFile ? (byFile[selectedFile] ?? []) : [];
-		const seen = new Set<string>(filePresets);
-
-		// Then custom presets from transcoder (may overlap)
-		const extraCustom = tcCustom.filter((n: string) => !seen.has(n));
-		extraCustom.forEach((n: string) => seen.add(n));
-
-		// Then built-in presets
-		const extraBuiltin = builtin.filter((n: string) => !seen.has(n));
-
-		return [...filePresets, ...extraCustom, ...extraBuiltin];
-	});
-
-	// When the preset file changes, auto-fill preset names from it
-	function handlePresetFileChange(newFile: string) {
-		tcForm.handbrake_preset_file = newFile;
-		if (!newFile) return;
-
-		const byFile = settings?.transcoder_config?.presets_by_file ?? {};
-		const filePresets = byFile[newFile] ?? [];
-		if (filePresets.length === 0) return;
-
-		// Auto-fill: pick presets by resolution hint
-		const is4k = (n: string) => /4k|2160/i.test(n);
-		const isDvd = (n: string) => /dvd|480|576|720p/i.test(n);
-		const preset4k = filePresets.find(is4k);
-		const presetDvd = filePresets.find(isDvd);
-		const presetStd = filePresets.find((n: string) => !is4k(n) && !isDvd(n)) ?? filePresets[0];
-
-		if (presetStd) tcForm.handbrake_preset = presetStd;
-		if (preset4k) tcForm.handbrake_preset_4k = preset4k;
-		if (presetDvd) tcForm.handbrake_preset_dvd = presetDvd;
-	}
 
 	// Returns the valid options array for select-type transcoder fields, or null.
 	// Always includes the current value so the select never shows blank.
 	function tcSelectOptions(key: string): string[] | null {
 		if (!settings?.transcoder_config) return null;
 		const tc = settings.transcoder_config;
-		const presetFiles = tc.valid_preset_files;
-		const presets = presetOptions;
 		const map: Record<string, string[] | undefined> = {
-			audio_encoder: tc.valid_audio_encoders,
-			subtitle_mode: tc.valid_subtitle_modes,
 			log_level: tc.valid_log_levels,
 			log_level_libraries: tc.valid_log_levels,
-			handbrake_preset: presets.length ? ['', ...presets] : undefined,
-			handbrake_preset_4k: presets.length ? ['', ...presets] : undefined,
-			handbrake_preset_dvd: presets.length ? ['', ...presets] : undefined,
-			handbrake_preset_file: presetFiles?.length ? ['', ...presetFiles] : undefined,
 		};
 		const opts = map[key] ?? null;
 		if (!opts) return null;
@@ -1471,142 +1438,24 @@
 						class="space-y-4 rounded-lg border border-primary/20 bg-surface p-4 dark:border-primary/20 dark:bg-surface-dark"
 					>
 						<!-- Encoding sub-panel -->
-						<div class="space-y-4 rounded-md border border-primary/15 bg-page p-4 dark:border-primary/20 dark:bg-primary/5">
-							<h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Video Encoding</h3>
-
-							<!-- Video Encoder -->
-							<div class="relative {isTcFieldDirty('video_encoder') ? 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50' : ''}">
-								<div class="{isTcFieldDirty('video_encoder') ? 'px-3 py-3' : ''}">
-									<div class="mb-1 flex items-center gap-1">
-										<label for="tc-video_encoder" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-											{TC_LABELS['video_encoder'] ?? 'Video Encoder'}
-										</label>
-										{#if isTcFieldDirty('video_encoder')}
-											<span class="ml-1 h-1.5 w-1.5 rounded-full bg-primary" title="Modified"></span>
-										{/if}
-									</div>
-									<select
-										id="tc-video_encoder"
-										class={inputClass}
-										bind:value={tcForm.video_encoder}
-									>
-										{#each VIDEO_ENCODER_OPTIONS as enc}
-											<option value={enc.value}>{enc.label}</option>
-										{/each}
-									</select>
-									{#if TC_HELP['video_encoder']}
-										<p class="mt-1 text-xs text-gray-400">{TC_HELP['video_encoder']}</p>
-									{/if}
-								</div>
-							</div>
-
-							<!-- Preset dropdowns (3-column row) -->
-							<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-								{#each TC_PRESET_KEYS as key}
-									{@const selectOpts = tcSelectOptions(key)}
-									<div class="relative {isTcFieldDirty(key) ? 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50' : ''}">
-										<div class="{isTcFieldDirty(key) ? 'px-3 py-3' : ''}">
-											<div class="mb-1 flex items-center gap-1">
-												<label for="tc-{key}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-													{TC_LABELS[key] ?? key}
-												</label>
-												{#if isTcFieldDirty(key)}
-													<span class="ml-1 h-1.5 w-1.5 rounded-full bg-primary" title="Modified"></span>
-												{/if}
-											</div>
-											{#if selectOpts}
-												<select
-													id="tc-{key}"
-													class={inputClass}
-													bind:value={tcForm[key]}
-												>
-													{#each selectOpts as opt}
-														<option value={opt}>{opt || '(None)'}</option>
-													{/each}
-												</select>
-											{:else}
-												<input
-													id="tc-{key}"
-													type="text"
-													class={inputClass}
-													bind:value={tcForm[key]}
-												/>
-											{/if}
-											{#if TC_HELP[key]}
-												<p class="mt-1 text-xs text-gray-400">{TC_HELP[key]}</p>
-											{/if}
-										</div>
-									</div>
-								{/each}
-							</div>
-
-							<!-- Custom Preset File (full width, last) -->
-							{#if tcSelectOptions('handbrake_preset_file')}
-								{@const pfOpts = tcSelectOptions('handbrake_preset_file')}
-								<div class="relative {isTcFieldDirty('handbrake_preset_file') ? 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50' : ''}">
-									<div class="{isTcFieldDirty('handbrake_preset_file') ? 'px-3 py-3' : ''}">
-										<div class="mb-1 flex items-center gap-1">
-											<label for="tc-handbrake_preset_file" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-												{TC_LABELS['handbrake_preset_file']}
-											</label>
-											{#if isTcFieldDirty('handbrake_preset_file')}
-												<span class="ml-1 h-1.5 w-1.5 rounded-full bg-primary" title="Modified"></span>
-											{/if}
-										</div>
-										<select
-											id="tc-handbrake_preset_file"
-											class={inputClass}
-											value={tcForm.handbrake_preset_file ?? ''}
-											onchange={(e) => handlePresetFileChange(e.currentTarget.value)}
-										>
-											{#each pfOpts as opt}
-												<option value={opt}>{opt || '(None)'}</option>
-											{/each}
-										</select>
-										{#if TC_HELP['handbrake_preset_file']}
-											<p class="mt-1 text-xs text-gray-400">{TC_HELP['handbrake_preset_file']}</p>
-										{/if}
-									</div>
-								</div>
+						<section class="space-y-3">
+							<h3 class="text-base font-semibold text-gray-700 dark:text-gray-300">Transcoder - Encoding</h3>
+							{#if presetScheme || presetOffline}
+								<PresetEditor
+									scope="global"
+									initialState={presetInitialState}
+									scheme={presetScheme}
+									{presets}
+									offline={presetOffline}
+									saving={presetSaving}
+									onSave={handlePresetSave}
+									onSaveAsNew={handlePresetSaveAsNew}
+									onRetry={loadPresetData}
+								/>
+							{:else}
+								<p class="text-sm text-gray-400">Loading presets...</p>
 							{/if}
-
-							<!-- Audio & Subtitle streams (part of video transcode) -->
-							<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-								{#each ['audio_encoder', 'subtitle_mode'] as key}
-									{@const selectOpts = tcSelectOptions(key)}
-									<div class="relative {isTcFieldDirty(key) ? 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50' : ''}">
-										<div class="{isTcFieldDirty(key) ? 'px-3 py-3' : ''}">
-											<div class="mb-1 flex items-center gap-1">
-												<label for="tc-{key}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-													{TC_LABELS[key] ?? key}
-												</label>
-												{#if isTcFieldDirty(key)}
-													<span class="ml-1 h-1.5 w-1.5 rounded-full bg-primary" title="Modified"></span>
-												{/if}
-											</div>
-											{#if selectOpts}
-												<select
-													id="tc-{key}"
-													class={inputClass}
-													bind:value={tcForm[key]}
-												>
-													{#each selectOpts as opt}
-														<option value={opt}>{opt}</option>
-													{/each}
-												</select>
-											{:else}
-												<input
-													id="tc-{key}"
-													type="text"
-													class={inputClass}
-													bind:value={tcForm[key]}
-												/>
-											{/if}
-										</div>
-									</div>
-								{/each}
-							</div>
-						</div>
+						</section>
 
 						<!-- Directories sub-panel -->
 						<div class="space-y-4 rounded-md border border-primary/15 bg-page p-4 dark:border-primary/20 dark:bg-primary/5">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -44,7 +44,13 @@
 	let presetSaving = $state(false);
 
 	const presetInitialState = $derived.by<PresetEditorState>(() => {
-		const cfg = settings?.transcoder_config?.config as Record<string, unknown> | undefined;
+		// $state.snapshot converts the reactive proxy tree to plain data so
+		// child components never see Svelte $state proxies through props.
+		// Passing proxies triggers DOMException 'Proxy object could not be
+		// cloned' when the browser structured-clones the prop payload.
+		const cfg = $state.snapshot(settings?.transcoder_config?.config) as
+			| Record<string, unknown>
+			| undefined;
 		const raw = cfg?.global_overrides as Partial<Overrides> | undefined;
 		return {
 			preset_slug: (cfg?.selected_preset_slug as string) ?? '',

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -48,7 +48,10 @@ vi.mock('$lib/api/settings', () => ({
 		drives: [{ name: 'Drive 1', mount: '/dev/sr0', maker: 'LG', model: 'WH16NS40', capabilities: ['CD', 'DVD', 'BD'], firmware: '1.0' }]
 	})),
 	fetchAbcdeConfig: vi.fn(() => Promise.resolve({ content: 'CDROM=/dev/sr0\nOUTPUTTYPE=flac', path: '/etc/abcde.conf', exists: true })),
-	saveAbcdeConfig: vi.fn(() => Promise.resolve({ success: true }))
+	saveAbcdeConfig: vi.fn(() => Promise.resolve({ success: true })),
+	fetchTranscoderScheme: vi.fn(() => Promise.resolve(null)),
+	fetchTranscoderPresets: vi.fn(() => Promise.resolve(null)),
+	createCustomPreset: vi.fn(() => Promise.resolve({ slug: 'custom-preset', name: 'Custom', scheme: 'handbrake', parent_slug: 'default', overrides: { shared: {}, tiers: {} }, is_custom: true }))
 }));
 
 vi.mock('$lib/api/drives', () => ({

--- a/tests/routers/test_jobs_extended.py
+++ b/tests/routers/test_jobs_extended.py
@@ -131,16 +131,16 @@ async def test_update_transcode_config_success(app_client):
     with patch(
         "backend.routers.jobs.arm_client.update_transcode_overrides",
         new_callable=AsyncMock,
-        return_value={"success": True, "overrides": {"video_encoder": "x265", "video_quality": 20}},
+        return_value={"success": True, "overrides": {"preset_slug": "hq-1080p", "delete_source": True}},
     ):
         resp = await app_client.patch(
             "/api/jobs/1/transcode-config",
-            json={"video_encoder": "x265", "video_quality": "20"},
+            json={"preset_slug": "hq-1080p", "delete_source": "true"},
         )
     assert resp.status_code == 200
     data = resp.json()
     assert data["success"] is True
-    assert data["overrides"]["video_encoder"] == "x265"
+    assert data["overrides"]["preset_slug"] == "hq-1080p"
 
 
 async def test_update_transcode_config_invalid_keys(app_client):
@@ -162,7 +162,7 @@ async def test_update_transcode_config_not_found(app_client):
         return_value={"success": False, "error": "Job not found"},
     ):
         resp = await app_client.patch(
-            "/api/jobs/999/transcode-config", json={"video_encoder": "x265"}
+            "/api/jobs/999/transcode-config", json={"preset_slug": "hq-1080p"}
         )
     assert resp.status_code == 404
 

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -444,6 +444,22 @@ async def test_update_preset_proxy_forwards_404(app_client):
     assert resp.json()["detail"] == "Cannot update built-in"
 
 
+async def test_update_preset_proxy_handles_non_json_error_body(app_client):
+    """When transcoder error body isn't JSON, fall back to generic detail."""
+    err_resp = httpx.Response(500, content=b"<html>Internal Error</html>")
+    err = httpx.HTTPStatusError("boom", request=None, response=err_resp)
+    with patch(
+        "backend.routers.settings.transcoder_client.update_preset",
+        new_callable=AsyncMock,
+        side_effect=err,
+    ):
+        resp = await app_client.patch(
+            "/api/settings/transcoder/presets/x", json={}
+        )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Preset operation failed"
+
+
 # --- DELETE /api/settings/transcoder/presets/{slug} ---
 
 

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -479,3 +479,30 @@ async def test_delete_preset_proxy_forwards_404(app_client):
         resp = await app_client.delete("/api/settings/transcoder/presets/x")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Preset not found"
+
+
+# --- slug validation at router boundary (SSRF defense-in-depth) ---
+
+
+async def test_update_preset_proxy_returns_400_on_invalid_slug(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.update_preset",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Invalid preset slug: 'bad'"),
+    ):
+        resp = await app_client.patch(
+            "/api/settings/transcoder/presets/bad", json={}
+        )
+    assert resp.status_code == 400
+    assert "Invalid preset slug" in resp.json()["detail"]
+
+
+async def test_delete_preset_proxy_returns_400_on_invalid_slug(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.delete_preset",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Invalid preset slug: 'bad'"),
+    ):
+        resp = await app_client.delete("/api/settings/transcoder/presets/bad")
+    assert resp.status_code == 400
+    assert "Invalid preset slug" in resp.json()["detail"]

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -287,6 +287,58 @@ async def test_test_metadata_key_connect_error(app_client):
     assert "unreachable" in data["message"].lower()
 
 
+# --- GET /api/settings/transcoder/scheme ---
+
+
+async def test_get_transcoder_scheme_success(app_client):
+    data = {"slug": "default", "name": "Default Scheme", "presets": []}
+    with patch(
+        "backend.routers.settings.transcoder_client.get_scheme",
+        new_callable=AsyncMock,
+        return_value=data,
+    ):
+        resp = await app_client.get("/api/settings/transcoder/scheme")
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "default"
+
+
+async def test_get_transcoder_scheme_unreachable(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.get_scheme",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await app_client.get("/api/settings/transcoder/scheme")
+    assert resp.status_code == 502
+    assert "unreachable" in resp.json()["detail"].lower()
+
+
+# --- GET /api/settings/transcoder/presets ---
+
+
+async def test_get_transcoder_presets_success(app_client):
+    data = {"presets": [{"slug": "hq-1080p", "name": "HQ 1080p"}]}
+    with patch(
+        "backend.routers.settings.transcoder_client.get_presets",
+        new_callable=AsyncMock,
+        return_value=data,
+    ):
+        resp = await app_client.get("/api/settings/transcoder/presets")
+    assert resp.status_code == 200
+    assert resp.json()["presets"][0]["slug"] == "hq-1080p"
+
+
+async def test_get_transcoder_presets_unreachable(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.get_presets",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await app_client.get("/api/settings/transcoder/presets")
+    assert resp.status_code == 502
+    assert "unreachable" in resp.json()["detail"].lower()
+
+
 # --- PUT /api/settings/abcde failure ---
 
 

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -441,6 +441,7 @@ async def test_update_preset_proxy_forwards_404(app_client):
             "/api/settings/transcoder/presets/x", json={}
         )
     assert resp.status_code == 404
+    assert resp.json()["detail"] == "Cannot update built-in"
 
 
 # --- DELETE /api/settings/transcoder/presets/{slug} ---
@@ -465,3 +466,16 @@ async def test_delete_preset_proxy_offline(app_client):
     ):
         resp = await app_client.delete("/api/settings/transcoder/presets/x")
     assert resp.status_code == 502
+
+
+async def test_delete_preset_proxy_forwards_404(app_client):
+    err_resp = httpx.Response(404, json={"detail": "Preset not found"})
+    err = httpx.HTTPStatusError("not found", request=None, response=err_resp)
+    with patch(
+        "backend.routers.settings.transcoder_client.delete_preset",
+        new_callable=AsyncMock,
+        side_effect=err,
+    ):
+        resp = await app_client.delete("/api/settings/transcoder/presets/x")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Preset not found"

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -353,3 +353,115 @@ async def test_put_abcde_config_failure(app_client):
         )
     assert resp.status_code == 400
     assert "Parse error" in resp.json()["detail"]
+
+
+# --- POST /api/settings/transcoder/presets ---
+
+
+async def test_create_preset_proxy_success(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.create_preset",
+        new_callable=AsyncMock,
+        return_value={"slug": "x", "name": "X"},
+    ):
+        resp = await app_client.post(
+            "/api/settings/transcoder/presets",
+            json={"name": "X", "parent_slug": "y", "overrides": {}},
+        )
+    assert resp.status_code == 201
+    assert resp.json() == {"slug": "x", "name": "X"}
+
+
+async def test_create_preset_proxy_offline(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.create_preset",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await app_client.post(
+            "/api/settings/transcoder/presets",
+            json={"name": "X", "parent_slug": "y"},
+        )
+    assert resp.status_code == 502
+
+
+async def test_create_preset_proxy_forwards_4xx_detail(app_client):
+    err_resp = httpx.Response(409, json={"detail": "Slug exists"})
+    err = httpx.HTTPStatusError("conflict", request=None, response=err_resp)
+    with patch(
+        "backend.routers.settings.transcoder_client.create_preset",
+        new_callable=AsyncMock,
+        side_effect=err,
+    ):
+        resp = await app_client.post(
+            "/api/settings/transcoder/presets",
+            json={"name": "X", "parent_slug": "y"},
+        )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Slug exists"
+
+
+# --- PATCH /api/settings/transcoder/presets/{slug} ---
+
+
+async def test_update_preset_proxy_success(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.update_preset",
+        new_callable=AsyncMock,
+        return_value={"slug": "x", "name": "Y"},
+    ):
+        resp = await app_client.patch(
+            "/api/settings/transcoder/presets/x", json={"name": "Y"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Y"
+
+
+async def test_update_preset_proxy_offline(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.update_preset",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await app_client.patch(
+            "/api/settings/transcoder/presets/x", json={}
+        )
+    assert resp.status_code == 502
+
+
+async def test_update_preset_proxy_forwards_404(app_client):
+    err_resp = httpx.Response(404, json={"detail": "Cannot update built-in"})
+    err = httpx.HTTPStatusError("not found", request=None, response=err_resp)
+    with patch(
+        "backend.routers.settings.transcoder_client.update_preset",
+        new_callable=AsyncMock,
+        side_effect=err,
+    ):
+        resp = await app_client.patch(
+            "/api/settings/transcoder/presets/x", json={}
+        )
+    assert resp.status_code == 404
+
+
+# --- DELETE /api/settings/transcoder/presets/{slug} ---
+
+
+async def test_delete_preset_proxy_success(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.delete_preset",
+        new_callable=AsyncMock,
+        return_value={"success": True, "deleted": "x"},
+    ):
+        resp = await app_client.delete("/api/settings/transcoder/presets/x")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == "x"
+
+
+async def test_delete_preset_proxy_offline(app_client):
+    with patch(
+        "backend.routers.settings.transcoder_client.delete_preset",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await app_client.delete("/api/settings/transcoder/presets/x")
+    assert resp.status_code == 502

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -244,6 +244,23 @@ async def test_update_transcoder_config_failure(app_client):
     assert "Invalid encoder" in resp.json()["detail"]
 
 
+async def test_update_transcoder_config_forwards_422(app_client):
+    """422 validation errors from transcoder should surface (not swallowed as 502)."""
+    err_resp = httpx.Response(422, json={"detail": "global_overrides must be a string"})
+    err = httpx.HTTPStatusError("unprocessable", request=None, response=err_resp)
+    with patch(
+        "backend.routers.settings.transcoder_client.update_config",
+        new_callable=AsyncMock,
+        side_effect=err,
+    ):
+        resp = await app_client.patch(
+            "/api/settings/transcoder",
+            json={"global_overrides": {"shared": {}, "tiers": {}}},
+        )
+    assert resp.status_code == 422
+    assert "global_overrides" in resp.json()["detail"]
+
+
 # --- GET /api/settings/test-metadata ---
 
 

--- a/tests/services/test_arm_db_extended.py
+++ b/tests/services/test_arm_db_extended.py
@@ -13,10 +13,6 @@ from tests.factories import make_job, make_track
 # --- _coerce_override ---
 
 
-def test_coerce_override_video_quality():
-    assert arm_db._coerce_override("video_quality", "22") == ("video_quality", 22)
-
-
 def test_coerce_override_delete_source_bool():
     assert arm_db._coerce_override("delete_source", True) == ("delete_source", True)
 
@@ -31,16 +27,29 @@ def test_coerce_override_delete_source_int():
     assert arm_db._coerce_override("delete_source", 0) == ("delete_source", False)
 
 
+def test_coerce_override_preset_slug():
+    assert arm_db._coerce_override("preset_slug", "hq-1080p") == ("preset_slug", "hq-1080p")
+
+
+def test_coerce_override_overrides_dict():
+    payload = {"video_encoder": "x265", "video_quality": 20}
+    assert arm_db._coerce_override("overrides", payload) == ("overrides", payload)
+
+
+def test_coerce_override_overrides_non_dict_skipped():
+    assert arm_db._coerce_override("overrides", "not-a-dict") is None
+
+
 def test_coerce_override_string_field():
-    assert arm_db._coerce_override("video_encoder", "x265") == ("video_encoder", "x265")
+    assert arm_db._coerce_override("output_extension", "mkv") == ("output_extension", "mkv")
 
 
 def test_coerce_override_none_skipped():
-    assert arm_db._coerce_override("video_encoder", None) is None
+    assert arm_db._coerce_override("preset_slug", None) is None
 
 
 def test_coerce_override_empty_string_skipped():
-    assert arm_db._coerce_override("video_encoder", "") is None
+    assert arm_db._coerce_override("preset_slug", "") is None
 
 
 # --- get_job_retranscode_info ---
@@ -96,7 +105,7 @@ def test_retranscode_info_music_disc_returns_none():
 def test_retranscode_info_with_overrides():
     job = make_job(
         job_id=1, disctype="bluray",
-        transcode_overrides='{"video_encoder": "x265", "video_quality": 20}',
+        transcode_overrides='{"preset_slug": "hq-1080p", "delete_source": true}',
         multi_title=False,
     )
     job.tracks = []
@@ -109,7 +118,7 @@ def test_retranscode_info_with_overrides():
         result = arm_db.get_job_retranscode_info(1)
 
     assert result is not None
-    assert result["config_overrides"]["video_encoder"] == "x265"
+    assert result["config_overrides"]["preset_slug"] == "hq-1080p"
 
 
 def test_retranscode_info_multi_title_with_tracks():
@@ -153,12 +162,28 @@ def test_update_transcode_overrides_success():
         ctx.scalars.return_value.unique.return_value.first.return_value = mock_job
         mock_session.return_value = ctx
         result = arm_db.update_job_transcode_overrides(
-            1, {"video_encoder": "x265", "video_quality": "20"}
+            1, {"preset_slug": "hq-1080p", "delete_source": "true"}
         )
 
     assert result is not None
-    assert result["video_encoder"] == "x265"
-    assert result["video_quality"] == 20
+    assert result["preset_slug"] == "hq-1080p"
+    assert result["delete_source"] is True
+
+
+def test_update_transcode_overrides_with_overrides_dict():
+    mock_job = MagicMock()
+    with patch.object(arm_db, "get_rw_session") as mock_session:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        ctx.scalars.return_value.unique.return_value.first.return_value = mock_job
+        mock_session.return_value = ctx
+        result = arm_db.update_job_transcode_overrides(
+            1, {"overrides": {"video_encoder": "x265", "video_quality": 20}}
+        )
+
+    assert result is not None
+    assert result["overrides"] == {"video_encoder": "x265", "video_quality": 20}
 
 
 def test_update_transcode_overrides_not_found():
@@ -169,7 +194,7 @@ def test_update_transcode_overrides_not_found():
         ctx.scalars.return_value.unique.return_value.first.return_value = None
         mock_session.return_value = ctx
         result = arm_db.update_job_transcode_overrides(
-            999, {"video_encoder": "x265"}
+            999, {"preset_slug": "hq-1080p"}
         )
 
     assert result is None

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -628,37 +628,28 @@ async def test_restart_transcoder_unreachable():
 # --- create_preset ---
 
 
-@pytest.mark.asyncio
 async def test_create_preset_returns_response_on_success():
-    mock_resp = AsyncMock()
-    mock_resp.raise_for_status = MagicMock(return_value=None)
-    mock_resp.json = lambda: {"slug": "my-preset", "name": "My Preset"}
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.return_value = _mock_response({"slug": "my-preset", "name": "My Preset"})
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.create_preset({"name": "My Preset", "parent_slug": "x"})
     assert result == {"slug": "my-preset", "name": "My Preset"}
+    mock_client.post.assert_awaited_once_with(
+        "/api/v1/presets", json={"name": "My Preset", "parent_slug": "x"}
+    )
 
 
-@pytest.mark.asyncio
 async def test_create_preset_returns_none_on_offline():
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.side_effect = httpx.ConnectError("connection refused")
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.create_preset({"name": "x", "parent_slug": "y"})
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_create_preset_raises_on_4xx():
-    mock_resp = AsyncMock()
-    mock_resp.status_code = 409
-    mock_resp.json = lambda: {"detail": "Slug exists"}
-    mock_resp.raise_for_status = MagicMock(
-        side_effect=httpx.HTTPStatusError("conflict", request=MagicMock(), response=MagicMock())
-    )
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.return_value = _mock_response({"detail": "Slug exists"}, status_code=409)
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         with pytest.raises(httpx.HTTPStatusError):
             await transcoder_client.create_preset({"name": "x", "parent_slug": "y"})
@@ -667,46 +658,56 @@ async def test_create_preset_raises_on_4xx():
 # --- update_preset ---
 
 
-@pytest.mark.asyncio
 async def test_update_preset_returns_response_on_success():
-    mock_resp = AsyncMock()
-    mock_resp.raise_for_status = MagicMock(return_value=None)
-    mock_resp.json = lambda: {"slug": "my-preset", "name": "Updated"}
-    mock_client = AsyncMock()
-    mock_client.patch = AsyncMock(return_value=mock_resp)
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.patch.return_value = _mock_response({"slug": "my-preset", "name": "Updated"})
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.update_preset("my-preset", {"name": "Updated"})
     assert result == {"slug": "my-preset", "name": "Updated"}
+    mock_client.patch.assert_awaited_once_with(
+        "/api/v1/presets/my-preset", json={"name": "Updated"}
+    )
 
 
-@pytest.mark.asyncio
 async def test_update_preset_returns_none_on_offline():
-    mock_client = AsyncMock()
-    mock_client.patch = AsyncMock(side_effect=httpx.ConnectError("nope"))
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.patch.side_effect = httpx.ConnectError("nope")
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.update_preset("x", {})
     assert result is None
 
 
+async def test_update_preset_raises_on_4xx():
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.patch.return_value = _mock_response({"detail": "Preset not found"}, status_code=404)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        with pytest.raises(httpx.HTTPStatusError):
+            await transcoder_client.update_preset("missing-slug", {"name": "x"})
+
+
 # --- delete_preset ---
 
 
-@pytest.mark.asyncio
 async def test_delete_preset_returns_response_on_success():
-    mock_resp = AsyncMock()
-    mock_resp.raise_for_status = MagicMock(return_value=None)
-    mock_resp.json = lambda: {"success": True, "deleted": "my-preset"}
-    mock_client = AsyncMock()
-    mock_client.delete = AsyncMock(return_value=mock_resp)
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.delete.return_value = _mock_response({"success": True, "deleted": "my-preset"})
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.delete_preset("my-preset")
     assert result == {"success": True, "deleted": "my-preset"}
+    mock_client.delete.assert_awaited_once_with("/api/v1/presets/my-preset")
 
 
-@pytest.mark.asyncio
 async def test_delete_preset_returns_none_on_offline():
-    mock_client = AsyncMock()
-    mock_client.delete = AsyncMock(side_effect=httpx.ConnectError("nope"))
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.delete.side_effect = httpx.ConnectError("nope")
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.delete_preset("x")
     assert result is None
+
+
+async def test_delete_preset_raises_on_4xx():
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.delete.return_value = _mock_response({"detail": "Preset not found"}, status_code=404)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        with pytest.raises(httpx.HTTPStatusError):
+            await transcoder_client.delete_preset("missing-slug")

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -266,6 +266,19 @@ async def test_update_config_offline():
     assert result is None
 
 
+async def test_update_config_raises_on_4xx():
+    """4xx/5xx responses should raise HTTPStatusError (not swallowed to None)."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.patch.return_value = _mock_response(
+        {"detail": "global_overrides must be a string"}, status_code=422
+    )
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        with pytest.raises(httpx.HTTPStatusError):
+            await transcoder_client.update_config(
+                {"global_overrides": {"shared": {}, "tiers": {}}}
+            )
+
+
 # --- get_jobs ---
 
 

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -182,6 +182,48 @@ async def test_get_system_stats_offline():
     assert result is None
 
 
+# --- get_scheme ---
+
+
+async def test_get_scheme_success():
+    data = {"slug": "default", "name": "Default Scheme", "presets": []}
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = _mock_response(data)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.get_scheme()
+    assert result == data
+    mock_client.get.assert_awaited_once_with("/api/v1/scheme")
+
+
+async def test_get_scheme_offline():
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.side_effect = httpx.ConnectError("refused")
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.get_scheme()
+    assert result is None
+
+
+# --- get_presets ---
+
+
+async def test_get_presets_success():
+    data = {"presets": [{"slug": "hq-1080p", "name": "HQ 1080p"}]}
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = _mock_response(data)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.get_presets()
+    assert result == data
+    mock_client.get.assert_awaited_once_with("/api/v1/presets")
+
+
+async def test_get_presets_offline():
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.side_effect = httpx.ConnectError("refused")
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.get_presets()
+    assert result is None
+
+
 # --- get_config ---
 
 

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -711,3 +711,61 @@ async def test_delete_preset_raises_on_4xx():
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         with pytest.raises(httpx.HTTPStatusError):
             await transcoder_client.delete_preset("missing-slug")
+
+
+# --- slug validation (SSRF protection) ---
+
+
+@pytest.mark.parametrize("bad_slug", [
+    "../admin",
+    "preset/../other",
+    "preset?query=1",
+    "preset with spaces",
+    "Preset-Uppercase",
+    "-leading-dash",
+    "trailing-dash-",
+    "double--dash",
+    "",
+    "a" * 101,
+    "preset#fragment",
+    "preset%2e%2e",
+])
+async def test_update_preset_rejects_malicious_slug(bad_slug):
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        with pytest.raises(ValueError, match="Invalid preset slug"):
+            await transcoder_client.update_preset(bad_slug, {"name": "x"})
+    mock_client.patch.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_slug", [
+    "../admin",
+    "preset/../other",
+    "preset?query=1",
+    "Preset-Uppercase",
+    "",
+])
+async def test_delete_preset_rejects_malicious_slug(bad_slug):
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        with pytest.raises(ValueError, match="Invalid preset slug"):
+            await transcoder_client.delete_preset(bad_slug)
+    mock_client.delete.assert_not_called()
+
+
+@pytest.mark.parametrize("good_slug", [
+    "nvidia-balanced",
+    "my-anime-preset",
+    "a",
+    "preset123",
+    "slug-with-9-digits",
+])
+async def test_update_preset_accepts_valid_slug(good_slug):
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.patch.return_value = _mock_response({"slug": good_slug})
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.update_preset(good_slug, {"name": "x"})
+    assert result == {"slug": good_slug}
+    mock_client.patch.assert_awaited_once_with(
+        f"/api/v1/presets/{good_slug}", json={"name": "x"}
+    )

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -623,3 +623,90 @@ async def test_restart_transcoder_unreachable():
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.restart_transcoder()
     assert result is None
+
+
+# --- create_preset ---
+
+
+@pytest.mark.asyncio
+async def test_create_preset_returns_response_on_success():
+    mock_resp = AsyncMock()
+    mock_resp.raise_for_status = MagicMock(return_value=None)
+    mock_resp.json = lambda: {"slug": "my-preset", "name": "My Preset"}
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.create_preset({"name": "My Preset", "parent_slug": "x"})
+    assert result == {"slug": "my-preset", "name": "My Preset"}
+
+
+@pytest.mark.asyncio
+async def test_create_preset_returns_none_on_offline():
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.create_preset({"name": "x", "parent_slug": "y"})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_create_preset_raises_on_4xx():
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 409
+    mock_resp.json = lambda: {"detail": "Slug exists"}
+    mock_resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("conflict", request=MagicMock(), response=MagicMock())
+    )
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        with pytest.raises(httpx.HTTPStatusError):
+            await transcoder_client.create_preset({"name": "x", "parent_slug": "y"})
+
+
+# --- update_preset ---
+
+
+@pytest.mark.asyncio
+async def test_update_preset_returns_response_on_success():
+    mock_resp = AsyncMock()
+    mock_resp.raise_for_status = MagicMock(return_value=None)
+    mock_resp.json = lambda: {"slug": "my-preset", "name": "Updated"}
+    mock_client = AsyncMock()
+    mock_client.patch = AsyncMock(return_value=mock_resp)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.update_preset("my-preset", {"name": "Updated"})
+    assert result == {"slug": "my-preset", "name": "Updated"}
+
+
+@pytest.mark.asyncio
+async def test_update_preset_returns_none_on_offline():
+    mock_client = AsyncMock()
+    mock_client.patch = AsyncMock(side_effect=httpx.ConnectError("nope"))
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.update_preset("x", {})
+    assert result is None
+
+
+# --- delete_preset ---
+
+
+@pytest.mark.asyncio
+async def test_delete_preset_returns_response_on_success():
+    mock_resp = AsyncMock()
+    mock_resp.raise_for_status = MagicMock(return_value=None)
+    mock_resp.json = lambda: {"success": True, "deleted": "my-preset"}
+    mock_client = AsyncMock()
+    mock_client.delete = AsyncMock(return_value=mock_resp)
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.delete_preset("my-preset")
+    assert result == {"success": True, "deleted": "my-preset"}
+
+
+@pytest.mark.asyncio
+async def test_delete_preset_returns_none_on_offline():
+    mock_client = AsyncMock()
+    mock_client.delete = AsyncMock(side_effect=httpx.ConnectError("nope"))
+    with patch.object(transcoder_client, "get_client", return_value=mock_client):
+        result = await transcoder_client.delete_preset("x")
+    assert result is None


### PR DESCRIPTION
## Summary

Replaces the hardcoded transcoder encoding settings UI with a scheme-aware preset picker driven by the new transcoder API. The UI is now a pure client - it renders whatever the transcoder reports as valid for the active GPU scheme.

- Add `fetchTranscoderScheme()` and `fetchTranscoderPresets()` API functions
- Add backend proxy endpoints: `GET /api/settings/transcoder/scheme`, `GET /api/settings/transcoder/presets`
- Replace encoding section in `settings/+page.svelte` with preset picker + customize panel
- Update `TranscodeOverrides.svelte` to submit `preset_slug` + `overrides` shape
- Update backend `TRANSCODE_OVERRIDE_KEYS` and `_coerce_override()` for new shape

## Related PRs

- Depends on: uprightbass360/automatic-ripping-machine-transcoder#77 and uprightbass360/automatic-ripping-machine-neu#229

All three PRs form a coordinated release train and must merge together.

## Test plan

- [x] svelte-check passes
- [x] 121 UI backend tests pass
- [x] Settings page renders preset dropdown + customize panel (verified locally)
- [x] TranscodeOverrides component submits new shape (verified locally)
- [x] End-to-end verification against transcoder branch: GET /scheme, GET /presets, POST /presets CRUD all working