### PR TITLE
fix: tracks_total excludes disabled tracks

### DIFF
--- a/backend/services/arm_db.py
+++ b/backend/services/arm_db.py
@@ -99,18 +99,25 @@ def _minlength(job) -> int:
 
 
 def _rippable_tracks(job) -> list:
-    """Return tracks above minlength (the ones ARM will actually rip).
+    """Return tracks the ripper will actually rip - enabled and above minlength.
 
-    Music discs skip the minlength filter — all CD tracks are ripped
+    Filters out tracks the user (or auto-flag logic) has marked enabled=False,
+    then applies the MINLENGTH filter for video discs.
+
+    Music discs skip the minlength filter - all CD tracks are ripped
     regardless of length (MINLENGTH is a video-only setting).
+
+    Uses `is not False` so NULL/unset enabled (as in older DB rows or test
+    fixtures) still counts as enabled - existing behavior for pre-flag data.
     """
     tracks = list(job.tracks) if job.tracks else []
+    enabled = [t for t in tracks if getattr(t, "enabled", True) is not False]
     if getattr(job, "disctype", None) == "music":
-        return tracks
+        return enabled
     ml = _minlength(job)
     if ml <= 0:
-        return tracks
-    return [t for t in tracks if t.length is None or t.length >= ml]
+        return enabled
+    return [t for t in enabled if t.length is None or t.length >= ml]
 
 
 def get_active_jobs() -> list[dict]:

--- a/tests/services/test_arm_db_coverage.py
+++ b/tests/services/test_arm_db_coverage.py
@@ -227,6 +227,52 @@ def test_get_job_track_counts_no_tracks():
     assert result == {"tracks_total": 0, "tracks_ripped": 0}
 
 
+def test_get_job_track_counts_excludes_disabled_tracks():
+    """tracks_total must reflect only enabled tracks - see bug_track_count_includes_disabled."""
+    enabled_ripped = make_track(track_id=1, enabled=True, ripped=True)
+    enabled_pending = make_track(track_id=2, enabled=True, ripped=False)
+    disabled = make_track(track_id=3, enabled=False, ripped=False)
+
+    job = make_job(job_id=1)
+    job.tracks = [enabled_ripped, enabled_pending, disabled]
+
+    with patch.object(arm_db, "get_session") as mock_session:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        ctx.scalars.return_value.unique.return_value.first.return_value = job
+        mock_session.return_value = ctx
+        result = arm_db.get_job_track_counts(1)
+
+    assert result["tracks_total"] == 2, "Disabled track must not count toward total"
+    assert result["tracks_ripped"] == 1
+
+
+def test_get_active_jobs_excludes_disabled_tracks():
+    """get_active_jobs must also filter disabled tracks from tracks_total."""
+    enabled = make_track(track_id=1, enabled=True, ripped=False)
+    disabled = make_track(track_id=2, enabled=False, ripped=False)
+
+    job = MagicMock(spec=Job)
+    job.__table__ = Job.__table__
+    for col in Job.__table__.columns:
+        setattr(job, col.name, None)
+    job.job_id = 1
+    job.status = "active"
+    job.tracks = [enabled, disabled]
+
+    with patch.object(arm_db, "get_session") as mock_session:
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        ctx.scalars.return_value.unique.return_value.all.return_value = [job]
+        mock_session.return_value = ctx
+        result = arm_db.get_active_jobs()
+
+    assert result[0]["tracks_total"] == 1
+    assert result[0]["tracks_ripped"] == 0
+
+
 # --- get_drives_with_jobs ---
 
 


### PR DESCRIPTION
## Summary

- \`_rippable_tracks\` filtered by MINLENGTH but not by \`track.enabled\`. The dashboard ACTIVE RIPS card showed '7 titles' on a job where only 2 titles were actually enabled to rip.
- One-line addition to the filter + supporting tests. Both callers (get_active_jobs, get_job_track_counts) get the fix.
- Uses \`is not False\` guard so existing NULL/unset enabled fields (older rows, test fixtures without explicit enabled=True) still count as enabled.

Observed live on 2026-04-21 during Playwright validation of UI v16.0.0-rc on hifi-server.

## Test plan

- [x] \`pytest tests/services/test_arm_db_coverage.py\` - 42 passed (2 new tests for enabled filter)
- [x] \`pytest tests/\` - 663 passed, no regressions
- [ ] Manual: verify dashboard card shows enabled count instead of total on next active rip