### PR TITLE
feat: SKIP_TRANSCODE UI controls and skip-and-finalize

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -383,6 +383,7 @@ class JobConfigUpdateRequest(BaseModel):
     MINLENGTH: int | None = None
     MAXLENGTH: int | None = None
     AUDIO_FORMAT: str | None = None
+    SKIP_TRANSCODE: bool | None = None
 
 
 class DriveUpdateRequest(BaseModel):

--- a/backend/routers/arm_actions.py
+++ b/backend/routers/arm_actions.py
@@ -42,6 +42,12 @@ async def fix_permissions(job_id: int) -> dict[str, Any]:
     return _check_result(await arm_client.fix_permissions(job_id))
 
 
+@router.post("/{job_id}/skip-and-finalize", responses=_502_503_ARM)
+async def skip_and_finalize(job_id: int) -> dict[str, Any]:
+    """Skip transcoding and finalize a stuck job (proxies to ARM)."""
+    return _check_result(await arm_client.skip_and_finalize(job_id))
+
+
 @router.put("/{job_id}/title", responses=_502_503_ARM)
 async def update_title(job_id: int, body: TitleUpdateRequest) -> dict[str, Any]:
     """Update a job's title metadata (proxies to ARM)."""

--- a/backend/routers/arm_actions.py
+++ b/backend/routers/arm_actions.py
@@ -21,31 +21,30 @@ def _check_result(result: dict[str, Any] | None) -> dict[str, Any]:
     return result
 
 
-@router.post("/{job_id}/abandon", responses=_502_503_ARM)
-async def abandon_job(job_id: int) -> dict[str, Any]:
-    return _check_result(await arm_client.abandon_job(job_id))
+def _proxy_post(path: str, method_name: str, *, http_method: str = "post") -> None:
+    """Register a simple ARM proxy endpoint that forwards only job_id."""
+
+    async def _endpoint(job_id: int) -> dict[str, Any]:
+        result = await getattr(arm_client, method_name)(job_id)
+        return _check_result(result)
+
+    _endpoint.__name__ = method_name
+    _endpoint.__qualname__ = method_name
+    route = f"/{{job_id}}/{path}" if path else "/{job_id}"
+    getattr(router, http_method)(route, responses=_502_503_ARM)(_endpoint)
 
 
-@router.post("/{job_id}/cancel", responses=_502_503_ARM)
-async def cancel_waiting_job(job_id: int) -> dict[str, Any]:
-    """Cancel a job in 'waiting' status (proxies to ARM)."""
-    return _check_result(await arm_client.cancel_waiting_job(job_id))
+# Simple proxies — just forward job_id to ARM
+_proxy_post("abandon", "abandon_job")
+_proxy_post("cancel", "cancel_waiting_job")
+_proxy_post("fix-permissions", "fix_permissions")
+_proxy_post("skip-and-finalize", "skip_and_finalize")
+_proxy_post("start", "start_waiting_job")
+_proxy_post("crc-submit", "send_to_crc_db")
+_proxy_post("", "delete_job", http_method="delete")
 
 
-@router.delete("/{job_id}", responses=_502_503_ARM)
-async def delete_job(job_id: int) -> dict[str, Any]:
-    return _check_result(await arm_client.delete_job(job_id))
-
-
-@router.post("/{job_id}/fix-permissions", responses=_502_503_ARM)
-async def fix_permissions(job_id: int) -> dict[str, Any]:
-    return _check_result(await arm_client.fix_permissions(job_id))
-
-
-@router.post("/{job_id}/skip-and-finalize", responses=_502_503_ARM)
-async def skip_and_finalize(job_id: int) -> dict[str, Any]:
-    """Skip transcoding and finalize a stuck job (proxies to ARM)."""
-    return _check_result(await arm_client.skip_and_finalize(job_id))
+# --- Endpoints with extra parameters (kept as regular functions) ---
 
 
 @router.put("/{job_id}/title", responses=_502_503_ARM)
@@ -60,12 +59,6 @@ async def update_job_config(job_id: int, body: JobConfigUpdateRequest) -> dict[s
     return _check_result(await arm_client.update_job_config(job_id, body.model_dump(exclude_none=True)))
 
 
-@router.post("/{job_id}/start", responses=_502_503_ARM)
-async def start_waiting_job(job_id: int) -> dict[str, Any]:
-    """Start a job in 'waiting' status (proxies to ARM)."""
-    return _check_result(await arm_client.start_waiting_job(job_id))
-
-
 @router.post("/{job_id}/pause", responses=_502_503_ARM)
 async def pause_waiting_job(job_id: int, body: dict[str, Any] | None = None) -> dict[str, Any]:
     """Set or toggle per-job pause for a waiting job (proxies to ARM)."""
@@ -77,12 +70,6 @@ async def pause_waiting_job(job_id: int, body: dict[str, Any] | None = None) -> 
 async def set_job_tracks(job_id: int, body: list[dict]) -> dict[str, Any]:
     """Replace a job's tracks with MusicBrainz data (proxies to ARM)."""
     return _check_result(await arm_client.set_job_tracks(job_id, body))
-
-
-@router.post("/{job_id}/crc-submit", responses=_502_503_ARM)
-async def crc_submit(job_id: int) -> dict[str, Any]:
-    """Submit a job's CRC data to the community database (proxies to ARM)."""
-    return _check_result(await arm_client.send_to_crc_db(job_id))
 
 
 # --- Naming preview (separate prefix) ---

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -110,6 +110,11 @@ async def fix_permissions(job_id: int) -> dict[str, Any] | None:
     return await _request("POST", f"/api/v1/jobs/{job_id}/fix-permissions")
 
 
+async def skip_and_finalize(job_id: int) -> dict[str, Any] | None:
+    """Skip transcoding and finalize a stuck job. Returns None if ARM is unreachable."""
+    return await _request("POST", f"/api/v1/jobs/{job_id}/skip-and-finalize")
+
+
 async def scan_folder(path: str) -> dict[str, Any] | None:
     """Scan a folder for disc structure. Returns None if ARM is unreachable."""
     return await _request("POST", "/api/v1/jobs/folder/scan", json={"path": path})

--- a/frontend/src/lib/api/__tests__/jobs.test.ts
+++ b/frontend/src/lib/api/__tests__/jobs.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { skipAndFinalize } from '$lib/api/jobs';
+
+// Mock the global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('skipAndFinalize', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('sends POST to /api/jobs/{id}/skip-and-finalize', async () => {
+		const responseBody = { success: true, message: 'Job finalized' };
+		mockFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve(responseBody)
+		});
+
+		const result = await skipAndFinalize(42);
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, init] = mockFetch.mock.calls[0];
+		expect(url).toBe('/api/jobs/42/skip-and-finalize');
+		expect(init.method).toBe('POST');
+		expect(result).toEqual(responseBody);
+	});
+
+	it('throws on non-ok response', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 502,
+			statusText: 'Bad Gateway',
+			json: () => Promise.resolve({ detail: 'ARM error' })
+		});
+
+		await expect(skipAndFinalize(42)).rejects.toThrow('ARM error');
+	});
+});

--- a/frontend/src/lib/api/jobs.ts
+++ b/frontend/src/lib/api/jobs.ts
@@ -57,6 +57,13 @@ export function fixJobPermissions(id: number): Promise<unknown> {
 	return apiFetch(`/api/jobs/${id}/fix-permissions`, { method: 'POST' });
 }
 
