### PR TITLE
fix: transcoder log panel correlates to correct job

### DIFF
--- a/backend/routers/transcoder.py
+++ b/backend/routers/transcoder.py
@@ -122,8 +122,14 @@ async def retranscode_transcoder_job(job_id: int):
 
 @router.get("/job-for-arm/{arm_job_id}")
 async def get_transcoder_job_for_arm(arm_job_id: int) -> dict[str, Any]:
-    """Look up the most recent transcoder job for a given ARM job ID."""
-    data = await transcoder_client.get_jobs(arm_job_id=arm_job_id, limit=1)
+    """Look up the transcoder job for a given ARM job ID.
+
+    IDs are unified: the transcoder stores ARM's job_id as its own primary key,
+    so filtering on job_id returns at most one record and never correlates with
+    an unrelated earlier job when the current ARM job has not yet reached the
+    transcoder.
+    """
+    data = await transcoder_client.get_jobs(job_id=arm_job_id, limit=1)
     if not data or not data.get("jobs"):
         return {"found": False}
     job = data["jobs"][0]

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -357,14 +357,19 @@ async def get_jobs(
     status: str | None = None,
     limit: int = 50,
     offset: int = 0,
-    arm_job_id: int | None = None,
+    job_id: int | None = None,
 ) -> dict[str, Any] | None:
+    """List transcoder jobs.
+
+    The transcoder uses the ARM job_id as its own primary key, so filtering
+    on job_id returns the transcoder-side record for that ARM job (if any).
+    """
     try:
         params: dict[str, Any] = {"limit": limit, "offset": offset}
         if status:
             params["status"] = status
-        if arm_job_id is not None:
-            params["arm_job_id"] = arm_job_id
+        if job_id is not None:
+            params["job_id"] = job_id
         resp = await get_client().get("/jobs", params=params)
         resp.raise_for_status()
         return _normalize_timestamps(resp.json())

--- a/frontend/src/lib/components/InlineLogFeed.svelte
+++ b/frontend/src/lib/components/InlineLogFeed.svelte
@@ -84,7 +84,14 @@
 	}
 
 	$effect(() => {
+		// Reset stale state whenever the target log file changes. Without this,
+		// navigating from one job's detail page to another would flash the
+		// previous job's entries while the new fetch 404s, or permanently
+		// freeze after MAX_FAILURES with no way to recover.
 		logfile; maxEntries; levelFilter;
+		entries = [];
+		error = null;
+		failCount = 0;
 		loading = true;
 		load();
 	});

--- a/tests/routers/test_transcoder.py
+++ b/tests/routers/test_transcoder.py
@@ -340,3 +340,26 @@ async def test_get_job_for_arm_offline(app_client):
         resp = await app_client.get("/api/transcoder/job-for-arm/42")
     assert resp.status_code == 200
     assert resp.json()["found"] is False
+
+
+async def test_get_job_for_arm_filters_by_job_id_not_most_recent(app_client):
+    """GET job-for-arm must filter by job_id so it never returns an unrelated older job.
+
+    Regression: the previous implementation passed arm_job_id as an unknown
+    param, which FastAPI silently dropped, causing the transcoder to return
+    its most recent job regardless of ARM id.
+    """
+    mock_get = AsyncMock(return_value={"jobs": [{"id": 42, "logfile": "JOB_42_Transcode.log"}]})
+    with patch(
+        "backend.routers.transcoder.transcoder_client.get_jobs",
+        new=mock_get,
+    ):
+        await app_client.get("/api/transcoder/job-for-arm/42")
+
+    mock_get.assert_called_once()
+    _, kwargs = mock_get.call_args
+    assert kwargs.get("job_id") == 42, (
+        f"Expected get_jobs to be called with job_id=42 (unified ID) "
+        f"to avoid stale-correlation; got kwargs={kwargs!r}"
+    )
+    assert "arm_job_id" not in kwargs

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -297,7 +297,7 @@ async def test_get_jobs_with_filters():
     mock_client.get.return_value = _mock_response(data)
     with patch.object(transcoder_client, "get_client", return_value=mock_client):
         result = await transcoder_client.get_jobs(
-            status="completed", limit=10, offset=5, arm_job_id=42
+            status="completed", limit=10, offset=5, job_id=42
         )
     assert result == data
     call_kwargs = mock_client.get.call_args
@@ -305,11 +305,11 @@ async def test_get_jobs_with_filters():
     assert params["status"] == "completed"
     assert params["limit"] == 10
     assert params["offset"] == 5
-    assert params["arm_job_id"] == 42
+    assert params["job_id"] == 42
 
 
-async def test_get_jobs_no_status_or_arm_job_id():
-    """get_jobs excludes status and arm_job_id when not provided."""
+async def test_get_jobs_no_status_or_job_id():
+    """get_jobs excludes status and job_id when not provided."""
     data = {"jobs": [], "total": 0}
     mock_client = AsyncMock(spec=httpx.AsyncClient)
     mock_client.get.return_value = _mock_response(data)
@@ -318,7 +318,7 @@ async def test_get_jobs_no_status_or_arm_job_id():
     call_kwargs = mock_client.get.call_args
     params = call_kwargs[1]["params"]
     assert "status" not in params
-    assert "arm_job_id" not in params
+    assert "job_id" not in params
 
 
 async def test_get_jobs_offline():


### PR DESCRIPTION
## Summary

Two linked bugs caused the job detail page's "Transcoder Log" panel to show an unrelated older job's log.

1. **Silent param drop.** \`backend/routers/transcoder.py:job-for-arm\` called \`get_jobs(arm_job_id=...)\`, but the transcoder \`/jobs\` endpoint doesn't accept \`arm_job_id\` - FastAPI silently dropped it and the call became "return the most recent transcoder job." For a currently-ripping ARM job (no matching transcoder job yet), the endpoint returned whichever disc the transcoder processed last. The detail page for job 161 would happily fetch JOB_159_Transcode.log.

   Fix: use \`job_id\` as the filter. The transcoder uses ARM's job_id as its own primary key (unified ID scheme), so this returns at most one record and never correlates with an unrelated earlier job.

2. **InlineLogFeed state leak.** The \`$effect\` watching \`logfile\` called \`load()\` without clearing \`entries\`, \`error\`, or \`failCount\`. Navigating between job detail pages flashed the previous job's log entries while the new fetch 404'd silently. After MAX_FAILURES (3) 404s the auto-refresh timer was permanently cleared with no UI to recover.

   Fix: reset state in the effect before triggering load.

Observed live on 2026-04-21 during Playwright validation of UI v16.0.0-rc.

## Test plan

- [x] \`pytest tests/routers/test_transcoder.py\` - 33 passed including new regression (\`test_get_job_for_arm_filters_by_job_id_not_most_recent\`)
- [x] \`pytest tests/\` - 662 passed
- [x] \`npm test --run\` - 796 frontend tests passed
- [ ] Manual: navigate to an active (copying/ripping) ARM job in the UI, confirm Transcoder Log panel does NOT show an unrelated older job's entries
- [ ] Manual: navigate between two completed jobs' detail pages, confirm log entries swap cleanly without a flash of the previous job's content