### PR TITLE
feat: support {show} and {episode_name} naming variables in UI

### DIFF
--- a/frontend/src/lib/components/RipSettings.svelte
+++ b/frontend/src/lib/components/RipSettings.svelte
@@ -38,8 +38,8 @@
 		if (vtype === 'series') {
 			return {
 				label: 'TV',
-				title: config.TV_TITLE_PATTERN ?? '{title} S{season}E{episode}',
-				folder: config.TV_FOLDER_PATTERN ?? '{title}/Season {season}',
+				title: config.TV_TITLE_PATTERN ?? '{show} S{season}E{episode}',
+				folder: config.TV_FOLDER_PATTERN ?? '{show}/Season {season}',
 				titleKey: 'TV_TITLE_PATTERN',
 				folderKey: 'TV_FOLDER_PATTERN',
 			};

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1247,8 +1247,8 @@
 			{#if key.endsWith('_PATTERN') && settings?.naming_variables}
 				{@const patternVars = Object.entries(settings.naming_variables).filter(([v]) => {
 					if (key.startsWith('MUSIC_')) return ['title', 'year', 'artist', 'album', 'label'].includes(v);
-					if (key.startsWith('TV_')) return ['title', 'year', 'season', 'episode', 'label', 'video_type'].includes(v);
-					return ['title', 'year', 'label', 'video_type'].includes(v);
+					if (key.startsWith('TV_')) return ['show', 'title', 'year', 'season', 'episode', 'episode_name', 'label', 'video_type', 'disc_number', 'disc_total'].includes(v);
+					return ['title', 'year', 'label', 'video_type', 'disc_number', 'disc_total'].includes(v);
 				})}
 				<div class="mt-1.5 flex flex-wrap gap-1">
 					{#each patternVars as [varName, varDesc]}


### PR DESCRIPTION
## Summary

Updates the UI to support the new `{show}` and `{episode_name}` naming pattern variables added in NEU PR #236.

- Settings page: TV pattern variable tags now include `{show}`, `{episode_name}`, `{disc_number}`, `{disc_total}`
- RipSettings component: default TV pattern fallback uses `{show}` instead of `{title}`
- Movie patterns also gain `{disc_number}`, `{disc_total}`

## Related PRs

- NEU: uprightbass360/automatic-ripping-machine-neu#236

## Test plan

- [x] svelte-check: 0 errors, 0 warnings
- [x] Existing tests pass (patterns come from config, not hard-coded defaults)