+export function skipAndFinalize(jobId: number): Promise<{ success: boolean; message?: string; error?: string }> {
+	return apiFetch<{ success: boolean; message?: string; error?: string }>(
+		`/api/jobs/${jobId}/skip-and-finalize`,
+		{ method: 'POST' }
+	);
+}
+
 export function searchMetadata(query: string, year?: string, page = 1): Promise<SearchResult[]> {
 	const params = new URLSearchParams({ q: query });
 	if (year) params.set('year', year);

--- a/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { Job, JobDetail } from '$lib/types/arm';
-	import { cancelWaitingJob, startWaitingJob, pauseWaitingJob, fetchJob, updateJobTitle, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
+	import { cancelWaitingJob, startWaitingJob, pauseWaitingJob, fetchJob, updateJobTitle, updateJobConfig, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
 	import type { NamingPreviewTrack } from '$lib/api/jobs';
 	import { getVideoTypeConfig, discTypeLabel } from '$lib/utils/job-type';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
@@ -48,6 +48,29 @@
 	let editingFilenameTrackId = $state<number | null>(null);
 	let editingFilenameValue = $state('');
 	let errorMessage = $state<string | null>(null);
+	let skipTranscode = $state(false);
+
+	// Sync from job config when detail loads
+	$effect(() => {
+		if (detail?.config?.SKIP_TRANSCODE != null) {
+			const val = String(detail.config.SKIP_TRANSCODE).toLowerCase();
+			skipTranscode = val === 'true' || val === '1';
+		}
+	});
+
+	async function handleSkipTranscodeToggle() {
+		skipTranscode = !skipTranscode;
+		errorMessage = null;
+		try {
+			await updateJobConfig(job.job_id, {
+				SKIP_TRANSCODE: skipTranscode,
+			});
+			loadDetail();
+		} catch (e) {
+			errorMessage = `Failed to update skip transcode: ${e instanceof Error ? e.message : 'Unknown error'}`;
+			skipTranscode = !skipTranscode;
+		}
+	}
 
 	// MakeMKV's minlength threshold - tracks shorter than this are silently
 	// skipped during ripping regardless of checkbox state.
@@ -988,8 +1011,23 @@
 	{/if}
 
 	{#if showTranscodeSettings && isVideo}
-		<div class="border-t border-primary/20 p-4 dark:border-primary/20">
-			<TranscodeOverrides {job} onsaved={handleConfigSaved} />
+		<div class="border-t border-primary/20 p-4 space-y-3 dark:border-primary/20">
+			<div class="flex items-center justify-between rounded-lg bg-amber-50 px-3 py-2 dark:bg-amber-900/20">
+				<div class="flex items-center gap-2">
+					<span class="text-sm font-medium text-amber-800 dark:text-amber-200">Skip Transcoding</span>
+					<span class="text-xs text-amber-600 dark:text-amber-400">Finalize with raw MKV files</span>
+				</div>
+				<button
+					onclick={handleSkipTranscodeToggle}
+					class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors {skipTranscode ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'}"
+					title={skipTranscode ? 'Transcoding will be skipped' : 'Files will be sent to transcoder'}
+				>
+					<span class="inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform {skipTranscode ? 'translate-x-4' : 'translate-x-0.5'}"></span>
+				</button>
+			</div>
+			{#if !skipTranscode}
+				<TranscodeOverrides {job} onsaved={handleConfigSaved} />
+			{/if}
 		</div>
 	{/if}
 

--- a/frontend/src/lib/components/DiscReviewWidget.test.ts
+++ b/frontend/src/lib/components/DiscReviewWidget.test.ts
@@ -36,12 +36,13 @@ vi.mock('$lib/api/logs', () => ({
 	fetchLogContent: vi.fn(() => Promise.resolve({ content: '' }))
 }));
 
-import { startWaitingJob, cancelWaitingJob, fetchJob, fetchNamingPreview, updateJobTitle } from '$lib/api/jobs';
+import { startWaitingJob, cancelWaitingJob, fetchJob, fetchNamingPreview, updateJobTitle, updateJobConfig } from '$lib/api/jobs';
 const mockStart = vi.mocked(startWaitingJob);
 const mockCancel = vi.mocked(cancelWaitingJob);
 const mockFetchJob = vi.mocked(fetchJob);
 const mockFetchNamingPreview = vi.mocked(fetchNamingPreview);
 const mockUpdateJobTitle = vi.mocked(updateJobTitle);
+const mockUpdateJobConfig = vi.mocked(updateJobConfig);
 
 vi.stubGlobal('confirm', vi.fn(() => true));
 
@@ -274,6 +275,29 @@ describe('DiscReviewWidget', () => {
 				expect(screen.getByText('Test Movie')).toBeInTheDocument();
 			});
 			expect(mockUpdateJobTitle).not.toHaveBeenCalledWith(1, { video_type: 'movie' });
+		});
+	});
+
+	describe('skip transcode toggle', () => {
+		it('renders skip transcode toggle after clicking Transcode button', async () => {
+			renderWidget({ video_type: 'movie', disctype: 'bluray' });
+			await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Transcode'));
+			await waitFor(() => {
+				expect(screen.getByText('Skip Transcoding')).toBeInTheDocument();
+			});
+		});
+
+		it('calls updateJobConfig with SKIP_TRANSCODE when toggled', async () => {
+			mockUpdateJobConfig.mockResolvedValue(undefined as any);
+			renderWidget({ video_type: 'movie', disctype: 'bluray' });
+			await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Transcode'));
+			await waitFor(() => expect(screen.getByTitle('Files will be sent to transcoder')).toBeInTheDocument());
+			await fireEvent.click(screen.getByTitle('Files will be sent to transcoder'));
+			await waitFor(() => {
+				expect(mockUpdateJobConfig).toHaveBeenCalledWith(1, { SKIP_TRANSCODE: true });
+			});
 		});
 	});
 

--- a/frontend/src/lib/components/DiscReviewWidget.test.ts
+++ b/frontend/src/lib/components/DiscReviewWidget.test.ts
@@ -28,7 +28,10 @@ vi.mock('$lib/api/jobs', () => ({
 }));
 
 vi.mock('$lib/api/settings', () => ({
-	fetchSettings: vi.fn(() => Promise.resolve({ transcoder_config: { config: {} } }))
+	fetchSettings: vi.fn(() => Promise.resolve({ transcoder_config: { config: {} } })),
+	fetchTranscoderScheme: vi.fn(() => Promise.resolve(null)),
+	fetchTranscoderPresets: vi.fn(() => Promise.resolve([])),
+	createCustomPreset: vi.fn(() => Promise.resolve(null))
 }));
 
 vi.mock('$lib/api/logs', () => ({
@@ -297,6 +300,24 @@ describe('DiscReviewWidget', () => {
 			await fireEvent.click(screen.getByTitle('Files will be sent to transcoder'));
 			await waitFor(() => {
 				expect(mockUpdateJobConfig).toHaveBeenCalledWith(1, { SKIP_TRANSCODE: true });
+			});
+		});
+
+		it('reverts skipTranscode and shows error when updateJobConfig rejects', async () => {
+			mockUpdateJobConfig.mockRejectedValue(new Error('Network failure'));
+			renderWidget({ video_type: 'movie', disctype: 'bluray' });
+			await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Transcode'));
+			// Toggle starts as off ("Files will be sent to transcoder")
+			await waitFor(() => expect(screen.getByTitle('Files will be sent to transcoder')).toBeInTheDocument());
+			await fireEvent.click(screen.getByTitle('Files will be sent to transcoder'));
+			// After rejection, toggle should revert back to off state
+			await waitFor(() => {
+				expect(screen.getByTitle('Files will be sent to transcoder')).toBeInTheDocument();
+			});
+			// Error message should be displayed
+			await waitFor(() => {
+				expect(screen.getByText(/Failed to update skip transcode.*Network failure/)).toBeInTheDocument();
 			});
 		});
 	});

--- a/frontend/src/lib/types/arm.ts
+++ b/frontend/src/lib/types/arm.ts
@@ -306,6 +306,7 @@ export interface JobConfigUpdate {
 	MINLENGTH?: number;
 	MAXLENGTH?: number;
 	AUDIO_FORMAT?: string;
+	SKIP_TRANSCODE?: boolean;
 }
 
 export interface TranscoderConfig {

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
-	import { fetchJob, retranscodeJob, fetchMusicDetail, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
+	import { fetchJob, retranscodeJob, skipAndFinalize, fetchMusicDetail, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
 	import type { NamingPreviewTrack } from '$lib/api/jobs';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
 	import PosterImage from '$lib/components/PosterImage.svelte';
@@ -96,6 +96,28 @@
 			retranscodeFeedback = { type: 'error', message: e instanceof Error ? e.message : 'Failed to queue' };
 		} finally {
 			retranscoding = false;
+		}
+	}
+
+	let skippingTranscode = $state(false);
+	let skipTranscodeFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
+
+	async function handleSkipAndFinalize() {
+		if (!job) return;
+		skippingTranscode = true;
+		skipTranscodeFeedback = null;
+		try {
+			const result = await skipAndFinalize(job.job_id);
+			if (result.success) {
+				skipTranscodeFeedback = { type: 'success', message: result.message || 'Finalized without transcoding' };
+				await loadJob();
+			} else {
+				skipTranscodeFeedback = { type: 'error', message: result.error || 'Failed to skip transcode' };
+			}
+		} catch (e) {
+			skipTranscodeFeedback = { type: 'error', message: e instanceof Error ? e.message : 'Failed to skip transcode' };
+		} finally {
+			skippingTranscode = false;
 		}
 	}
 
@@ -297,10 +319,24 @@
 							{retranscoding ? 'Queuing...' : 'Re-transcode'}
 						</button>
 					{/if}
+					{#if job.status === 'waiting_transcode' || job.status === 'transcoding'}
+						<button
+							onclick={handleSkipAndFinalize}
+							disabled={skippingTranscode}
+							class="rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
+						>
+							{skippingTranscode ? 'Finalizing...' : 'Skip Transcode & Finalize'}
+						</button>
+					{/if}
 					<JobActions {job} onaction={loadJob} ondelete={() => goto('/')} />
 					{#if retranscodeFeedback}
 						<span class="text-xs {retranscodeFeedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
 							{retranscodeFeedback.message}
+						</span>
+					{/if}
+					{#if skipTranscodeFeedback}
+						<span class="text-xs {skipTranscodeFeedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
+							{skipTranscodeFeedback.message}
 						</span>
 					{/if}
 				</div>

--- a/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/frontend/src/routes/jobs/[id]/page.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, cleanup, waitFor } from '$lib/test-utils';
+import Page from './+page.svelte';
+import type { JobDetail } from '$lib/types/arm';
+
+// --- Mocks ---
+
+const mockGoto = vi.fn();
+vi.mock('$app/navigation', () => ({ goto: (...args: unknown[]) => mockGoto(...args) }));
+
+vi.mock('$app/stores', () => ({
+	page: {
+		subscribe: (fn: (val: { params: { id: '42' } }) => void) => {
+			fn({ params: { id: '42' } });
+			return () => {};
+		}
+	}
+}));
+
+const baseJob: JobDetail = {
+	job_id: 42,
+	arm_version: '2.0',
+	crc_id: null,
+	logfile: null,
+	start_time: '2025-06-15T10:00:00Z',
+	stop_time: null,
+	job_length: null,
+	status: 'waiting_transcode',
+	stage: null,
+	no_of_titles: 1,
+	title: 'Test Movie',
+	title_auto: null,
+	title_manual: null,
+	year: '2024',
+	year_auto: null,
+	year_manual: null,
+	video_type: 'movie',
+	video_type_auto: null,
+	video_type_manual: null,
+	imdb_id: null,
+	imdb_id_auto: null,
+	imdb_id_manual: null,
+	poster_url: null,
+	poster_url_auto: null,
+	poster_url_manual: null,
+	devpath: '/dev/sr0',
+	mountpoint: null,
+	hasnicetitle: null,
+	errors: null,
+	disctype: 'bluray',
+	label: 'TEST_MOVIE',
+	path: null,
+	raw_path: null,
+	transcode_path: null,
+	artist: null,
+	artist_auto: null,
+	artist_manual: null,
+	album: null,
+	album_auto: null,
+	album_manual: null,
+	season: null,
+	season_auto: null,
+	season_manual: null,
+	episode: null,
+	episode_auto: null,
+	episode_manual: null,
+	transcode_overrides: null,
+	multi_title: null,
+	title_pattern_override: null,
+	folder_pattern_override: null,
+	disc_number: null,
+	disc_total: null,
+	ejected: null,
+	pid: null,
+	manual_pause: null,
+	wait_start_time: null,
+	tracks_total: null,
+	tracks_ripped: null,
+	tvdb_id: null,
+	source_type: null,
+	tracks: [],
+	config: { MINLENGTH: '120' }
+} as unknown as JobDetail;
+
+vi.mock('$lib/api/jobs', () => ({
+	fetchJob: vi.fn(() => Promise.resolve({ ...baseJob })),
+	retranscodeJob: vi.fn(),
+	skipAndFinalize: vi.fn(() => Promise.resolve({ success: true, message: 'Done' })),
+	fetchMusicDetail: vi.fn(),
+	toggleMultiTitle: vi.fn(),
+	updateTrack: vi.fn(),
+	fetchNamingPreview: vi.fn(() => Promise.resolve({ success: true, job_title: '', job_folder: '', tracks: [] })),
+	searchMetadata: vi.fn(),
+	fetchMediaDetail: vi.fn(),
+	searchMusicMetadata: vi.fn(),
+	setJobTracks: vi.fn(),
+	fetchCrcLookup: vi.fn(),
+	submitToCrcDb: vi.fn(),
+	updateJobConfig: vi.fn(),
+	updateJobTitle: vi.fn(),
+	updateJobTranscodeConfig: vi.fn()
+}));
+
+vi.mock('$lib/api/logs', () => ({
+	fetchStructuredLogContent: vi.fn(() => Promise.resolve({ entries: [] })),
+	fetchStructuredTranscoderLogContent: vi.fn(() => Promise.resolve({ entries: [] })),
+	fetchTranscoderLogForArmJob: vi.fn(() => Promise.resolve({ found: false })),
+	fetchLogContent: vi.fn(() => Promise.resolve({ content: '' }))
+}));
+
+vi.mock('$lib/api/settings', () => ({
+	fetchSettings: vi.fn(() => Promise.resolve({ transcoder_config: { config: {} } }))
+}));
+
+import { fetchJob, skipAndFinalize } from '$lib/api/jobs';
+const mockFetchJob = vi.mocked(fetchJob);
+const mockSkipAndFinalize = vi.mocked(skipAndFinalize);
+
+describe('Job detail page — skip transcode', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('shows Skip Transcode & Finalize button for waiting_transcode status', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
+		renderComponent(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument();
+		});
+	});
+
+	it('shows Skip Transcode & Finalize button for transcoding status', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'transcoding' } as any);
+		renderComponent(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument();
+		});
+	});
+
+	it('does NOT show skip button for other statuses', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'success' } as any);
+		renderComponent(Page);
+		// Wait for page to render by checking for the breadcrumb Dashboard link
+		await waitFor(() => {
+			expect(screen.getByText('Dashboard')).toBeInTheDocument();
+		});
+		expect(screen.queryByText('Skip Transcode & Finalize')).not.toBeInTheDocument();
+	});
+
+	it('calls skipAndFinalize and shows success feedback', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
+		mockSkipAndFinalize.mockResolvedValue({ success: true, message: 'Finalized without transcoding' });
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
+		await fireEvent.click(screen.getByText('Skip Transcode & Finalize'));
+		await waitFor(() => {
+			expect(mockSkipAndFinalize).toHaveBeenCalledWith(42);
+		});
+		await waitFor(() => {
+			expect(screen.getByText('Finalized without transcoding')).toBeInTheDocument();
+		});
+	});
+
+	it('shows error feedback when skipAndFinalize returns success=false', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
+		mockSkipAndFinalize.mockResolvedValue({ success: false, error: 'Job not found' });
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
+		await fireEvent.click(screen.getByText('Skip Transcode & Finalize'));
+		await waitFor(() => {
+			expect(screen.getByText('Job not found')).toBeInTheDocument();
+		});
+	});
+
+	it('shows error feedback when skipAndFinalize throws', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
+		mockSkipAndFinalize.mockRejectedValue(new Error('Network error'));
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
+		await fireEvent.click(screen.getByText('Skip Transcode & Finalize'));
+		await waitFor(() => {
+			expect(screen.getByText('Network error')).toBeInTheDocument();
+		});
+	});
+
+	it('disables button while skipping is in progress', async () => {
+		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
+		// Never resolve to keep button in disabled state
+		mockSkipAndFinalize.mockReturnValue(new Promise(() => {}));
+		renderComponent(Page);
+		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
+		const button = screen.getByText('Skip Transcode & Finalize');
+		await fireEvent.click(button);
+		await waitFor(() => {
+			expect(screen.getByText('Finalizing...')).toBeInTheDocument();
+		});
+		expect(screen.getByText('Finalizing...').closest('button')).toBeDisabled();
+	});
+});

