### PR TITLE
feat: confirmation dialog before skip-and-finalize

### DIFF
--- a/frontend/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/src/lib/components/ConfirmDialog.svelte
@@ -24,6 +24,17 @@
 			? 'confirm-btn-danger'
 			: 'confirm-btn-primary'
 	);
+
+	$effect(() => {
+		if (!open) return;
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				oncancel();
+			}
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	});
 </script>
 
 {#if open}
@@ -37,8 +48,8 @@
 		></button>
 
 		<!-- Dialog -->
-		<div class="relative z-10 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-surface-dark" data-dialog>
-			<h3 class="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+		<div class="relative z-10 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-surface-dark" data-dialog role="dialog" aria-modal="true" aria-labelledby="dialog-title">
+			<h3 id="dialog-title" class="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
 			<p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{message}</p>
 			<div class="mt-4 flex justify-end gap-3">
 				<button

--- a/frontend/src/lib/components/ConfirmDialog.test.ts
+++ b/frontend/src/lib/components/ConfirmDialog.test.ts
@@ -77,5 +77,12 @@ describe('ConfirmDialog', () => {
 			await fireEvent.click(screen.getByLabelText('Close dialog'));
 			expect(oncancel).toHaveBeenCalledOnce();
 		});
+
+		it('calls oncancel when Escape is pressed', async () => {
+			const oncancel = vi.fn();
+			renderDialog({ oncancel });
+			await fireEvent.keyDown(window, { key: 'Escape' });
+			expect(oncancel).toHaveBeenCalledOnce();
+		});
 	});
 });

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -347,7 +347,7 @@
 							{retranscoding ? 'Queuing...' : 'Re-transcode'}
 						</button>
 					{/if}
