### PR TITLE
fix: strip legacy transcode_overrides keys on read

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, field_validator
+
+from backend.services.arm_db import TRANSCODE_OVERRIDES_ALLOWLIST
+
+log = logging.getLogger(__name__)
 
 
 # --- ARM Job Schemas ---
@@ -99,14 +104,28 @@ class JobSchema(BaseModel):
     def _parse_transcode_overrides(cls, v: Any) -> dict | None:
         if v is None:
             return None
-        if isinstance(v, dict):
-            return v
         if isinstance(v, str):
             try:
-                return json.loads(v)
+                parsed = json.loads(v)
             except (json.JSONDecodeError, TypeError):
                 return None
-        return None
+        elif isinstance(v, dict):
+            parsed = v
+        else:
+            return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        offending = set(parsed.keys()) - TRANSCODE_OVERRIDES_ALLOWLIST
+        if offending:
+            log.warning(
+                "Stripping legacy transcode_overrides keys: %s",
+                sorted(offending),
+            )
+            return {k: v for k, v in parsed.items() if k in TRANSCODE_OVERRIDES_ALLOWLIST}
+
+        return parsed
 
     artist: str | None = None
     artist_auto: str | None = None

--- a/backend/services/arm_db.py
+++ b/backend/services/arm_db.py
@@ -522,6 +522,58 @@ def get_ripping_paused() -> bool:
         return False
 
 
+# Allowlisted top-level keys in transcode_overrides JSON after the preset
+# rollout. Anything outside this set is legacy flat-key shape and is
+# stripped on read with a WARN log. Must match the arm-neu Alembic
+# migration o0p1q2r3s4t5_transcode_overrides_drop_legacy and the
+# transcoder's expected webhook shape.
+TRANSCODE_OVERRIDES_ALLOWLIST: frozenset[str] = frozenset({
+    "preset_slug",
+    "overrides",
+    "delete_source",
+    "output_extension",
+})
+
+
+def _filter_transcode_overrides(raw: str | None, job_id: int) -> dict | None:
+    """Parse and filter transcode_overrides JSON, stripping legacy keys.
+
+    Returns the filtered dict, or None if the input is null, malformed,
+    or not a JSON object. Logs a WARN naming the stripped keys when any
+    are removed, and on malformed or non-dict JSON.
+    """
+    import json as _json
+
+    if raw is None:
+        return None
+
+    try:
+        parsed = _json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        log.warning(
+            "Malformed transcode_overrides JSON on job_id=%s: %s",
+            job_id, exc,
+        )
+        return None
+
+    if not isinstance(parsed, dict):
+        log.warning(
+            "transcode_overrides on job_id=%s is not a JSON object (got %s); dropping",
+            job_id, type(parsed).__name__,
+        )
+        return None
+
+    offending = set(parsed.keys()) - TRANSCODE_OVERRIDES_ALLOWLIST
+    if offending:
+        log.warning(
+            "Stripping legacy transcode_overrides keys on job_id=%s: %s",
+            job_id, sorted(offending),
+        )
+        return {k: v for k, v in parsed.items() if k in TRANSCODE_OVERRIDES_ALLOWLIST}
+
+    return parsed
+
+
 def get_job_retranscode_info(job_id: int) -> dict | None:
     """Build a webhook-shaped payload for re-transcoding an ARM job.
 
@@ -539,14 +591,13 @@ def get_job_retranscode_info(job_id: int) -> dict | None:
             title = job.title or job.title_auto or job.label or "Unknown"
             year = job.year or job.year_auto or ""
 
-            # Parse transcode overrides if present
-            config_overrides = None
-            if getattr(job, 'transcode_overrides', None):
-                import json as _json
-                try:
-                    config_overrides = _json.loads(job.transcode_overrides)
-                except (ValueError, TypeError):
-                    pass
+            # Parse and filter transcode_overrides. Legacy flat-key shapes
+            # (pre-preset-rollout) are stripped with a WARN log so the UI
+            # and downstream transcoder never see keys outside the
+            # allowlist. See TRANSCODE_OVERRIDES_ALLOWLIST above.
+            config_overrides = _filter_transcode_overrides(
+                getattr(job, 'transcode_overrides', None), job.job_id
+            )
 
             payload = {
                 "title": title,
@@ -583,14 +634,6 @@ def get_job_retranscode_info(job_id: int) -> dict | None:
         return None
 
 
-TRANSCODE_OVERRIDE_KEYS = {
-    "preset_slug",
-    "overrides",
-    "delete_source",
-    "output_extension",
-}
-
-
 def _coerce_override(key: str, value) -> tuple[str, object] | None:
     """Coerce a single transcode override value. Returns None to skip."""
     if value is None or value == "":
@@ -616,7 +659,7 @@ def update_job_transcode_overrides(job_id: int, overrides: dict) -> dict | None:
     import json as _json
 
     # Validate keys
-    invalid = set(overrides.keys()) - TRANSCODE_OVERRIDE_KEYS
+    invalid = set(overrides.keys()) - TRANSCODE_OVERRIDES_ALLOWLIST
     if invalid:
         raise ValueError(f"Unknown keys: {', '.join(sorted(invalid))}")
 

--- a/tests/services/test_arm_db_shape_filter.py
+++ b/tests/services/test_arm_db_shape_filter.py
@@ -158,3 +158,43 @@ def test_allowlist_matches_migration_shape():
     """Constant must match the arm-neu migration's 4-key allowlist."""
     expected = frozenset({"preset_slug", "overrides", "delete_source", "output_extension"})
     assert frozenset(arm_db.TRANSCODE_OVERRIDES_ALLOWLIST) == expected