--- a/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/frontend/src/routes/jobs/[id]/page.test.ts
@@ -116,44 +116,50 @@ import { fetchJob, skipAndFinalize } from '$lib/api/jobs';
 const mockFetchJob = vi.mocked(fetchJob);
 const mockSkipAndFinalize = vi.mocked(skipAndFinalize);
 
+// --- Helpers ---
+
+/** Render the page with the given job status pre-loaded. */
+function renderWithStatus(status: string) {
+	mockFetchJob.mockResolvedValue({ ...baseJob, status } as any);
+	renderComponent(Page);
+}
+
+/** Render, wait for the skip button to appear, then click it. */
+async function clickSkipButton(status = 'waiting_transcode') {
+	renderWithStatus(status);
+	const btn = await screen.findByText('Skip Transcode & Finalize');
+	await fireEvent.click(btn);
+}
+
+const SKIP_BTN = 'Skip Transcode & Finalize';
+
 describe('Job detail page — skip transcode', () => {
 	afterEach(() => {
 		cleanup();
 		vi.clearAllMocks();
 	});
 
-	it('shows Skip Transcode & Finalize button for waiting_transcode status', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
-		renderComponent(Page);
-		await waitFor(() => {
-			expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument();
-		});
-	});
-
-	it('shows Skip Transcode & Finalize button for transcoding status', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'transcoding' } as any);
-		renderComponent(Page);
-		await waitFor(() => {
-			expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument();
-		});
-	});
+	it.each(['waiting_transcode', 'transcoding'])(
+		'shows Skip Transcode & Finalize button for %s status',
+		async (status) => {
+			renderWithStatus(status);
+			await waitFor(() => {
+				expect(screen.getByText(SKIP_BTN)).toBeInTheDocument();
+			});
+		}
+	);
 
 	it('does NOT show skip button for other statuses', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'success' } as any);
