### PR TITLE
chore(deps): bump peter-evans/create-pull-request to v8.1.1

### DIFF
--- a/.github/workflows/bump-submodule.yml
+++ b/.github/workflows/bump-submodule.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create PR
         if: steps.bump.outputs.already_current != 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.RELEASE_PAT }}
           branch: auto-bump/contracts-${{ steps.bump.outputs.short_sha }}


### PR DESCRIPTION
Matches arm-neu which just merged the same bump (dependabot #247) and transcoder which is bumping in parallel (PR #104).

v8 adds Node 24 support (GitHub-hosted runners fine; no self-hosted). v8.1.1 fixes a retry-on-422-eventual-consistency bug that can affect the bump-submodule auto-PR workflow.

Pinned to full SHA to satisfy SonarCloud githubactions:S7637.