+
+
+def test_job_schema_validator_strips_legacy_transcode_overrides(caplog):
+    """JobSchema._parse_transcode_overrides filters legacy flat keys on read.
+
+    This is a parallel read site to arm_db.get_job_retranscode_info: any
+    endpoint that serializes a Job through JobSchema (e.g. job list, job
+    detail) must not leak old-shape keys like video_encoder or
+    handbrake_preset* to the frontend.
+    """
+    import json as _json
+
+    from backend.models.schemas import JobSchema
+
+    old_shape = {
+        "video_encoder": "nvenc_h265",
+        "handbrake_preset": "Foo",
+        "handbrake_preset_dvd": "Bar",
+        "preset_slug": "nvidia_balanced",  # keep this one
+        "delete_source": True,  # keep
+    }
+
+    with caplog.at_level(logging.WARNING, logger="backend.models.schemas"):
+        schema = JobSchema.model_validate(
+            {"job_id": 42, "transcode_overrides": _json.dumps(old_shape)}
+        )
+
+    assert schema.transcode_overrides == {
+        "preset_slug": "nvidia_balanced",
+        "delete_source": True,
+    }
+    assert "video_encoder" not in schema.transcode_overrides
+    assert "handbrake_preset" not in schema.transcode_overrides
+    assert "handbrake_preset_dvd" not in schema.transcode_overrides
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARN log naming stripped keys"
+    messages = "\n".join(r.getMessage() for r in warnings)
+    assert "video_encoder" in messages
+    assert "handbrake_preset" in messages