-		renderComponent(Page);
-		// Wait for page to render by checking for the breadcrumb Dashboard link
+		renderWithStatus('success');
 		await waitFor(() => {
 			expect(screen.getByText('Dashboard')).toBeInTheDocument();
 		});
-		expect(screen.queryByText('Skip Transcode & Finalize')).not.toBeInTheDocument();
+		expect(screen.queryByText(SKIP_BTN)).not.toBeInTheDocument();
 	});
 
 	it('calls skipAndFinalize and shows success feedback', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
 		mockSkipAndFinalize.mockResolvedValue({ success: true, message: 'Finalized without transcoding' });
-		renderComponent(Page);
-		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
-		await fireEvent.click(screen.getByText('Skip Transcode & Finalize'));
+		await clickSkipButton();
 		await waitFor(() => {
 			expect(mockSkipAndFinalize).toHaveBeenCalledWith(42);
 		});
@@ -163,35 +169,24 @@ describe('Job detail page — skip transcode', () => {
 	});
 
 	it('shows error feedback when skipAndFinalize returns success=false', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
 		mockSkipAndFinalize.mockResolvedValue({ success: false, error: 'Job not found' });
-		renderComponent(Page);
-		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
-		await fireEvent.click(screen.getByText('Skip Transcode & Finalize'));
+		await clickSkipButton();
 		await waitFor(() => {
 			expect(screen.getByText('Job not found')).toBeInTheDocument();
 		});
 	});
 
 	it('shows error feedback when skipAndFinalize throws', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
 		mockSkipAndFinalize.mockRejectedValue(new Error('Network error'));
-		renderComponent(Page);
-		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
-		await fireEvent.click(screen.getByText('Skip Transcode & Finalize'));
+		await clickSkipButton();
 		await waitFor(() => {
 			expect(screen.getByText('Network error')).toBeInTheDocument();
 		});
 	});
 
 	it('disables button while skipping is in progress', async () => {
-		mockFetchJob.mockResolvedValue({ ...baseJob, status: 'waiting_transcode' } as any);
-		// Never resolve to keep button in disabled state
 		mockSkipAndFinalize.mockReturnValue(new Promise(() => {}));
-		renderComponent(Page);
-		await waitFor(() => expect(screen.getByText('Skip Transcode & Finalize')).toBeInTheDocument());
-		const button = screen.getByText('Skip Transcode & Finalize');
-		await fireEvent.click(button);
+		await clickSkipButton();
 		await waitFor(() => {
 			expect(screen.getByText('Finalizing...')).toBeInTheDocument();
 		});

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -790,6 +790,7 @@
 		MUSIC_TITLE_PATTERN: { label: 'Music Title Pattern', description: 'Pattern for music display titles' },
 		MUSIC_FOLDER_PATTERN: { label: 'Music Folder Pattern', description: 'Pattern for music folder names (use / for nested directories)' },
 		// Transcoder Integration
+		SKIP_TRANSCODE: { label: 'Skip Transcoding (Global Default)', description: 'When enabled, ripped files are finalized directly without sending to the transcoder. Can be overridden per-job from the review panel.' },
 		TRANSCODER_URL: { label: 'Transcoder Webhook URL', description: 'URL of the arm-transcoder webhook endpoint (leave empty to disable)' },
 		TRANSCODER_WEBHOOK_SECRET: { label: 'Transcoder Webhook Secret', description: 'Must match WEBHOOK_SECRET in arm-transcoder .env' },
 		LOCAL_RAW_PATH: { label: 'Local Raw Path', description: 'Local scratch storage where ARM rips to (for file move before notify)' },
@@ -834,7 +835,7 @@
 				{ keys: ['MAKEMKV_PERMA_KEY', 'MAKEMKV_COMMUNITY_KEYDB', 'MAX_CONCURRENT_MAKEMKVINFO', 'PRESCAN_TIMEOUT', 'PRESCAN_CACHE_MB', 'PRESCAN_RETRIES', 'DISC_ENUM_TIMEOUT'] },
 			]},
 			{ label: 'Post-Rip', subpanels: [
-				{ keys: ['AUTO_EJECT', 'DELRAWFILES', 'RIP_POSTER'] },
+				{ keys: ['SKIP_TRANSCODE', 'AUTO_EJECT', 'DELRAWFILES', 'RIP_POSTER'] },
 			]},
 			{ label: 'Media Directories', subpanels: [
 				{ keys: ['RAW_PATH', 'TRANSCODE_PATH', 'COMPLETED_PATH', 'MUSIC_PATH', 'INGRESS_PATH', 'EXTRAS_SUB'] },
@@ -1456,20 +1457,27 @@
 						<!-- Encoding sub-panel -->
 						<section class="space-y-3">
 							<h3 class="text-base font-semibold text-gray-700 dark:text-gray-300">Transcoder - Encoding</h3>
-							{#if presetScheme || presetOffline}
-								<PresetEditor
-									scope="global"
-									initialState={presetInitialState}
-									scheme={presetScheme}
-									{presets}
-									offline={presetOffline}
-									saving={presetSaving}
-									onSave={handlePresetSave}
-									onSaveAsNew={handlePresetSaveAsNew}
-									onRetry={loadPresetData}
-								/>
-							{:else}
-								<p class="text-sm text-gray-400">Loading presets...</p>
+							<div class={armForm['SKIP_TRANSCODE']?.toLowerCase() === 'true' ? 'opacity-40 pointer-events-none' : ''}>
+								{#if presetScheme || presetOffline}
+									<PresetEditor
+										scope="global"
+										initialState={presetInitialState}
+										scheme={presetScheme}
+										{presets}
+										offline={presetOffline}
+										saving={presetSaving}
+										onSave={handlePresetSave}
+										onSaveAsNew={handlePresetSaveAsNew}
+										onRetry={loadPresetData}
+									/>
+								{:else}
+									<p class="text-sm text-gray-400">Loading presets...</p>
+								{/if}
+							</div>
+							{#if armForm['SKIP_TRANSCODE']?.toLowerCase() === 'true'}
+								<p class="mt-1 text-xs text-amber-600 dark:text-amber-400">
+									Transcoding is skipped globally — these settings are inactive
+								</p>
 							{/if}
 						</section>
 

--- a/tests/routers/test_arm_actions.py
+++ b/tests/routers/test_arm_actions.py
@@ -158,3 +158,39 @@ async def test_pause_waiting_job_explicit_false(app_client):
     assert resp.status_code == 200
     assert resp.json()["paused"] is False
     mock_pause.assert_called_once_with(1, paused=False)
+
+
+# --- skip_and_finalize endpoint ---
+
+
+async def test_skip_and_finalize_endpoint(app_client):
+    """POST /api/jobs/{id}/skip-and-finalize proxies to arm_client."""
+    with patch(
+        "backend.routers.arm_actions.arm_client.skip_and_finalize",
+        new_callable=AsyncMock, return_value={"success": True, "message": "Job finalized"},
+    ):
+        resp = await app_client.post("/api/jobs/5/skip-and-finalize")
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+
+async def test_skip_and_finalize_502_on_arm_error(app_client):
+    """POST /api/jobs/{id}/skip-and-finalize returns 502 when ARM reports failure."""
+    with patch(
+        "backend.routers.arm_actions.arm_client.skip_and_finalize",
+        new_callable=AsyncMock,
+        return_value={"success": False, "error": "Job not in transcoding state"},
+    ):
+        resp = await app_client.post("/api/jobs/5/skip-and-finalize")
+    assert resp.status_code == 502
+    assert "Job not in transcoding state" in resp.json()["detail"]
+
+
+async def test_skip_and_finalize_503_when_unreachable(app_client):
+    """POST /api/jobs/{id}/skip-and-finalize returns 503 when ARM is down."""
+    with patch(
+        "backend.routers.arm_actions.arm_client.skip_and_finalize",
+        new_callable=AsyncMock, return_value=None,
+    ):
+        resp = await app_client.post("/api/jobs/5/skip-and-finalize")
+    assert resp.status_code == 503

--- a/tests/routers/test_arm_actions.py
+++ b/tests/routers/test_arm_actions.py
@@ -14,48 +14,47 @@ from backend.routers.arm_actions import _check_result
 # --- _check_result unit tests ---
 
 
-def test_check_result_none_raises_503():
-    """None result (ARM unreachable) raises 503."""
+@pytest.mark.parametrize(
+    "result, expected_status, expected_detail_substr",
+    [
+        (None, 503, "unreachable"),
+        ({"success": False, "error": "Job not found"}, 502, "Job not found"),
+        ({"success": False, "Error": "Something broke"}, 502, "Something broke"),
+        ({"success": False}, 502, "Action failed"),
+    ],
+    ids=["none-503", "error-key", "Error-key-capital", "fallback-message"],
+)
+def test_check_result_raises(result, expected_status, expected_detail_substr):
+    """_check_result raises HTTPException for None or success=False results."""
     with pytest.raises(HTTPException) as exc_info:
-        _check_result(None)
-    assert exc_info.value.status_code == 503
-    assert "unreachable" in exc_info.value.detail.lower()
+        _check_result(result)
+    assert exc_info.value.status_code == expected_status
+    assert expected_detail_substr.lower() in exc_info.value.detail.lower()
 
 
-def test_check_result_success_false_raises_502():
-    """Result with success=False raises 502 with error message."""
-    with pytest.raises(HTTPException) as exc_info:
-        _check_result({"success": False, "error": "Job not found"})
-    assert exc_info.value.status_code == 502
-    assert "Job not found" in exc_info.value.detail
-
-
-def test_check_result_success_false_uses_Error_key():
-    """Result with 'Error' key (capital E) is also used for detail."""
-    with pytest.raises(HTTPException) as exc_info:
-        _check_result({"success": False, "Error": "Something broke"})
-    assert exc_info.value.status_code == 502
-    assert "Something broke" in exc_info.value.detail
-
-
-def test_check_result_success_false_fallback_message():
-    """Result with success=False and no error keys uses 'Action failed' fallback."""
-    with pytest.raises(HTTPException) as exc_info:
-        _check_result({"success": False})
-    assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == "Action failed"
-
-
-def test_check_result_success_true_passthrough():
-    """Successful result is returned unchanged."""
-    result: dict[str, Any] = {"success": True, "data": "ok"}
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"success": True, "data": "ok"},
+        {"job_id": 1, "status": "abandoned"},
+    ],
+    ids=["success-true", "no-success-key"],
+)
+def test_check_result_passthrough(result):
+    """Successful or keyless results pass through unchanged."""
     assert _check_result(result) == result
 
 
-def test_check_result_dict_without_success_key():
-    """A dict without 'success' key is passed through (not an error)."""
-    result: dict[str, Any] = {"job_id": 1, "status": "abandoned"}
-    assert _check_result(result) == result
+# --- Endpoint test helpers ---
+
+
+def _patch_arm_client(method_name: str, return_value):
+    """Patch an arm_client method for endpoint tests."""
+    return patch(
+        f"backend.routers.arm_actions.arm_client.{method_name}",
+        new_callable=AsyncMock,
+        return_value=return_value,
+    )
 
 
 # --- Endpoint tests via app_client ---
@@ -63,10 +62,7 @@ def test_check_result_dict_without_success_key():
 
 async def test_abandon_job_endpoint(app_client):
     """POST /api/jobs/{id}/abandon proxies to arm_client."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.abandon_job",
-        new_callable=AsyncMock, return_value={"success": True},
-    ):
+    with _patch_arm_client("abandon_job", {"success": True}):
         resp = await app_client.post("/api/jobs/1/abandon")
     assert resp.status_code == 200
     assert resp.json()["success"] is True
@@ -74,30 +70,21 @@ async def test_abandon_job_endpoint(app_client):
 
 async def test_abandon_job_503_when_unreachable(app_client):
     """POST /api/jobs/{id}/abandon returns 503 when ARM is down."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.abandon_job",
-        new_callable=AsyncMock, return_value=None,
-    ):
+    with _patch_arm_client("abandon_job", None):
         resp = await app_client.post("/api/jobs/1/abandon")
     assert resp.status_code == 503
 
 
 async def test_delete_job_endpoint(app_client):
     """DELETE /api/jobs/{id} proxies to arm_client."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.delete_job",
-        new_callable=AsyncMock, return_value={"success": True},
-    ):
+    with _patch_arm_client("delete_job", {"success": True}):
         resp = await app_client.delete("/api/jobs/1")
     assert resp.status_code == 200
 
 
 async def test_set_ripping_enabled_endpoint(app_client):
     """POST /api/system/ripping-enabled toggles ripping."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.set_ripping_enabled",
-        new_callable=AsyncMock, return_value={"success": True},
-    ):
+    with _patch_arm_client("set_ripping_enabled", {"success": True}):
         resp = await app_client.post(
             "/api/system/ripping-enabled", json={"enabled": True},
         )
