### PR TITLE
feat: log filter UI in InlineLogFeed

### DIFF
--- a/frontend/src/lib/components/InlineLogFeed.svelte
+++ b/frontend/src/lib/components/InlineLogFeed.svelte
@@ -35,8 +35,47 @@
 	let loading = $state(true);
 	let expanded = $state(false);
 
+	// User-facing filter state. Starts from the levelFilter prop but is
+	// overwritable from the filter bar. Server-side filtering (backend honors
+	// level and search query params); we debounce the search input to avoid
+	// hammering the server as the user types.
+	let activeLevel = $state<string>(levelFilter ?? '');
+	let searchInput = $state<string>('');
+	let activeSearch = $state<string>('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+	let hasFilter = $derived(!!activeLevel || !!activeSearch);
+
+	function onLevelChange(e: Event) {
+		activeLevel = (e.target as HTMLSelectElement).value;
+		load();
+	}
+
+	function onSearchInput(e: Event) {
+		const val = (e.target as HTMLInputElement).value;
+		searchInput = val;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => { activeSearch = val.trim(); load(); }, 300);
+	}
+
+	function clearFilters() {
+		activeLevel = '';
+		searchInput = '';
+		activeSearch = '';
+		if (searchDebounce) { clearTimeout(searchDebounce); searchDebounce = null; }
+		load();
+	}
+
 	let errorCount = $derived(entries.filter((e) => e.level === 'error' || e.level === 'critical').length);
 	let warningCount = $derived(entries.filter((e) => e.level === 'warning').length);
+
+	const LEVEL_OPTIONS = [
+		{ value: '', label: 'All levels' },
+		{ value: 'debug', label: 'Debug+' },
+		{ value: 'info', label: 'Info+' },
+		{ value: 'warning', label: 'Warning+' },
+		{ value: 'error', label: 'Error+' },
+		{ value: 'critical', label: 'Critical' },
+	];
 
 	const levelBadgeColors: Record<string, string> = {
 		error: 'bg-red-900/60 text-red-300',
@@ -64,7 +103,8 @@
 				logfile,
 				'tail',
 				maxEntries,
-				levelFilter || undefined
+				activeLevel || undefined,
+				activeSearch || undefined
 			);
 			entries = data.entries.toReversed();
 			error = null;
@@ -83,15 +123,27 @@
 		}
 	}
 
+	// Track the last logfile we reset state for, so we only reset on actual
+	// logfile changes (not on every filter change that might re-run the
+	// surrounding effect).
+	let lastResetLogfile = '';
 	$effect(() => {
 		// Reset stale state whenever the target log file changes. Without this,
 		// navigating from one job's detail page to another would flash the
 		// previous job's entries while the new fetch 404s, or permanently
-		// freeze after MAX_FAILURES with no way to recover.
-		logfile; maxEntries; levelFilter;
-		entries = [];
-		error = null;
-		failCount = 0;
+		// freeze after MAX_FAILURES with no way to recover. Filter state is
+		// also cleared so a fresh job starts unfiltered.
+		const currentLogfile = logfile;
+		if (currentLogfile !== lastResetLogfile) {
+			lastResetLogfile = currentLogfile;
+			entries = [];
+			error = null;
+			failCount = 0;
+			activeLevel = levelFilter ?? '';
+			searchInput = '';
+			activeSearch = '';
+		}
+		maxEntries; // track as dep
 		loading = true;
 		load();
 	});
@@ -111,7 +163,7 @@
 	<div class={containerClass ?? ''}>
 		<div class="text-sm text-red-400">{error}</div>
 	</div>
-{:else if entries.length > 0}
+{:else if entries.length > 0 || hasFilter}
 	<div class={containerClass ?? ''}>
 		<div class="rounded-lg border border-gray-200 dark:border-gray-700">
 			<!-- Summary header -->
@@ -126,6 +178,11 @@
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
 				</svg>
 				<span class="font-medium text-gray-700 dark:text-gray-300">{title}</span>