--- a/tests/services/test_arm_db_shape_filter.py
+++ b/tests/services/test_arm_db_shape_filter.py
@@ -1,0 +1,160 @@
+"""Tests for transcode_overrides shape filtering in arm_db.get_job_retranscode_info.
+
+Old-shape keys (pre-preset-rollout flat keys like video_encoder,
+handbrake_preset*) must be stripped on read with a WARN log. Allowlist:
+{preset_slug, overrides, delete_source, output_extension}.
+
+Belt-and-braces guard: the arm-neu Alembic migration NULLs old-shape rows
+on upgrade, but rollback, snapshot-restore, or future shape drift could
+reintroduce them. This filter strips unknown keys on read so the UI and
+the transcoder never see shapes the transcoder can't interpret.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+from backend.services import arm_db
+from tests.factories import make_job
+
+
+def _patched_session(job):
+    """Build a context-manager mock for arm_db.get_session returning `job`."""
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=ctx)
+    ctx.__exit__ = MagicMock(return_value=False)
+    ctx.scalars.return_value.unique.return_value.first.return_value = job
+    return ctx
+
+
+def test_old_shape_keys_stripped_with_warning(caplog):
+    """Legacy flat keys are removed from config_overrides; WARN names them."""
+    old_shape = {
+        "video_encoder": "nvenc_h265",
+        "handbrake_preset": "Foo",
+        "handbrake_preset_dvd": "Bar",
+        "preset_slug": "nvidia_balanced",  # keep this one
+    }
+    job = make_job(
+        job_id=42, disctype="bluray",
+        transcode_overrides=json.dumps(old_shape),
+        multi_title=False,
+    )
+    job.tracks = []
+
+    with patch.object(arm_db, "get_session", return_value=_patched_session(job)), \
+         caplog.at_level(logging.WARNING, logger="backend.services.arm_db"):
+        result = arm_db.get_job_retranscode_info(42)
+
+    assert result is not None
+    config_overrides = result["config_overrides"]
+    assert config_overrides == {"preset_slug": "nvidia_balanced"}
+    assert "video_encoder" not in config_overrides
+    assert "handbrake_preset" not in config_overrides
+    assert "handbrake_preset_dvd" not in config_overrides
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARN log naming stripped keys"
+    messages = "\n".join(r.getMessage() for r in warnings)
+    assert "42" in messages, "WARN must reference the job_id"
+    assert "video_encoder" in messages
+    assert "handbrake_preset" in messages
+
+
+def test_new_shape_unchanged(caplog):
+    """Pure new-shape values pass through untouched with no WARN."""
+    new_shape = {
+        "preset_slug": "amd_balanced",
+        "overrides": {"shared": {"video_quality": 20}},
+        "delete_source": True,
+        "output_extension": "mkv",
+    }
+    job = make_job(
+        job_id=7, disctype="dvd",
+        transcode_overrides=json.dumps(new_shape),
+        multi_title=False,
+    )
+    job.tracks = []
+
+    with patch.object(arm_db, "get_session", return_value=_patched_session(job)), \
+         caplog.at_level(logging.WARNING, logger="backend.services.arm_db"):
+        result = arm_db.get_job_retranscode_info(7)
+
+    assert result is not None
+    assert result["config_overrides"] == new_shape
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [], (
+        "no WARN logs expected for pure new-shape values; got: "
+        + "; ".join(r.getMessage() for r in warnings)
+    )
+
+
+def test_null_transcode_overrides_no_warning(caplog):
+    """NULL column yields config_overrides=None with no WARN."""
+    job = make_job(
+        job_id=3, disctype="dvd",
+        transcode_overrides=None,
+        multi_title=False,
+    )
+    job.tracks = []
+
+    with patch.object(arm_db, "get_session", return_value=_patched_session(job)), \
+         caplog.at_level(logging.WARNING, logger="backend.services.arm_db"):
+        result = arm_db.get_job_retranscode_info(3)
+
+    assert result is not None
+    assert result["config_overrides"] is None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == []
+
+
+def test_malformed_json_returns_none_with_warning(caplog):
+    """Malformed JSON does not raise; config_overrides falls back to None + WARN."""
+    job = make_job(
+        job_id=9, disctype="bluray",
+        transcode_overrides="not valid json {",
+        multi_title=False,
+    )
+    job.tracks = []
+
+    with patch.object(arm_db, "get_session", return_value=_patched_session(job)), \
+         caplog.at_level(logging.WARNING, logger="backend.services.arm_db"):
+        result = arm_db.get_job_retranscode_info(9)
+
+    assert result is not None
+    assert result["config_overrides"] is None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) >= 1
+    messages = "\n".join(r.getMessage() for r in warnings)
+    assert "9" in messages, "WARN should reference the job_id"
+
+
+def test_non_dict_json_returns_none_with_warning(caplog):
+    """JSON value that isn't an object (e.g. list) is treated as malformed."""
+    job = make_job(
+        job_id=11, disctype="bluray",
+        transcode_overrides=json.dumps(["not", "a", "dict"]),
+        multi_title=False,
+    )
+    job.tracks = []
+
+    with patch.object(arm_db, "get_session", return_value=_patched_session(job)), \
+         caplog.at_level(logging.WARNING, logger="backend.services.arm_db"):
+        result = arm_db.get_job_retranscode_info(11)
+
+    assert result is not None
+    assert result["config_overrides"] is None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) >= 1
+
+
+def test_allowlist_matches_migration_shape():
+    """Constant must match the arm-neu migration's 4-key allowlist."""
+    expected = frozenset({"preset_slug", "overrides", "delete_source", "output_extension"})
+    assert frozenset(arm_db.TRANSCODE_OVERRIDES_ALLOWLIST) == expected


### PR DESCRIPTION
## Summary

- Belt-and-braces defense against old-shape \`transcode_overrides\` data reaching the UI. Companion to arm-neu PR #239 (Alembic migration that NULLs legacy rows).
- Filter unknown keys in \`get_job_retranscode_info\` and in \`JobSchema\` Pydantic validator so both read paths strip legacy keys (video_encoder, handbrake_preset*, etc.). Allowlist: \`{preset_slug, overrides, delete_source, output_extension}\`.
- Consolidated the existing \`TRANSCODE_OVERRIDE_KEYS\` (used by write-side validator) into a single \`TRANSCODE_OVERRIDES_ALLOWLIST\` shared by read and write.
- Malformed JSON and non-dict values no longer silently swallowed — now WARN logged.

Spec reference: item 6 of 2026-04-21-preset-system-hardening-design.md

## Test plan

- [x] \`pytest tests/services/test_arm_db_shape_filter.py -v\` - 7 passed (including validator test + allowlist drift guard)
- [x] \`pytest tests/\` - 661 passed, no regressions
- [ ] Manual: retranscode a job whose overrides have legacy keys; confirm the frontend only receives allowlisted fields