@@ -106,20 +93,14 @@ async def test_set_ripping_enabled_endpoint(app_client):
 
 async def test_start_waiting_job_endpoint(app_client):
     """POST /api/jobs/{id}/start proxies to arm_client."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.start_waiting_job",
-        new_callable=AsyncMock, return_value={"success": True},
-    ):
+    with _patch_arm_client("start_waiting_job", {"success": True}):
         resp = await app_client.post("/api/jobs/1/start")
     assert resp.status_code == 200
 
 
 async def test_pause_waiting_job_endpoint(app_client):
     """POST /api/jobs/{id}/pause proxies to arm_client."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.pause_waiting_job",
-        new_callable=AsyncMock, return_value={"success": True, "paused": True},
-    ):
+    with _patch_arm_client("pause_waiting_job", {"success": True, "paused": True}):
         resp = await app_client.post("/api/jobs/1/pause")
     assert resp.status_code == 200
     assert resp.json()["success"] is True
@@ -128,20 +109,14 @@ async def test_pause_waiting_job_endpoint(app_client):
 
 async def test_pause_waiting_job_503_when_unreachable(app_client):
     """POST /api/jobs/{id}/pause returns 503 when ARM is down."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.pause_waiting_job",
-        new_callable=AsyncMock, return_value=None,
-    ):
+    with _patch_arm_client("pause_waiting_job", None):
         resp = await app_client.post("/api/jobs/1/pause")
     assert resp.status_code == 503
 
 
 async def test_pause_waiting_job_explicit_true(app_client):
     """POST /api/jobs/{id}/pause with {paused: true} forwards paused=True."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.pause_waiting_job",
