### PR TITLE
feat: job progress widgets for rip/copy/transcode phases

### DIFF
--- a/backend/routers/transcoder.py
+++ b/backend/routers/transcoder.py
@@ -128,9 +128,18 @@ async def get_transcoder_job_for_arm(arm_job_id: int) -> dict[str, Any]:
     so filtering on job_id returns at most one record and never correlates with
     an unrelated earlier job when the current ARM job has not yet reached the
     transcoder.
+
+    Returns `progress` so the job detail page can render a transcoder progress
+    bar without an extra round-trip.
     """
     data = await transcoder_client.get_jobs(job_id=arm_job_id, limit=1)
     if not data or not data.get("jobs"):
         return {"found": False}
     job = data["jobs"][0]
-    return {"found": True, "logfile": job.get("logfile"), "transcoder_job_id": job.get("id"), "status": job.get("status")}
+    return {
+        "found": True,
+        "logfile": job.get("logfile"),
+        "transcoder_job_id": job.get("id"),
+        "status": job.get("status"),
+        "progress": job.get("progress"),
+    }

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -67,6 +67,12 @@ export function logDownloadUrl(filename: string): string {
 
 export async function fetchTranscoderLogForArmJob(
 	armJobId: number
-): Promise<{ found: boolean; logfile?: string; transcoder_job_id?: number; status?: string }> {
+): Promise<{
+	found: boolean;
+	logfile?: string;
+	transcoder_job_id?: number;
+	status?: string;
+	progress?: number | null;
+}> {
 	return apiFetch(`/api/transcoder/job-for-arm/${armJobId}`);
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -49,7 +49,13 @@
 	);
 	let nonWaitingActiveJobs = $derived(dash.active_jobs.filter(j => {
 		const s = j.status?.toLowerCase();
-		return s !== 'waiting' && s !== 'transcoding' && s !== 'waiting_transcode' && s !== 'identifying' && s !== 'ready';
+		return s !== 'waiting' && s !== 'transcoding' && s !== 'waiting_transcode'
+			&& s !== 'identifying' && s !== 'ready'
+			&& s !== 'copying' && s !== 'ejecting';
+	}));
+	let finishingJobs = $derived(dash.active_jobs.filter(j => {
+		const s = j.status?.toLowerCase();
+		return s === 'copying' || s === 'ejecting' || s === 'waiting_transcode';
 	}));
 
 	let progressMap = $state<Record<number, RipProgress>>({});
@@ -383,6 +389,19 @@
 		</section>
 	{/if}
 
+	<!-- Finishing (copying / ejecting / waiting_transcode) -->
+	{#if finishingJobs.length > 0}
+		<section>
+			<SectionFrame variant="full" accent="var(--color-amber-500, #f59e0b)" label="FINISHING — {finishingJobs.length} {finishingJobs.length === 1 ? 'JOB' : 'JOBS'}">
+				<div class="space-y-2">
+					{#each finishingJobs as job (job.job_id)}
+						<ActiveJobRow {job} driveNames={dash.drive_names} />
+					{/each}
+				</div>
+			</SectionFrame>
+		</section>
+	{/if}
+
 	<!-- Active transcodes -->
 	{#if dash.active_transcodes.length > 0}
 		<section>
@@ -403,7 +422,7 @@
 	{/if}
 
 	<!-- Idle state -->
-	{#if pageReady && scanningJobs.length === 0 && waitingJobs.length === 0 && nonWaitingActiveJobs.length === 0 && dash.active_transcodes.length === 0}
+	{#if pageReady && scanningJobs.length === 0 && waitingJobs.length === 0 && nonWaitingActiveJobs.length === 0 && finishingJobs.length === 0 && dash.active_transcodes.length === 0}
 		<section>
 			<div class="rounded-lg border border-primary/20 bg-surface p-6 text-center shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 				<svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -2,8 +2,9 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
-	import { fetchJob, retranscodeJob, skipAndFinalize, forceComplete, fetchMusicDetail, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
-	import type { NamingPreviewTrack } from '$lib/api/jobs';
+	import { fetchJob, fetchJobProgress, retranscodeJob, skipAndFinalize, forceComplete, fetchMusicDetail, toggleMultiTitle, updateTrack, fetchNamingPreview } from '$lib/api/jobs';
+	import type { NamingPreviewTrack, RipProgress } from '$lib/api/jobs';
+	import ProgressBar from '$lib/components/ProgressBar.svelte';
 	import { posterSrc, posterFallback } from '$lib/utils/poster';
 	import PosterImage from '$lib/components/PosterImage.svelte';
 	import { fetchStructuredTranscoderLogContent, fetchTranscoderLogForArmJob } from '$lib/api/logs';
@@ -30,6 +31,9 @@
 	let retranscoding = $state(false);
 	let retranscodeFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 	let transcoderLogfile = $state<string | null>(null);
+	let transcoderProgress = $state<number | null>(null);
+	let transcoderJobStatus = $state<string | null>(null);
+	let ripProgress = $state<RipProgress | null>(null);
 
 	let isFolderImport = $derived(job?.source_type === 'folder');
 
@@ -246,11 +250,21 @@
 			}).catch(() => {
 				namingPreviews = {};
 			});
-			// Look up transcoder log for this ARM job
+			// Look up transcoder job info for this ARM job (logfile + progress)
 			fetchTranscoderLogForArmJob(id).then((info) => {
-				transcoderLogfile = info.found ? (info.logfile ?? null) : null;
+				if (info.found) {
+					transcoderLogfile = info.logfile ?? null;
+					transcoderProgress = info.progress ?? null;
+					transcoderJobStatus = info.status ?? null;
+				} else {
+					transcoderLogfile = null;
+					transcoderProgress = null;
+					transcoderJobStatus = null;
+				}
 			}).catch(() => {
 				transcoderLogfile = null;
+				transcoderProgress = null;
+				transcoderJobStatus = null;
 			});
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('404')) {
@@ -279,6 +293,36 @@
 		loadJob();
 	}
 
+	async function refreshProgress() {
+		if (!job) return;
+		const s = job.status?.toLowerCase();
+		if (s === 'ripping') {
+			try {
+				ripProgress = await fetchJobProgress(job.job_id);
+			} catch {
+				ripProgress = null;
+			}
+		} else if (ripProgress && s !== 'ripping') {
+			// Clear stale rip progress once the phase changes so 100% doesn't linger
+			ripProgress = null;
+		}
+		if (s === 'waiting_transcode' || s === 'transcoding' || s === 'copying') {
+			try {
+				const info = await fetchTranscoderLogForArmJob(job.job_id);
+				if (info.found) {
+					transcoderLogfile = info.logfile ?? null;
+					transcoderProgress = info.progress ?? null;
+					transcoderJobStatus = info.status ?? null;
+				} else {
+					transcoderProgress = null;
+					transcoderJobStatus = null;
+				}
+			} catch {
+				transcoderProgress = null;
+			}
+		}
+	}
+
 	onMount(() => {
 		let stopped = false;
 		async function poll() {
@@ -286,12 +330,13 @@
 				await new Promise((r) => setTimeout(r, 5000));
 				if (job && isJobActive(job.status)) {
 					await loadJob();
+					await refreshProgress();
 				} else {
 					break;
 				}
 			}
 		}
-		loadJob().then(() => { loadMusicTracks(); return poll(); });
+		loadJob().then(() => { loadMusicTracks(); refreshProgress(); return poll(); });
 		return () => {
 			stopped = true;
 		};
@@ -476,6 +521,61 @@
 			{/if}
 		</div>
 
+		<!-- Progress widget: ripping, copying, waiting_transcode, transcoding -->
+		{#if job.status === 'ripping'}
+			<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
+				<div class="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+					<span>Ripping</span>
+					{#if ripProgress?.stage}
+						<span class="text-xs text-gray-500 dark:text-gray-400">{ripProgress.stage}</span>
+					{/if}
+				</div>
+				{#if ripProgress?.progress != null}
+					<ProgressBar value={ripProgress.progress} color="bg-primary" />
+				{:else}
+					<div class="h-2.5 overflow-hidden rounded-full bg-primary/15">
+						<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
+					</div>
+				{/if}
+			</div>
+		{:else if job.status === 'copying'}
+			<div class="rounded-lg border border-amber-200 bg-amber-50 p-4 shadow-xs dark:border-amber-800 dark:bg-amber-900/20">
+				<div class="mb-2 flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-300">
+					<span>Copying to shared storage</span>
+					<span class="text-xs text-amber-700/80 dark:text-amber-400/80">ARM is moving raw files to the transcoder's working directory.</span>
+				</div>
+				<div class="h-2.5 overflow-hidden rounded-full bg-amber-200/60 dark:bg-amber-900/40">
+					<div class="h-full w-1/3 animate-indeterminate rounded-full bg-amber-500/70"></div>
+				</div>
+			</div>
+		{:else if job.status === 'waiting_transcode'}
+			<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
+				<div class="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+					<span>Waiting to transcode</span>
+					<span class="text-xs text-gray-500 dark:text-gray-400">Queued on the transcoder.</span>
+				</div>
+				<div class="h-2.5 overflow-hidden rounded-full bg-primary/15">
+					<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
+				</div>
+			</div>
+		{:else if job.status === 'transcoding'}
+			<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
+				<div class="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+					<span>Transcoding</span>
+					{#if transcoderJobStatus}
+						<span class="text-xs text-gray-500 dark:text-gray-400">({transcoderJobStatus})</span>
+					{/if}
+				</div>
+				{#if transcoderProgress != null}
+					<ProgressBar value={transcoderProgress} color="bg-primary" />
+				{:else}
+					<div class="h-2.5 overflow-hidden rounded-full bg-primary/15">
+						<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
+					</div>
+				{/if}
+			</div>
+		{/if}
+
 		<!-- Auto vs Manual title info (outside container) -->
 		{#if hasAutoManualDiff}
 			<div class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm dark:border-amber-800 dark:bg-amber-900/20">
@@ -499,7 +599,7 @@
 		{#if job.logfile}
 			<InlineLogFeed logfile={job.logfile} maxEntries={15} title="ARM Ripper Log" />
 		{/if}
-		{#if transcoderLogfile && !isMusicDisc && job?.disctype !== 'data' && job?.status !== 'ripping' && job?.status !== 'ready' && job?.status !== 'identifying' && job?.status !== 'waiting'}
+		{#if transcoderLogfile && transcoderJobStatus && !isMusicDisc && job?.disctype !== 'data'}
 			<InlineLogFeed
 				logfile={transcoderLogfile}
 				maxEntries={15}

--- a/tests/routers/test_transcoder.py
+++ b/tests/routers/test_transcoder.py
@@ -304,7 +304,7 @@ async def test_retranscode_webhook_failure(app_client):
 
 async def test_get_job_for_arm_found(app_client):
     """GET job-for-arm returns found=True with job details."""
-    data = {"jobs": [{"id": 10, "logfile": "job_10.log", "status": "completed"}]}
+    data = {"jobs": [{"id": 10, "logfile": "job_10.log", "status": "completed", "progress": 100.0}]}
     with patch(
         "backend.routers.transcoder.transcoder_client.get_jobs",
         new_callable=AsyncMock,
@@ -316,6 +316,22 @@ async def test_get_job_for_arm_found(app_client):
     assert result["found"] is True
     assert result["transcoder_job_id"] == 10
     assert result["logfile"] == "job_10.log"
+    assert result["progress"] == 100.0
+
+
+async def test_get_job_for_arm_passes_progress_field(app_client):
+    """progress field is surfaced so the detail page can render a progress bar."""
+    data = {"jobs": [{"id": 10, "logfile": "job_10.log", "status": "processing", "progress": 42.5}]}
+    with patch(
+        "backend.routers.transcoder.transcoder_client.get_jobs",
+        new_callable=AsyncMock,
+        return_value=data,
+    ):
+        resp = await app_client.get("/api/transcoder/job-for-arm/42")
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["progress"] == 42.5
+    assert result["status"] == "processing"
 
 
 async def test_get_job_for_arm_not_found(app_client):

--- a/tests/routers/test_transcoder.py
+++ b/tests/routers/test_transcoder.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 
 # --- GET /api/transcoder/stats ---
 
@@ -316,7 +318,7 @@ async def test_get_job_for_arm_found(app_client):
     assert result["found"] is True
     assert result["transcoder_job_id"] == 10
     assert result["logfile"] == "job_10.log"
-    assert result["progress"] == 100.0
+    assert result["progress"] == pytest.approx(100.0)
 
 
 async def test_get_job_for_arm_passes_progress_field(app_client):
@@ -330,7 +332,7 @@ async def test_get_job_for_arm_passes_progress_field(app_client):
         resp = await app_client.get("/api/transcoder/job-for-arm/42")
     assert resp.status_code == 200
     result = resp.json()
-    assert result["progress"] == 42.5
+    assert result["progress"] == pytest.approx(42.5)
     assert result["status"] == "processing"
 
 


### PR DESCRIPTION
## Summary

Addresses the remaining items from the progress-bug investigation:

- **Job detail page had no progress widget at all.** Memory note said the transcoder progress container 'was no longer full width' — investigation found there was never a widget there to begin with.
- **Dashboard showed stale 100%** for jobs that had transitioned from ripping to copying, because the filter kept them in ACTIVE RIPS while the progress poll had already stopped updating them.

## Changes

**Detail page (`/jobs/[id]/+page.svelte`)**
- Status-branching progress widget with phase label:
  - `ripping` - ProgressBar from `/api/jobs/{id}/progress` + stage label
  - `copying` - amber indeterminate (no progress signal available; ARM rsync phase)
  - `waiting_transcode` - indeterminate with 'Queued on transcoder'
  - `transcoding` - ProgressBar from extended `/api/transcoder/job-for-arm/{id}` (or indeterminate fallback if not yet reported)
- Refreshes on existing 5s poll
- Transcoder log panel gate now requires `transcoderJobStatus` to be set (implies backend confirmed `found: true`), replacing a hardcoded status exclusion that missed `copying`

**Dashboard (`/+page.svelte`)**
- Exclude `copying` and `ejecting` from ACTIVE RIPS
- New FINISHING section with indeterminate bars for jobs between ripping and transcoding phases
- Idle-state check includes finishingJobs

**Backend (`/api/transcoder/job-for-arm/{id}`)**
- Returns `progress` field from the underlying transcoder payload

Companion to PR #194 (which fixed the stale-job-correlation bug that would have broken this feature).

## Test plan

- [x] \`pytest tests/\` - 663 passed (added test for progress field passthrough)
- [x] \`npm test --run\` - 796 passed
- [x] \`npm run check\` - 0 errors
- [ ] Manual: watch a job through all phases (ripping -> copying -> waiting_transcode -> transcoding) on both dashboard and detail page, confirm no stale 100% and progress updates live