+				{#if hasFilter}
+					<span class="rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary-text dark:bg-primary/15 dark:text-primary-text-dark">
+						filtered
+					</span>
+				{/if}
 				{#if errorCount > 0}
 					<span class="rounded-sm bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">
 						{errorCount} error{errorCount !== 1 ? 's' : ''}
@@ -141,18 +198,64 @@
 
 			{#if expanded}
 				<div class="border-t border-gray-200 dark:border-gray-700">
+					<!-- Filter bar -->
+					<div class="flex flex-wrap items-center gap-2 border-b border-gray-100 bg-gray-50 px-3 py-2 dark:border-gray-800 dark:bg-gray-800/30">
+						<label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+							<span>Level</span>
+							<select
+								value={activeLevel}
+								onchange={onLevelChange}
+								aria-label="Minimum log level"
+								class="rounded border border-gray-300 bg-white px-1.5 py-0.5 text-xs dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200"
+							>
+								{#each LEVEL_OPTIONS as opt}
+									<option value={opt.value}>{opt.label}</option>
+								{/each}
+							</select>
+						</label>
+						<label class="flex flex-1 items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+							<span class="sr-only">Search log entries</span>
+							<input
+								type="search"
+								value={searchInput}
+								oninput={onSearchInput}
+								placeholder="Search..."
+								aria-label="Search log entries"
+								class="min-w-0 flex-1 rounded border border-gray-300 bg-white px-2 py-0.5 text-xs dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200"
+							/>
+						</label>
+						{#if hasFilter}
+							<button
+								type="button"
+								onclick={clearFilters}
+								class="rounded px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+							>
+								Clear
+							</button>
+						{/if}
+					</div>
 					<div class="max-h-64 overflow-auto">
-						{#each entries as entry}
-							<div class="flex items-start gap-2 border-b border-l-2 border-b-gray-100 px-3 py-1.5 font-mono text-xs dark:border-b-gray-800 {borderColors[entry.level] ?? 'border-l-transparent'}">
-								<span class="inline-block w-12 shrink-0 rounded px-1 py-0.5 text-center text-[10px] font-semibold uppercase {levelBadgeColors[entry.level] ?? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}">
-									{entry.level}
-								</span>
-								{#if entry.timestamp}
-									<span class="shrink-0 text-gray-400">{entry.timestamp.replace('T', ' ').replace('Z', '').slice(11, 19)}</span>
+						{#if entries.length === 0}
+							<div class="px-3 py-3 text-center text-xs text-gray-500 dark:text-gray-400">
+								{#if hasFilter}
+									No entries match the current filter.
+								{:else}
+									No entries.
 								{/if}
-								<span class="min-w-0 break-words text-gray-700 dark:text-gray-300">{entry.event}</span>
 							</div>
-						{/each}
+						{:else}
+							{#each entries as entry}
+								<div class="flex items-start gap-2 border-b border-l-2 border-b-gray-100 px-3 py-1.5 font-mono text-xs dark:border-b-gray-800 {borderColors[entry.level] ?? 'border-l-transparent'}">
+									<span class="inline-block w-12 shrink-0 rounded px-1 py-0.5 text-center text-[10px] font-semibold uppercase {levelBadgeColors[entry.level] ?? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}">
+										{entry.level}
+									</span>
+									{#if entry.timestamp}
+										<span class="shrink-0 text-gray-400">{entry.timestamp.replace('T', ' ').replace('Z', '').slice(11, 19)}</span>
+									{/if}
+									<span class="min-w-0 break-words text-gray-700 dark:text-gray-300">{entry.event}</span>
+								</div>
+							{/each}
+						{/if}
 					</div>
 					<div class="border-t border-gray-200 px-3 py-2 dark:border-gray-700">
 						<a

--- a/frontend/src/lib/components/InlineLogFeed.test.ts
+++ b/frontend/src/lib/components/InlineLogFeed.test.ts
@@ -98,4 +98,98 @@ describe('InlineLogFeed', () => {
 			expect(link.closest('a')).toHaveAttribute('href', '/logs/test.log');
 		});
 	});
+
+	describe('filtering', () => {
+		it('renders level dropdown and search input when expanded', async () => {
+			renderComponent(InlineLogFeed, {
+				props: { logfile: 'test.log', fetchFn: createFetchFn(), autoRefresh: false }
+			});
+			await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Recent Log'));
+
+			expect(screen.getByLabelText('Minimum log level')).toBeInTheDocument();
+			expect(screen.getByLabelText('Search log entries')).toBeInTheDocument();
+		});
+
+		it('passes selected level to fetchFn on change', async () => {
+			const fetchFn = createFetchFn();
+			renderComponent(InlineLogFeed, {
+				props: { logfile: 'test.log', fetchFn, autoRefresh: false }
+			});
+			await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Recent Log'));
+
+			const select = screen.getByLabelText('Minimum log level') as HTMLSelectElement;
+			// Use the shared test pattern from PresetEditor: set value, dispatch change.
+			select.value = 'error';
+			await fireEvent.change(select);
+
+			expect(select.value).toBe('error');
+
+			await waitFor(() => {
+				const calls = fetchFn.mock.calls;
+				const hasLevelCall = calls.some((c: any[]) => c[3] === 'error');
+				expect(hasLevelCall).toBe(true);
+			});
+		});
+
+		it('shows "filtered" badge when a filter is active', async () => {
+			renderComponent(InlineLogFeed, {
+				props: { logfile: 'test.log', fetchFn: createFetchFn(), autoRefresh: false }
+			});
+			await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Recent Log'));
+
+			const select = screen.getByLabelText('Minimum log level') as HTMLSelectElement;
+			await fireEvent.change(select, { target: { value: 'warning' } });
+
+			await waitFor(() => {
+				expect(screen.getByText('filtered')).toBeInTheDocument();
+			});
+		});
+
+		it('shows "No entries match" when filter returns zero entries', async () => {
+			let callCount = 0;
+			const fetchFn = vi.fn((_f: string, _m: string, _l: number, level?: string) => {
+				callCount++;
+				if (level === 'critical') return Promise.resolve({ entries: [] });
+				return Promise.resolve({ entries: mockEntries });
+			});
+			renderComponent(InlineLogFeed, {
+				props: { logfile: 'test.log', fetchFn, autoRefresh: false }
+			});
+			await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Recent Log'));
+
+			const select = screen.getByLabelText('Minimum log level') as HTMLSelectElement;
+			await fireEvent.change(select, { target: { value: 'critical' } });
+
+			await waitFor(() => {
+				expect(screen.getByText(/No entries match/i)).toBeInTheDocument();
+			});
+			expect(callCount).toBeGreaterThan(1);
+			// Panel stays visible so user can clear the filter
+			expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+		});
+
+		it('clears filters via Clear button', async () => {
+			const fetchFn = createFetchFn();
+			renderComponent(InlineLogFeed, {
+				props: { logfile: 'test.log', fetchFn, autoRefresh: false }
+			});
+			await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument());
+			await fireEvent.click(screen.getByText('Recent Log'));
+
+			const select = screen.getByLabelText('Minimum log level') as HTMLSelectElement;
+			await fireEvent.change(select, { target: { value: 'error' } });
+			expect(select.value).toBe('error');
+
+			await waitFor(() => {
+				expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+
+			expect((screen.getByLabelText('Minimum log level') as HTMLSelectElement).value).toBe('');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Adds a level dropdown and search input to the log panel expanded view. The backend filtering plumbing already existed (backend and transcoder both honor \`level\` and \`search\` query params, API wrapper exposes them) but the component never surfaced filter controls.

- **Level dropdown:** 'All levels' / Debug+ / Info+ / Warning+ / Error+ / Critical. Changing the dropdown triggers an immediate reload against the new level filter.
- **Search input:** substring match, debounced 300ms.
- **Clear button** appears when any filter is active.
- **'filtered' badge** on the collapsed header when a filter is active.
- **Panel stays visible** when a filter returns zero matches, showing 'No entries match the current filter' so the user can clear it. Previously the entire panel would vanish when entries were empty, which would have made zero-match filtering unusable.

Filter state resets when the \`logfile\` prop changes, so navigating between jobs starts fresh.

**Incidental fix:** the logfile-reset \`\$effect\` was re-running on filter changes (Svelte 5 treats \`activeLevel = ...\` inside an effect body as a read dependency of activeLevel), which would reset the filter immediately after the user set it. Changed to track a \`lastResetLogfile\` sentinel so the reset only fires on actual logfile transitions.

Based on PR #194 (transcoder log correlation fix). Merges cleanly on top of it.

## Test plan

- [x] \`npm test InlineLogFeed --run\` - 13 passed (8 existing + 5 new)
- [x] \`npm test --run\` - 801 passed
- [x] \`npm run check\` - 0 errors
- [ ] Manual: expand a log panel, change level dropdown, confirm entries filter and server re-fetches
- [ ] Manual: type in search, confirm 300ms debounce before fetch
- [ ] Manual: filter to zero matches, confirm 'No entries match' placeholder and Clear button remain visible
- [ ] Manual: click Clear, confirm filter resets and all entries return