-        new_callable=AsyncMock, return_value={"success": True, "paused": True},
-    ) as mock_pause:
+    with _patch_arm_client("pause_waiting_job", {"success": True, "paused": True}) as mock_pause:
         resp = await app_client.post("/api/jobs/1/pause", json={"paused": True})
     assert resp.status_code == 200
     assert resp.json()["paused"] is True
@@ -150,10 +125,7 @@ async def test_pause_waiting_job_explicit_true(app_client):
 
 async def test_pause_waiting_job_explicit_false(app_client):
     """POST /api/jobs/{id}/pause with {paused: false} forwards paused=False."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.pause_waiting_job",
-        new_callable=AsyncMock, return_value={"success": True, "paused": False},
-    ) as mock_pause:
+    with _patch_arm_client("pause_waiting_job", {"success": True, "paused": False}) as mock_pause:
         resp = await app_client.post("/api/jobs/1/pause", json={"paused": False})
     assert resp.status_code == 200
     assert resp.json()["paused"] is False
@@ -165,10 +137,7 @@ async def test_pause_waiting_job_explicit_false(app_client):
 
 async def test_skip_and_finalize_endpoint(app_client):
     """POST /api/jobs/{id}/skip-and-finalize proxies to arm_client."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.skip_and_finalize",
-        new_callable=AsyncMock, return_value={"success": True, "message": "Job finalized"},
-    ):
+    with _patch_arm_client("skip_and_finalize", {"success": True, "message": "Job finalized"}):
         resp = await app_client.post("/api/jobs/5/skip-and-finalize")
     assert resp.status_code == 200
     assert resp.json()["success"] is True
@@ -176,11 +145,7 @@ async def test_skip_and_finalize_endpoint(app_client):
 
 async def test_skip_and_finalize_502_on_arm_error(app_client):
     """POST /api/jobs/{id}/skip-and-finalize returns 502 when ARM reports failure."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.skip_and_finalize",
-        new_callable=AsyncMock,
-        return_value={"success": False, "error": "Job not in transcoding state"},
-    ):
+    with _patch_arm_client("skip_and_finalize", {"success": False, "error": "Job not in transcoding state"}):
         resp = await app_client.post("/api/jobs/5/skip-and-finalize")
     assert resp.status_code == 502
     assert "Job not in transcoding state" in resp.json()["detail"]
@@ -188,9 +153,6 @@ async def test_skip_and_finalize_502_on_arm_error(app_client):
 
 async def test_skip_and_finalize_503_when_unreachable(app_client):
     """POST /api/jobs/{id}/skip-and-finalize returns 503 when ARM is down."""
-    with patch(
-        "backend.routers.arm_actions.arm_client.skip_and_finalize",
-        new_callable=AsyncMock, return_value=None,
-    ):
+    with _patch_arm_client("skip_and_finalize", None):
         resp = await app_client.post("/api/jobs/5/skip-and-finalize")
     assert resp.status_code == 503

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -24,70 +24,82 @@ def _mock_response(json_data, status_code: int = 200) -> MagicMock:
     return resp
 
 
+@pytest.fixture()
+def mock_client():
+    """Yield a patched AsyncMock httpx client and wire it into arm_client."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    with patch.object(arm_client, "get_client", return_value=client):
+        yield client
+
+
+def _set_request_response(client, json_data, status_code=200):
+    """Configure the mock client.request to return a mock response."""
+    client.request.return_value = _mock_response(json_data, status_code)
+
+
+def _set_request_connect_error(client):
+    """Configure the mock client.request to raise ConnectError."""
+    client.request.side_effect = httpx.ConnectError("refused")
+
+
+def _set_get_response(client, json_data, status_code=200):
+    """Configure the mock client.get to return a mock response."""
+    client.get.return_value = _mock_response(json_data, status_code)
+
+
+def _set_get_connect_error(client):
+    """Configure the mock client.get to raise ConnectError."""
+    client.get.side_effect = httpx.ConnectError("refused")
+
+
 # --- abandon_job (uses _request) ---
 
 
-async def test_abandon_job_success():
+async def test_abandon_job_success(mock_client):
     """abandon_job returns JSON on success."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.abandon_job(42)
+    _set_request_response(mock_client, {"success": True})
+    result = await arm_client.abandon_job(42)
     assert result == {"success": True}
     mock_client.request.assert_awaited_once_with("POST", "/api/v1/jobs/42/abandon")
 
 
-async def test_abandon_job_connect_error():
+async def test_abandon_job_connect_error(mock_client):
     """abandon_job returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.abandon_job(42)
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.abandon_job(42) is None
 
 
 # --- skip_and_finalize ---
 
 
-async def test_skip_and_finalize_success():
+async def test_skip_and_finalize_success(mock_client):
     """skip_and_finalize returns JSON on success."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True, "message": "Job finalized"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.skip_and_finalize(7)
+    _set_request_response(mock_client, {"success": True, "message": "Job finalized"})
+    result = await arm_client.skip_and_finalize(7)
     assert result == {"success": True, "message": "Job finalized"}
     mock_client.request.assert_awaited_once_with("POST", "/api/v1/jobs/7/skip-and-finalize")
 
 
-async def test_skip_and_finalize_connect_error():
+async def test_skip_and_finalize_connect_error(mock_client):
     """skip_and_finalize returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.skip_and_finalize(7)
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.skip_and_finalize(7) is None
 
 
 # --- get_config ---
 
 
-async def test_get_config_success():
+async def test_get_config_success(mock_client):
     """get_config returns JSON on success."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"RIPMETHOD": "mkv"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_config()
+    _set_request_response(mock_client, {"RIPMETHOD": "mkv"})
+    result = await arm_client.get_config()
     assert result == {"RIPMETHOD": "mkv"}
 
 
-async def test_get_config_http_error():
+async def test_get_config_http_error(mock_client):
     """get_config returns error dict on HTTP 500 (not None)."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response(
-        {"error": "Internal error"}, status_code=500
-    )
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_config()
+    _set_request_response(mock_client, {"error": "Internal error"}, status_code=500)
+    result = await arm_client.get_config()
     assert result is not None
     assert result["success"] is False
     assert "500" in result["error"]
@@ -96,75 +108,59 @@ async def test_get_config_http_error():
 # --- update_title ---
 
 
-async def test_update_title_success():
+async def test_update_title_success(mock_client):
     """update_title sends PUT with JSON body."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True})
+    _set_request_response(mock_client, {"success": True})
     data = {"title": "New Title", "year": "2024"}
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.update_title(1, data)
+    result = await arm_client.update_title(1, data)
     assert result == {"success": True}
     mock_client.request.assert_awaited_once_with(
         "PUT", "/api/v1/jobs/1/title", json=data
     )
 
 
-async def test_update_title_connect_error():
+async def test_update_title_connect_error(mock_client):
     """update_title returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.update_title(1, {"title": "X"})
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.update_title(1, {"title": "X"}) is None
 
 
 # --- set_ripping_enabled ---
 
 