-					{#if job.status === 'waiting_transcode' || job.status === 'transcoding'}
+					{#if job.status === 'waiting_transcode'}
 						<button
 							onclick={() => (showSkipConfirm = true)}
 							disabled={skippingTranscode}
@@ -355,6 +355,8 @@
 						>
 							{skippingTranscode ? 'Finalizing...' : 'Skip Transcode & Finalize'}
 						</button>
+					{/if}
+					{#if job.status === 'waiting_transcode' || job.status === 'transcoding'}
 						<button
 							onclick={handleForceComplete}
 							disabled={forcingComplete}
@@ -755,7 +757,7 @@
 	open={showSkipConfirm}
 	title="Skip transcoding and finalize?"
 	message="The raw ripped files will be moved from the raw directory to the completed directory as-is. No transcoding will be applied. This cannot be undone."
-	confirmLabel="Yes, Skip Transcode"
+	confirmLabel="Yes, Skip & Finalize"
 	variant="danger"
 	onconfirm={confirmSkipAndFinalize}
 	oncancel={() => (showSkipConfirm = false)}

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -9,6 +9,7 @@
 	import { fetchStructuredTranscoderLogContent, fetchTranscoderLogForArmJob } from '$lib/api/logs';
 	import type { JobDetail, MusicDetail } from '$lib/types/arm';
 	import JobActions from '$lib/components/JobActions.svelte';
+	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import StatusBadge from '$lib/components/StatusBadge.svelte';
 	import TitleSearch from '$lib/components/TitleSearch.svelte';
 	import MusicSearch from '$lib/components/MusicSearch.svelte';
@@ -101,8 +102,14 @@
 
 	let skippingTranscode = $state(false);
 	let skipTranscodeFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
+	let showSkipConfirm = $state(false);
 	let forcingComplete = $state(false);
 	let forceCompleteFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
+
+	async function confirmSkipAndFinalize() {
+		showSkipConfirm = false;
+		await handleSkipAndFinalize();
+	}
 
 	async function handleSkipAndFinalize() {
 		if (!job) return;
@@ -342,7 +349,7 @@
 					{/if}
 					{#if job.status === 'waiting_transcode' || job.status === 'transcoding'}
 						<button
-							onclick={handleSkipAndFinalize}
+							onclick={() => (showSkipConfirm = true)}
 							disabled={skippingTranscode}
 							class="rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
 						>
@@ -743,3 +750,13 @@
 		{/if}
 	</div>
 {/if}
+
+<ConfirmDialog
+	open={showSkipConfirm}
+	title="Skip transcoding and finalize?"
+	message="The raw ripped files will be moved from the raw directory to the completed directory as-is. No transcoding will be applied. This cannot be undone."
+	confirmLabel="Yes, Skip Transcode"
+	variant="danger"
+	onconfirm={confirmSkipAndFinalize}
+	oncancel={() => (showSkipConfirm = false)}
+/>

--- a/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/frontend/src/routes/jobs/[id]/page.test.ts
@@ -133,7 +133,7 @@ async function clickSkipButton(status = 'waiting_transcode') {
 	await fireEvent.click(btn);
 	// The skip button now opens a confirmation dialog. Click the dialog's confirm
 	// button to actually invoke the API.
-	const confirmBtn = await screen.findByText('Yes, Skip Transcode');
+	const confirmBtn = await screen.findByText(/yes.*skip.*finalize/i);
 	await fireEvent.click(confirmBtn);
 }
 
@@ -145,15 +145,20 @@ describe('Job detail page — skip transcode', () => {
 		vi.clearAllMocks();
 	});
 
-	it.each(['waiting_transcode', 'transcoding'])(
-		'shows Skip Transcode & Finalize button for %s status',
-		async (status) => {
-			renderWithStatus(status);
-			await waitFor(() => {
-				expect(screen.getByText(SKIP_BTN)).toBeInTheDocument();
-			});
-		}
-	);
+	it('shows Skip Transcode & Finalize button for waiting_transcode status', async () => {
+		renderWithStatus('waiting_transcode');
+		await waitFor(() => {
+			expect(screen.getByText(SKIP_BTN)).toBeInTheDocument();
+		});
+	});
+
+	it('does NOT show skip button for transcoding status (backend would 409)', async () => {
+		renderWithStatus('transcoding');
+		await waitFor(() => {
+			expect(screen.getByText('Dashboard')).toBeInTheDocument();
+		});
+		expect(screen.queryByText(SKIP_BTN)).not.toBeInTheDocument();
+	});
 
 	it('does NOT show skip button for other statuses', async () => {
 		renderWithStatus('success');
@@ -219,7 +224,7 @@ describe('Job detail page — skip transcode confirmation dialog', () => {
 
 		// Click the dialog's confirm button (distinct label so it does not collide
 		// with the page's Skip Transcode & Finalize button).
-		const confirmBtn = screen.getByText('Yes, Skip Transcode');
+		const confirmBtn = screen.getByText(/yes.*skip.*finalize/i);
 		await fireEvent.click(confirmBtn);
 
 		await waitFor(() => {

--- a/frontend/src/routes/jobs/[id]/page.test.ts
+++ b/frontend/src/routes/jobs/[id]/page.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { renderComponent, screen, fireEvent, cleanup, waitFor } from '$lib/test-utils';
+import { renderComponent, screen, fireEvent, cleanup, waitFor, within } from '$lib/test-utils';
 import Page from './+page.svelte';
 import type { JobDetail } from '$lib/types/arm';
 
@@ -126,11 +126,15 @@ function renderWithStatus(status: string) {
 	renderComponent(Page);
 }
 
-/** Render, wait for the skip button to appear, then click it. */
+/** Render, wait for the skip button to appear, click it, then confirm the dialog. */
 async function clickSkipButton(status = 'waiting_transcode') {
 	renderWithStatus(status);
 	const btn = await screen.findByText('Skip Transcode & Finalize');
 	await fireEvent.click(btn);
+	// The skip button now opens a confirmation dialog. Click the dialog's confirm
+	// button to actually invoke the API.
+	const confirmBtn = await screen.findByText('Yes, Skip Transcode');
+	await fireEvent.click(confirmBtn);
 }
 
 const SKIP_BTN = 'Skip Transcode & Finalize';
@@ -193,6 +197,58 @@ describe('Job detail page — skip transcode', () => {
 			expect(screen.getByText('Finalizing...')).toBeInTheDocument();
 		});
 		expect(screen.getByText('Finalizing...').closest('button')).toBeDisabled();
+	});
+});
+
+describe('Job detail page — skip transcode confirmation dialog', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('does not call the API until the user confirms', async () => {
+		renderWithStatus('waiting_transcode');
+		const skipBtn = await screen.findByText(SKIP_BTN);
+		await fireEvent.click(skipBtn);
+
+		// API must not be called yet - dialog must appear first.
+		expect(mockSkipAndFinalize).not.toHaveBeenCalled();
+
+		// Dialog is rendered with an explanatory title.
+		expect(screen.getByText(/skip transcoding and finalize\?/i)).toBeInTheDocument();
+
+		// Click the dialog's confirm button (distinct label so it does not collide
+		// with the page's Skip Transcode & Finalize button).
+		const confirmBtn = screen.getByText('Yes, Skip Transcode');
+		await fireEvent.click(confirmBtn);
+
+		await waitFor(() => {
+			expect(mockSkipAndFinalize).toHaveBeenCalledOnce();
+		});
+		expect(mockSkipAndFinalize).toHaveBeenCalledWith(42);
+	});
+
+	it('cancels without calling the API', async () => {
+		renderWithStatus('waiting_transcode');
+		const skipBtn = await screen.findByText(SKIP_BTN);
+		await fireEvent.click(skipBtn);
+
+		// Dialog appears.
+		const dialogTitle = await screen.findByText(/skip transcoding and finalize\?/i);
+		expect(dialogTitle).toBeInTheDocument();
+
+		// Cancel the dialog. Use within() to scope to the dialog, in case any
+		// other cancel buttons exist elsewhere on the page.
+		const dialog = dialogTitle.closest('[data-dialog]') as HTMLElement;
+		expect(dialog).not.toBeNull();
+		const cancelBtn = within(dialog).getByText('Cancel');
+		await fireEvent.click(cancelBtn);
+
+		expect(mockSkipAndFinalize).not.toHaveBeenCalled();
+		// Dialog is dismissed.
+		await waitFor(() => {
+			expect(screen.queryByText(/skip transcoding and finalize\?/i)).not.toBeInTheDocument();
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

- Adds a confirmation dialog before Skip Transcode & Finalize fires the API. Prevents one-click triggering of a destructive, irreversible action.
- Only renders the Skip button for jobs in `waiting_transcode` (Force Complete still renders for both `waiting_transcode` and `transcoding`, since the companion arm-neu PR now 409s on `transcoding` and showing a button that always errors is bad UX).
- ConfirmDialog gets Escape-to-close, `role=\"dialog\"`, `aria-modal`, `aria-labelledby`.

Companion backend PR: [arm-neu#xxx](https://github.com/uprightbass360/automatic-ripping-machine-neu/pull/) (update link once known).

Spec reference: item 2 of 2026-04-21-preset-system-hardening-design.md

## Test plan

- [x] `npm test page.test --run` - 131 passed
- [x] `npm test ConfirmDialog.test --run` - 10 passed (includes new Escape test)
- [x] `npm test --run` - 796 passed, no regressions
- [ ] Manual: on a TRANSCODE_WAITING job, click Skip Transcode & Finalize, verify dialog opens
- [ ] Manual: click Cancel / press Escape, verify dialog closes without calling API
- [ ] Manual: click Yes, Skip & Finalize, verify API fires
- [ ] Manual: on a TRANSCODE_ACTIVE job, verify Skip button is NOT rendered