-async def test_set_ripping_enabled_success():
+async def test_set_ripping_enabled_success(mock_client):
     """set_ripping_enabled sends POST with JSON body."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.set_ripping_enabled(True)
+    _set_request_response(mock_client, {"success": True})
+    result = await arm_client.set_ripping_enabled(True)
     assert result == {"success": True}
     mock_client.request.assert_awaited_once_with(
         "POST", "/api/v1/system/ripping-enabled", json={"enabled": True}
     )
 
 
-async def test_set_ripping_enabled_connect_error():
+async def test_set_ripping_enabled_connect_error(mock_client):
     """set_ripping_enabled returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.set_ripping_enabled(False)
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.set_ripping_enabled(False) is None
 
 
 # --- update_drive ---
 
 
-async def test_update_drive_success():
+async def test_update_drive_success(mock_client):
     """update_drive sends PATCH with JSON body."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.update_drive(3, {"name": "Drive A"})
+    _set_request_response(mock_client, {"success": True})
+    result = await arm_client.update_drive(3, {"name": "Drive A"})
     assert result == {"success": True}
     mock_client.request.assert_awaited_once_with(
         "PATCH", "/api/v1/drives/3", json={"name": "Drive A"}
     )
 
 
-async def test_update_drive_http_error():
+async def test_update_drive_http_error(mock_client):
     """update_drive returns error dict on HTTP 404."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response(
-        {"error": "Not found"}, status_code=404
-    )
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.update_drive(3, {"name": "X"})
+    _set_request_response(mock_client, {"error": "Not found"}, status_code=404)
+    result = await arm_client.update_drive(3, {"name": "X"})
     assert result is not None
     assert result["success"] is False
 
@@ -172,115 +168,90 @@ async def test_update_drive_http_error():
 # --- pause_waiting_job ---
 
 
-async def test_pause_waiting_job_success():
+async def test_pause_waiting_job_success(mock_client):
     """pause_waiting_job returns JSON on success."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True, "paused": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.pause_waiting_job(42)
+    _set_request_response(mock_client, {"success": True, "paused": True})
+    result = await arm_client.pause_waiting_job(42)
     assert result == {"success": True, "paused": True}
     mock_client.request.assert_awaited_once_with("POST", "/api/v1/jobs/42/pause")
 
 
-async def test_pause_waiting_job_connect_error():
+async def test_pause_waiting_job_connect_error(mock_client):
     """pause_waiting_job returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.pause_waiting_job(42)
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.pause_waiting_job(42) is None
 
 
 # --- search_metadata (direct httpx, not _request) ---
 
 
-async def test_search_metadata_success():
+async def test_search_metadata_success(mock_client):
     """search_metadata returns list of results."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        [{"title": "Matrix", "year": "1999"}])
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.search_metadata("Matrix")
+    _set_get_response(mock_client, [{"title": "Matrix", "year": "1999"}])
+    result = await arm_client.search_metadata("Matrix")
     assert result == [{"title": "Matrix", "year": "1999"}]
-    # Verify year not included in params when None
     call_kwargs = mock_client.get.call_args
     assert "year" not in call_kwargs[1].get("params", {})
 
 
-async def test_search_metadata_with_year():
+async def test_search_metadata_with_year(mock_client):
     """search_metadata includes year param when provided."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response([])
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        await arm_client.search_metadata("Matrix", year="1999")
+    _set_get_response(mock_client, [])
+    await arm_client.search_metadata("Matrix", year="1999")
     call_kwargs = mock_client.get.call_args
     assert call_kwargs[1]["params"]["year"] == "1999"
 
 
-async def test_search_metadata_raises_on_error():
+async def test_search_metadata_raises_on_error(mock_client):
     """search_metadata raises HTTPStatusError on 5xx."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response({}, status_code=503)
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        with pytest.raises(httpx.HTTPStatusError):
-            await arm_client.search_metadata("Matrix")
+    _set_get_response(mock_client, {}, status_code=503)
+    with pytest.raises(httpx.HTTPStatusError):
+        await arm_client.search_metadata("Matrix")
 
 
 # --- get_media_detail ---
 
 
-async def test_get_media_detail_success():
+async def test_get_media_detail_success(mock_client):
     """get_media_detail returns detail dict on 200."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        {"title": "Matrix", "imdb_id": "tt0133093"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_media_detail("tt0133093")
+    _set_get_response(mock_client, {"title": "Matrix", "imdb_id": "tt0133093"})
+    result = await arm_client.get_media_detail("tt0133093")
     assert result["title"] == "Matrix"
 
 
-async def test_get_media_detail_404_returns_none():
+async def test_get_media_detail_404_returns_none(mock_client):
     """get_media_detail returns None on 404 (not found)."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = 404
     resp.json.return_value = {}
-    resp.raise_for_status = MagicMock()  # not called — 404 handled before
+    resp.raise_for_status = MagicMock()
     mock_client.get.return_value = resp
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_media_detail("tt9999999")
+    result = await arm_client.get_media_detail("tt9999999")
     assert result is None
 
 
-async def test_get_media_detail_raises_on_500():
+async def test_get_media_detail_raises_on_500(mock_client):
     """get_media_detail raises on 500 (not 404)."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response({}, status_code=500)
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        with pytest.raises(httpx.HTTPStatusError):
-            await arm_client.get_media_detail("tt0133093")
+    _set_get_response(mock_client, {}, status_code=500)
+    with pytest.raises(httpx.HTTPStatusError):
+        await arm_client.get_media_detail("tt0133093")
 
 
 # --- search_music_metadata ---
 
 
-async def test_search_music_metadata_success():
+async def test_search_music_metadata_success(mock_client):
     """search_music_metadata returns results."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        {"results": [{"title": "Master of Puppets"}], "total": 1})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.search_music_metadata("Metallica")
+    _set_get_response(mock_client, {"results": [{"title": "Master of Puppets"}], "total": 1})
+    result = await arm_client.search_music_metadata("Metallica")
     assert result["total"] == 1
 
 
-async def test_search_music_metadata_filters_none_kwargs():
+async def test_search_music_metadata_filters_none_kwargs(mock_client):
     """search_music_metadata excludes None kwargs from params."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response({"results": [], "total": 0})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        await arm_client.search_music_metadata(
-            "Metallica", artist="Metallica", format=None, country="US")
+    _set_get_response(mock_client, {"results": [], "total": 0})
+    await arm_client.search_music_metadata(
+        "Metallica", artist="Metallica", format=None, country="US")
     call_kwargs = mock_client.get.call_args
     params = call_kwargs[1]["params"]
     assert params["artist"] == "Metallica"
@@ -288,12 +259,10 @@ async def test_search_music_metadata_filters_none_kwargs():
     assert "format" not in params
 
 
-async def test_search_music_metadata_converts_to_str():
+async def test_search_music_metadata_converts_to_str(mock_client):
     """search_music_metadata converts non-string kwargs to str."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response({"results": [], "total": 0})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        await arm_client.search_music_metadata("test", offset=25)
+    _set_get_response(mock_client, {"results": [], "total": 0})
+    await arm_client.search_music_metadata("test", offset=25)
     call_kwargs = mock_client.get.call_args
     params = call_kwargs[1]["params"]
     assert params["offset"] == "25"
@@ -302,183 +271,143 @@ async def test_search_music_metadata_converts_to_str():
 # --- get_music_detail ---
 
 
-async def test_get_music_detail_success():
+async def test_get_music_detail_success(mock_client):
     """get_music_detail returns detail dict on 200."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        {"title": "Master of Puppets", "artist": "Metallica"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_music_detail("mbid-123")
+    _set_get_response(mock_client, {"title": "Master of Puppets", "artist": "Metallica"})
+    result = await arm_client.get_music_detail("mbid-123")
     assert result["title"] == "Master of Puppets"
 
 
-async def test_get_music_detail_404_returns_none():
+async def test_get_music_detail_404_returns_none(mock_client):
     """get_music_detail returns None on 404."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = 404
     resp.json.return_value = {}
     resp.raise_for_status = MagicMock()
     mock_client.get.return_value = resp
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_music_detail("bad-mbid")
+    result = await arm_client.get_music_detail("bad-mbid")
     assert result is None
 
 
 # --- lookup_crc ---
 
 
-async def test_lookup_crc_success():
+async def test_lookup_crc_success(mock_client):
     """lookup_crc returns CRC result dict."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        {"found": True, "results": [{"title": "Matrix"}], "has_api_key": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.lookup_crc("abc123")
+    _set_get_response(mock_client, {"found": True, "results": [{"title": "Matrix"}], "has_api_key": True})
+    result = await arm_client.lookup_crc("abc123")
     assert result["found"] is True
     mock_client.get.assert_awaited_once_with("/api/v1/metadata/crc/abc123")
 
 
-async def test_lookup_crc_raises_on_error():
+async def test_lookup_crc_raises_on_error(mock_client):
     """lookup_crc raises HTTPStatusError on failure."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response({}, status_code=500)
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        with pytest.raises(httpx.HTTPStatusError):
-            await arm_client.lookup_crc("abc123")
+    _set_get_response(mock_client, {}, status_code=500)
+    with pytest.raises(httpx.HTTPStatusError):
+        await arm_client.lookup_crc("abc123")
 
 
 # --- test_metadata_key ---
 
 
-async def test_metadata_key_success():
+async def test_metadata_key_success(mock_client):
     """test_metadata_key returns result dict."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        {"success": True, "message": "OMDb key valid", "provider": "omdb"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.test_metadata_key()
+    _set_get_response(mock_client, {"success": True, "message": "OMDb key valid", "provider": "omdb"})
+    result = await arm_client.test_metadata_key()
     assert result["success"] is True
     mock_client.get.assert_awaited_once_with("/api/v1/metadata/test-key", params={})
 
 
-async def test_metadata_key_with_key_and_provider():
+async def test_metadata_key_with_key_and_provider(mock_client):
     """test_metadata_key includes key and provider in params when provided."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response(
-        {"success": True, "message": "Key valid", "provider": "tmdb"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.test_metadata_key(key="abc123", provider="tmdb")
+    _set_get_response(mock_client, {"success": True, "message": "Key valid", "provider": "tmdb"})
+    result = await arm_client.test_metadata_key(key="abc123", provider="tmdb")
     assert result["success"] is True
     mock_client.get.assert_awaited_once_with(
         "/api/v1/metadata/test-key", params={"key": "abc123", "provider": "tmdb"})
 
 
-async def test_metadata_key_raises_on_error():
+async def test_metadata_key_raises_on_error(mock_client):
     """test_metadata_key raises HTTPStatusError on failure."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.get.return_value = _mock_response({}, status_code=502)
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        with pytest.raises(httpx.HTTPStatusError):
-            await arm_client.test_metadata_key()
+    _set_get_response(mock_client, {}, status_code=502)
+    with pytest.raises(httpx.HTTPStatusError):
+        await arm_client.test_metadata_key()
 
 
 # --- get_setup_status ---
 
 
-async def test_get_setup_status_success():
+async def test_get_setup_status_success(mock_client):
     """get_setup_status returns JSON on success."""
     data = {"first_run": True, "db_initialized": True}
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response(data)
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_setup_status()
+    _set_request_response(mock_client, data)
+    result = await arm_client.get_setup_status()
     assert result == data
     mock_client.request.assert_awaited_once_with("GET", "/api/v1/setup/status")
 
 
-async def test_get_setup_status_unreachable():
+async def test_get_setup_status_unreachable(mock_client):
     """get_setup_status returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_setup_status()
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.get_setup_status() is None
 
 
 # --- complete_setup ---
 
 
-async def test_complete_setup_success():
+async def test_complete_setup_success(mock_client):
     """complete_setup returns JSON on success."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.complete_setup()
+    _set_request_response(mock_client, {"success": True})
+    result = await arm_client.complete_setup()
     assert result == {"success": True}
     mock_client.request.assert_awaited_once_with("POST", "/api/v1/setup/complete")
 
 
-async def test_complete_setup_unreachable():
+async def test_complete_setup_unreachable(mock_client):
     """complete_setup returns None on ConnectError."""
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.complete_setup()
-    assert result is None
+    _set_request_connect_error(mock_client)
+    assert await arm_client.complete_setup() is None
 
 
 # --- eject_drive ---
 
 
-async def test_eject_drive_success():
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True, "method": "eject"})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.eject_drive(1, "eject")
+async def test_eject_drive_success(mock_client):
+    _set_request_response(mock_client, {"success": True, "method": "eject"})
+    result = await arm_client.eject_drive(1, "eject")
     assert result["success"] is True
     mock_client.request.assert_awaited_once()
 
 
-async def test_eject_drive_unreachable():
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        assert await arm_client.eject_drive(1) is None
+async def test_eject_drive_unreachable(mock_client):
+    _set_request_connect_error(mock_client)
+    assert await arm_client.eject_drive(1) is None
 
 
 # --- get_job_stats ---
 
 
-async def test_get_job_stats_success():
+async def test_get_job_stats_success(mock_client):
     data = {"by_status": {"success": 5}, "by_type": {"movie": 3}, "total": 5}
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response(data)
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.get_job_stats()
+    _set_request_response(mock_client, data)
+    result = await arm_client.get_job_stats()
     assert result["total"] == 5
 
 
-async def test_get_job_stats_unreachable():
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        assert await arm_client.get_job_stats() is None
+async def test_get_job_stats_unreachable(mock_client):
+    _set_request_connect_error(mock_client)
+    assert await arm_client.get_job_stats() is None
 
 
 # --- restart_arm ---
 
 
-async def test_restart_arm_success():
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.return_value = _mock_response({"success": True})
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        result = await arm_client.restart_arm()
+async def test_restart_arm_success(mock_client):
+    _set_request_response(mock_client, {"success": True})
+    result = await arm_client.restart_arm()
     assert result["success"] is True
 
 
-async def test_restart_arm_unreachable():
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.request.side_effect = httpx.ConnectError("refused")
-    with patch.object(arm_client, "get_client", return_value=mock_client):
-        assert await arm_client.restart_arm() is None
+async def test_restart_arm_unreachable(mock_client):
+    _set_request_connect_error(mock_client)
+    assert await arm_client.restart_arm() is None

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -46,6 +46,28 @@ async def test_abandon_job_connect_error():
     assert result is None
 
 
+# --- skip_and_finalize ---
+
+
+async def test_skip_and_finalize_success():
+    """skip_and_finalize returns JSON on success."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.request.return_value = _mock_response({"success": True, "message": "Job finalized"})
+    with patch.object(arm_client, "get_client", return_value=mock_client):
+        result = await arm_client.skip_and_finalize(7)
+    assert result == {"success": True, "message": "Job finalized"}
+    mock_client.request.assert_awaited_once_with("POST", "/api/v1/jobs/7/skip-and-finalize")
+
+
+async def test_skip_and_finalize_connect_error():
+    """skip_and_finalize returns None on ConnectError."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.request.side_effect = httpx.ConnectError("refused")
+    with patch.object(arm_client, "get_client", return_value=mock_client):
+        result = await arm_client.skip_and_finalize(7)
+    assert result is None
+
+
 # --- get_config ---
 
 


### PR DESCRIPTION
## Summary

Adds UI controls for the re-introduced SKIP_TRANSCODE feature:

- Surface `SKIP_TRANSCODE` in settings schema
- Review panel: per-job "Skip Transcoding" toggle (hides TranscodeOverrides when enabled)
- Job detail page: "Skip Transcode & Finalize" button for stuck TRANSCODE_WAITING/TRANSCODE_ACTIVE jobs
- Settings page: global SKIP_TRANSCODE toggle in Post-Rip section (dims PresetEditor when enabled)
- Full proxy chain for skip-and-finalize (arm_client → router → frontend API)

## Related PRs

- NEU: uprightbass360/automatic-ripping-machine-neu#231
- Transcoder: uprightbass360/automatic-ripping-machine-transcoder#79

## Test plan

- [x] svelte-check passes (0 errors, 0 warnings)
- [x] 644 backend tests pass
- [x] Review panel toggle persists per-job SKIP_TRANSCODE
- [x] Skip & Finalize button only shows for stuck transcode jobs
- [x] Settings page toggle dims PresetEditor when active