### PR TITLE
feat: ripper-only deployment (transcoder-disabled mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The UI is available at `http://localhost:8888`.
 | `ARM_UI_ARM_URL` | `http://localhost:8080` | ARM web UI base URL (for job actions) |
 | `ARM_UI_TRANSCODER_URL` | `http://localhost:5000` | Transcoder API base URL |
 | `ARM_UI_TRANSCODER_API_KEY` | *(empty)* | Optional transcoder API key |
+| `ARM_UI_TRANSCODER_ENABLED` | `true` | Set `false` for ripper-only deployments (no transcoder). Hides all transcoder UI surfaces and short-circuits transcoder HTTP calls. See [ripper-only deployment](https://github.com/uprightbass360/automatic-ripping-machine-neu#ripper-only) in the ARM-neu README. |
 | `ARM_UI_ARM_THEMES_PATH` | `/data/config/themes` | Directory for custom color scheme JSON files |
 | `ARM_UI_IMAGE_CACHE_PATH` | `/data/cache/images` | Directory for cached poster/cover images |
 | `ARM_UI_PORT` | `8888` | Server port |

--- a/backend/config.py
+++ b/backend/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     arm_url: str = "http://localhost:8080"
     transcoder_url: str = "http://localhost:5000"
     transcoder_api_key: str = ""
+    transcoder_enabled: bool = True
     port: int = 8888
 
     model_config = {"env_prefix": "ARM_UI_"}

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,6 +1,18 @@
 """FastAPI dependency injection utilities."""
 
+from fastapi import HTTPException
+
+from backend.config import settings
 from backend.services.arm_db import get_session
+
+
+def require_transcoder_enabled() -> None:
+    """Raise 503 when the transcoder feature is disabled for this deployment."""
+    if not settings.transcoder_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="Transcoder disabled on this deployment",
+        )
 
 
 def get_db():

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from backend.routers import (
     arm_actions,
+    config,
     dashboard,
     drives,
     files,
@@ -50,6 +51,7 @@ app.add_middleware(
 
 # API routes
 app.include_router(dashboard.router)
+app.include_router(config.router)
 app.include_router(jobs.router)
 app.include_router(arm_actions.router)
 app.include_router(arm_actions.naming_router)

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -1,0 +1,13 @@
+"""Feature-flag discovery endpoint for the frontend."""
+
+from fastapi import APIRouter
+
+from backend.config import settings
+
+router = APIRouter(prefix="/api", tags=["config"])
+
+
+@router.get("/config")
+async def get_config() -> dict[str, bool]:
+    """Return feature flags that the frontend needs to render the right UI."""
+    return {"transcoder_enabled": settings.transcoder_enabled}

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -2,6 +2,7 @@ import asyncio
 
 from fastapi import APIRouter
 
+from backend.config import settings as app_settings
 from backend.models.schemas import DashboardResponse, HardwareInfoSchema, JobSchema, SystemStatsSchema
 from backend.services import arm_client, arm_db, transcoder_client, system_cache
 
@@ -9,7 +10,13 @@ router = APIRouter(prefix="/api", tags=["dashboard"])
 
 
 async def _fetch_transcoder() -> tuple[bool, dict | None, list]:
-    """Fetch transcoder health, stats, and active jobs concurrently."""
+    """Fetch transcoder health, stats, and active jobs concurrently.
+
+    Returns a disabled payload without any HTTP call when the feature flag is off.
+    """
+    if not app_settings.transcoder_enabled:
+        return False, None, []
+
     health = await transcoder_client.health()
     if not health:
         return False, None, []
@@ -52,7 +59,10 @@ async def get_dashboard():
     # Transcoder + ARM system stats in parallel
     transcoder_task = asyncio.create_task(_fetch_transcoder())
     stats_task = asyncio.create_task(arm_client.get_system_stats())
-    transcoder_stats_task = asyncio.create_task(transcoder_client.get_system_stats())
+    if app_settings.transcoder_enabled:
+        transcoder_stats_task = asyncio.create_task(transcoder_client.get_system_stats())
+    else:
+        transcoder_stats_task = None
     ripping_task = asyncio.create_task(system_cache.get_ripping_data())
 
     transcoder_online, transcoder_stats, active_transcodes = await transcoder_task
@@ -63,9 +73,10 @@ async def get_dashboard():
         system_stats = SystemStatsSchema(**stats_data)
 
     transcoder_system_stats: SystemStatsSchema | None = None
-    transcoder_stats_data = await transcoder_stats_task
-    if transcoder_stats_data:
-        transcoder_system_stats = SystemStatsSchema(**transcoder_stats_data)
+    if transcoder_stats_task is not None:
+        transcoder_stats_data = await transcoder_stats_task
+        if transcoder_stats_data:
+            transcoder_system_stats = SystemStatsSchema(**transcoder_stats_data)
 
     ripping_data = await ripping_task
     makemkv_key_valid = None
@@ -75,7 +86,7 @@ async def get_dashboard():
         makemkv_key_checked_at = ripping_data.get("makemkv_key_checked_at")
 
     arm_hw = system_cache.get_arm_info()
-    transcoder_hw = system_cache.get_transcoder_info()
+    transcoder_hw = system_cache.get_transcoder_info() if app_settings.transcoder_enabled else None
 
     arm_online = stats_data is not None
 

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -29,40 +29,44 @@ async def _fetch_transcoder() -> tuple[bool, dict | None, list]:
     return True, stats, active
 
 
+def _load_db_state() -> tuple[list, int, dict[str, str], int, bool]:
+    """Read all dashboard state derived from the ARM database."""
+    active_jobs = arm_db.get_active_jobs()
+    drives = arm_db.get_drives()
+    drives_online = sum(1 for d in drives if not getattr(d, 'stale', False))
+    # Normalize mount paths — drives store /mnt/dev/sr0, jobs store /dev/sr0
+    drive_names: dict[str, str] = {}
+    for d in drives:
+        if d.mount and d.name:
+            drive_names[d.mount] = d.name
+            basename = d.mount.rsplit("/", 1)[-1]
+            drive_names[f"/dev/{basename}"] = d.name
+    notification_count = arm_db.get_notification_count()
+    ripping_paused = arm_db.get_ripping_paused()
+    return active_jobs, drives_online, drive_names, notification_count, ripping_paused
+
+
+async def _fetch_transcoder_system_stats() -> SystemStatsSchema | None:
+    """Wrap transcoder_client.get_system_stats() with the feature-flag gate."""
+    if not app_settings.transcoder_enabled:
+        return None
+    data = await transcoder_client.get_system_stats()
+    return SystemStatsSchema(**data) if data else None
+
+
 @router.get("/dashboard", response_model=DashboardResponse)
 async def get_dashboard():
     db_available = arm_db.is_available()
 
-    # Skip DB queries entirely when database is unavailable
-    active_jobs: list = []
-    drives_online = 0
-    drive_names: dict[str, str] = {}
-    notification_count = 0
-
-    ripping_paused = False
-
     if db_available:
-        active_jobs = arm_db.get_active_jobs()
-        drives = arm_db.get_drives()
-        drives_online = sum(1 for d in drives if not getattr(d, 'stale', False))
-        # Normalize mount paths — drives store /mnt/dev/sr0, jobs store /dev/sr0
-        drive_names = {}
-        for d in drives:
-            if d.mount and d.name:
-                drive_names[d.mount] = d.name
-                # Also map the bare /dev/srX form
-                basename = d.mount.rsplit("/", 1)[-1]
-                drive_names[f"/dev/{basename}"] = d.name
-        notification_count = arm_db.get_notification_count()
-        ripping_paused = arm_db.get_ripping_paused()
+        active_jobs, drives_online, drive_names, notification_count, ripping_paused = _load_db_state()
+    else:
+        active_jobs, drives_online, drive_names, notification_count, ripping_paused = [], 0, {}, 0, False
 
     # Transcoder + ARM system stats in parallel
     transcoder_task = asyncio.create_task(_fetch_transcoder())
     stats_task = asyncio.create_task(arm_client.get_system_stats())
-    if app_settings.transcoder_enabled:
-        transcoder_stats_task = asyncio.create_task(transcoder_client.get_system_stats())
-    else:
-        transcoder_stats_task = None
+    transcoder_stats_task = asyncio.create_task(_fetch_transcoder_system_stats())
     ripping_task = asyncio.create_task(system_cache.get_ripping_data())
 
     transcoder_online, transcoder_stats, active_transcodes = await transcoder_task
@@ -72,11 +76,7 @@ async def get_dashboard():
     if stats_data:
         system_stats = SystemStatsSchema(**stats_data)
 
-    transcoder_system_stats: SystemStatsSchema | None = None
-    if transcoder_stats_task is not None:
-        transcoder_stats_data = await transcoder_stats_task
-        if transcoder_stats_data:
-            transcoder_system_stats = SystemStatsSchema(**transcoder_stats_data)
+    transcoder_system_stats = await transcoder_stats_task
 
     ripping_data = await ripping_task
     makemkv_key_valid = None

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -1,7 +1,9 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from backend.dependencies import require_transcoder_enabled
 from pydantic import BaseModel
 
 from backend.models.schemas import (
@@ -400,7 +402,8 @@ async def get_naming_variables():
     return result
 
 
-@router.patch("/jobs/{job_id}/transcode-config", responses={400: {"description": "Invalid request"}, 404: {"description": _JOB_NOT_FOUND}, 502: {}, 503: {}})
+@router.patch("/jobs/{job_id}/transcode-config", responses={400: {"description": "Invalid request"}, 404: {"description": _JOB_NOT_FOUND}, 502: {}, 503: {}},
+              dependencies=[Depends(require_transcoder_enabled)])
 async def update_transcode_config(job_id: int, request: Request):
     """Set per-job transcode override settings (proxied to ARM)."""
     body = await request.json()
@@ -432,7 +435,8 @@ async def update_track_fields(job_id: int, track_id: int, request: Request):
     return result
 
 
-@router.post("/jobs/{job_id}/retranscode", responses={404: {"description": "Job not found or not a video disc"}, 503: {"description": "Transcoder unavailable"}})
+@router.post("/jobs/{job_id}/retranscode", responses={404: {"description": "Job not found or not a video disc"}, 503: {"description": "Transcoder unavailable"}},
+             dependencies=[Depends(require_transcoder_enabled)])
 async def retranscode_job(job_id: int):
     """Re-send a completed ARM job to the transcoder."""
     payload = arm_db.get_job_retranscode_info(job_id)

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -4,11 +4,12 @@ import logging
 import os
 from typing import NoReturn
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 import httpx
 from pydantic import BaseModel
 
 from backend.config import settings as app_settings
+from backend.dependencies import require_transcoder_enabled
 from backend.models.schemas import SettingsResponse
 from backend.services import arm_client, arm_db, transcoder_client
 
@@ -142,7 +143,8 @@ async def test_metadata_key(key: str | None = None, provider: str | None = None)
         return {"success": False, "message": "ARM service unreachable", "provider": "unknown"}
 
 
-@router.get("/settings/transcoder/scheme", responses=_TRANSCODER_UNREACHABLE_RESPONSE)
+@router.get("/settings/transcoder/scheme", responses=_TRANSCODER_UNREACHABLE_RESPONSE,
+            dependencies=[Depends(require_transcoder_enabled)])
 async def get_transcoder_scheme():
     result = await transcoder_client.get_scheme()
     if result is None:
@@ -150,7 +152,8 @@ async def get_transcoder_scheme():
     return result
 
 
-@router.get("/settings/transcoder/presets", responses=_TRANSCODER_UNREACHABLE_RESPONSE)
+@router.get("/settings/transcoder/presets", responses=_TRANSCODER_UNREACHABLE_RESPONSE,
+            dependencies=[Depends(require_transcoder_enabled)])
 async def get_transcoder_presets():
     result = await transcoder_client.get_presets()
     if result is None:
@@ -169,7 +172,8 @@ def _raise_from_http_status_error(exc: httpx.HTTPStatusError) -> NoReturn:
 
 
 @router.post("/settings/transcoder/presets", status_code=201,
-             responses={409: {"description": "Slug conflict"}, 502: {"description": "Transcoder unreachable"}})
+             responses={409: {"description": "Slug conflict"}, 502: {"description": "Transcoder unreachable"}},
+             dependencies=[Depends(require_transcoder_enabled)])
 async def create_transcoder_preset(body: dict):
     try:
         result = await transcoder_client.create_preset(body)
@@ -181,7 +185,8 @@ async def create_transcoder_preset(body: dict):
 
 
 @router.patch("/settings/transcoder/presets/{slug}",
-              responses={400: {"description": "Invalid slug"}, 404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
+              responses={400: {"description": "Invalid slug"}, 404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}},
+              dependencies=[Depends(require_transcoder_enabled)])
 async def update_transcoder_preset(slug: str, body: dict):
     try:
         result = await transcoder_client.update_preset(slug, body)
@@ -195,7 +200,8 @@ async def update_transcoder_preset(slug: str, body: dict):
 
 
 @router.delete("/settings/transcoder/presets/{slug}",
-               responses={400: {"description": "Invalid slug"}, 404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}})
+               responses={400: {"description": "Invalid slug"}, 404: {"description": "Preset not found"}, 502: {"description": "Transcoder unreachable"}},
+               dependencies=[Depends(require_transcoder_enabled)])
 async def delete_transcoder_preset(slug: str):
     try:
         result = await transcoder_client.delete_preset(slug)
@@ -208,7 +214,8 @@ async def delete_transcoder_preset(slug: str):
     return result
 
 
-@router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, **_TRANSCODER_UNREACHABLE_RESPONSE})
+@router.patch("/settings/transcoder", responses={400: {"description": "Invalid config"}, **_TRANSCODER_UNREACHABLE_RESPONSE},
+              dependencies=[Depends(require_transcoder_enabled)])
 async def update_transcoder_config(body: dict):
     try:
         result = await transcoder_client.update_config(body)
@@ -221,7 +228,8 @@ async def update_transcoder_config(body: dict):
     return result
 
 
-@router.post("/settings/transcoder/test-connection")
+@router.post("/settings/transcoder/test-connection",
+             dependencies=[Depends(require_transcoder_enabled)])
 async def test_transcoder_connection():
     return await transcoder_client.test_connection()
 
@@ -230,7 +238,8 @@ class WebhookTestRequest(BaseModel):
     webhook_secret: str = ""
 
 
-@router.post("/settings/transcoder/test-webhook")
+@router.post("/settings/transcoder/test-webhook",
+             dependencies=[Depends(require_transcoder_enabled)])
 async def test_transcoder_webhook(body: WebhookTestRequest):
     return await transcoder_client.test_webhook(body.webhook_secret)
 

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -55,25 +55,26 @@ async def get_settings():
     # Transcoder config + GPU support
     transcoder_config = None
     transcoder_gpu_support = None
-
-    tc_config_resp = await transcoder_client.get_config()
-    if tc_config_resp:
-        transcoder_config = tc_config_resp
-
-    health = await transcoder_client.health()
     transcoder_auth_status = None
-    if health:
-        transcoder_gpu_support = health.get("gpu_support")
-        transcoder_auth_status = {
-            "require_api_auth": health.get("require_api_auth", False),
-            "webhook_secret_configured": health.get("webhook_secret_configured", False),
-        }
-        # If the dedicated /config endpoint was offline, use health fallback
-        if not transcoder_config:
-            transcoder_config = {
-                "config": health.get("config"),
-                "updatable_keys": list(health.get("config", {}).keys()),
+
+    if app_settings.transcoder_enabled:
+        tc_config_resp = await transcoder_client.get_config()
+        if tc_config_resp:
+            transcoder_config = tc_config_resp
+
+        health = await transcoder_client.health()
+        if health:
+            transcoder_gpu_support = health.get("gpu_support")
+            transcoder_auth_status = {
+                "require_api_auth": health.get("require_api_auth", False),
+                "webhook_secret_configured": health.get("webhook_secret_configured", False),
             }
+            # If the dedicated /config endpoint was offline, use health fallback
+            if not transcoder_config:
+                transcoder_config = {
+                    "config": health.get("config"),
+                    "updatable_keys": list(health.get("config", {}).keys()),
+                }
 
     return SettingsResponse(
         arm_config=arm_config,

--- a/backend/routers/transcoder.py
+++ b/backend/routers/transcoder.py
@@ -1,11 +1,16 @@
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from backend.dependencies import require_transcoder_enabled
 from backend.models.schemas import LogContentResponse, LogFileSchema, StructuredLogResponse, TranscoderJobListResponse, TranscoderStatsResponse
 from backend.services import transcoder_client
 
-router = APIRouter(prefix="/api/transcoder", tags=["transcoder"])
+router = APIRouter(
+    prefix="/api/transcoder",
+    tags=["transcoder"],
+    dependencies=[Depends(require_transcoder_enabled)],
+)
 
 
 @router.get("/workers")

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -1,0 +1,9 @@
+export interface AppConfig {
+	transcoder_enabled: boolean;
+}
+
+export async function fetchConfig(): Promise<AppConfig> {
+	const res = await fetch('/api/config');
+	if (!res.ok) throw new Error(`Config fetch failed: ${res.status}`);
+	return (await res.json()) as AppConfig;
+}

--- a/frontend/src/lib/components/BottomStatsBar.svelte
+++ b/frontend/src/lib/components/BottomStatsBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { HardwareInfo, SystemStats } from '$lib/types/arm';
+	import { transcoderEnabled } from '$lib/stores/config';
 
 	interface Props {
 		systemInfo: HardwareInfo | null;
@@ -15,7 +16,13 @@
 	type Panel = 'ripper' | 'transcoder' | 'gpu';
 	let activePanel = $state<Panel>('ripper');
 
-	const hasGpu = $derived(transcoderOnline && transcoderStats?.gpu != null);
+	$effect(() => {
+		if (!$transcoderEnabled && (activePanel === 'transcoder' || activePanel === 'gpu')) {
+			activePanel = 'ripper';
+		}
+	});
+
+	const hasGpu = $derived($transcoderEnabled && transcoderOnline && transcoderStats?.gpu != null);
 
 	const activeStats = $derived(activePanel === 'ripper' ? (armOnline ? systemStats : null) : (transcoderOnline ? transcoderStats : null));
 	const isOffline = $derived(
@@ -82,6 +89,7 @@
 					? 'bg-primary/20 text-primary-text shadow-xs dark:bg-primary/25 dark:text-primary-text-dark'
 					: 'text-primary-text/50 hover:text-primary-text dark:text-primary-text-dark/50 dark:hover:text-primary-text-dark'}"
 		>Ripper</button>
+		{#if $transcoderEnabled}
 		<button
 			onclick={() => activePanel = 'transcoder'}
 			class="rounded-sm px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider transition-colors
@@ -89,6 +97,7 @@
 					? 'bg-primary/20 text-primary-text shadow-xs dark:bg-primary/25 dark:text-primary-text-dark'
 					: 'text-primary-text/50 hover:text-primary-text dark:text-primary-text-dark/50 dark:hover:text-primary-text-dark'}"
 		>Transcoder</button>
+		{/if}
 		{#if hasGpu}
 			<button
 				onclick={() => activePanel = 'gpu'}

--- a/frontend/src/lib/components/EmptyDashboardPanel.svelte
+++ b/frontend/src/lib/components/EmptyDashboardPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { transcoderEnabled } from '$lib/stores/config';
+
     interface Props {
         drivesOnline: number;
         armOnline: boolean;
@@ -14,7 +16,9 @@
             <circle cx="12" cy="12" r="3" />
             <circle cx="12" cy="12" r="6.5" stroke-width="0.75" opacity="0.4" />
         </svg>
-        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">No active rips or transcodes</p>
-        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Insert a disc to get started - {drivesOnline} drive{drivesOnline !== 1 ? 's' : ''} online{#if !armOnline}, ARM offline{/if}{#if !transcoderOnline}, transcoder offline{/if}</p>
+        <p class="mt-3 text-sm font-medium text-gray-500 dark:text-gray-400">
+            {$transcoderEnabled ? 'No active rips or transcodes' : 'No active rips'}
+        </p>
+        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Insert a disc to get started - {drivesOnline} drive{drivesOnline !== 1 ? 's' : ''} online{#if !armOnline}, ARM offline{/if}{#if $transcoderEnabled && !transcoderOnline}, transcoder offline{/if}</p>
     </div>
 </section>

--- a/frontend/src/lib/components/SidebarStats.svelte
+++ b/frontend/src/lib/components/SidebarStats.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { HardwareInfo, SystemStats } from '$lib/types/arm';
 	import ProgressBar from './ProgressBar.svelte';
+	import { transcoderEnabled } from '$lib/stores/config';
 
 	interface Props {
 		systemInfo: HardwareInfo | null;
@@ -16,7 +17,13 @@
 	type Panel = 'ripper' | 'transcoder' | 'gpu';
 	let activePanel = $state<Panel>('ripper');
 
-	const hasGpu = $derived(transcoderOnline && transcoderStats?.gpu != null);
+	$effect(() => {
+		if (!$transcoderEnabled && (activePanel === 'transcoder' || activePanel === 'gpu')) {
+			activePanel = 'ripper';
+		}
+	});
+
+	const hasGpu = $derived($transcoderEnabled && transcoderOnline && transcoderStats?.gpu != null);
 
 	const activeHw = $derived(activePanel === 'ripper' ? (armOnline ? systemInfo : null) : (transcoderOnline ? transcoderInfo : null));
 	const activeStats = $derived(activePanel === 'ripper' ? (armOnline ? systemStats : null) : (transcoderOnline ? transcoderStats : null));
@@ -59,6 +66,7 @@
 					? 'bg-primary/20 text-primary-text shadow-xs dark:bg-primary/25 dark:text-primary-text-dark'
 					: 'text-primary-text/50 hover:text-primary-text dark:text-primary-text-dark/50 dark:hover:text-primary-text-dark'}"
 		>Ripper</button>
+		{#if $transcoderEnabled}
 		<button
 			onclick={() => activePanel = 'transcoder'}
 			class="flex-1 rounded-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider transition-colors
@@ -66,6 +74,7 @@
 					? 'bg-primary/20 text-primary-text shadow-xs dark:bg-primary/25 dark:text-primary-text-dark'
 					: 'text-primary-text/50 hover:text-primary-text dark:text-primary-text-dark/50 dark:hover:text-primary-text-dark'}"
 		>Transcoder</button>
+		{/if}
 		{#if hasGpu}
 			<button
 				onclick={() => activePanel = 'gpu'}

--- a/frontend/src/lib/stores/__tests__/config.test.ts
+++ b/frontend/src/lib/stores/__tests__/config.test.ts
@@ -21,7 +21,7 @@ describe('config store', () => {
 	});
 
 	it('hydrateConfig calls /api/config and updates store', async () => {
-		global.fetch = vi.fn().mockResolvedValueOnce({
+		globalThis.fetch = vi.fn().mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ transcoder_enabled: false })
 		}) as unknown as typeof fetch;
@@ -32,7 +32,7 @@ describe('config store', () => {
 	});
 
 	it('hydrateConfig falls back to true on fetch failure', async () => {
-		global.fetch = vi.fn().mockRejectedValueOnce(new Error('network')) as unknown as typeof fetch;
+		globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('network')) as unknown as typeof fetch;
 
 		const { transcoderEnabled, hydrateConfig, setTranscoderEnabled } = await import('../config');
 		setTranscoderEnabled(false);

--- a/frontend/src/lib/stores/__tests__/config.test.ts
+++ b/frontend/src/lib/stores/__tests__/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+describe('config store', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+	});
+
+	it('defaults to transcoderEnabled=true before hydration', async () => {
+		const { transcoderEnabled } = await import('../config');
+		expect(get(transcoderEnabled)).toBe(true);
+	});
+
+	it('setTranscoderEnabled updates store', async () => {
+		const { transcoderEnabled, setTranscoderEnabled } = await import('../config');
+		setTranscoderEnabled(false);
+		expect(get(transcoderEnabled)).toBe(false);
+		setTranscoderEnabled(true);
+		expect(get(transcoderEnabled)).toBe(true);
+	});
+
+	it('hydrateConfig calls /api/config and updates store', async () => {
+		global.fetch = vi.fn().mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ transcoder_enabled: false })
+		}) as unknown as typeof fetch;
+
+		const { transcoderEnabled, hydrateConfig } = await import('../config');
+		await hydrateConfig();
+		expect(get(transcoderEnabled)).toBe(false);
+	});
+
+	it('hydrateConfig falls back to true on fetch failure', async () => {
+		global.fetch = vi.fn().mockRejectedValueOnce(new Error('network')) as unknown as typeof fetch;
+
+		const { transcoderEnabled, hydrateConfig, setTranscoderEnabled } = await import('../config');
+		setTranscoderEnabled(false);
+		await hydrateConfig();
+		expect(get(transcoderEnabled)).toBe(true);
+	});
+});

--- a/frontend/src/lib/stores/config.ts
+++ b/frontend/src/lib/stores/config.ts
@@ -1,0 +1,19 @@
+import { writable } from 'svelte/store';
+import { fetchConfig } from '$lib/api/config';
+
+const _transcoderEnabled = writable<boolean>(true);
+
+export const transcoderEnabled = { subscribe: _transcoderEnabled.subscribe };
+
+export function setTranscoderEnabled(value: boolean): void {
+	_transcoderEnabled.set(value);
+}
+
+export async function hydrateConfig(): Promise<void> {
+	try {
+		const cfg = await fetchConfig();
+		_transcoderEnabled.set(cfg.transcoder_enabled);
+	} catch {
+		_transcoderEnabled.set(true);
+	}
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import { theme, toggleTheme } from '$lib/stores/theme';
 	import { colorScheme, schemeLocksMode, loadThemesFromApi } from '$lib/stores/colorScheme';
 	import { dashboard } from '$lib/stores/dashboard';
+	import { transcoderEnabled } from '$lib/stores/config';
 	import { setRippingEnabled } from '$lib/api/dashboard';
 	import SidebarStats from '$lib/components/SidebarStats.svelte';
 	import BottomStatsBar from '$lib/components/BottomStatsBar.svelte';
@@ -67,7 +68,7 @@
 		return () => dashboard.stop();
 	});
 
-	const navItems = [
+	const allNavItems = [
 		{ href: '/', label: 'Dashboard', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
 		{ href: '/notifications', label: 'Notifications', icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9' },
 		{ href: '/logs', label: 'Logs', icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
@@ -75,6 +76,7 @@
 		{ href: '/transcoder', label: 'Transcoder', icon: 'M7 4V2a1 1 0 012 0v2h6V2a1 1 0 012 0v2h1a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h1zm0 8h10m-10 4h6' },
 		{ href: '/settings', label: 'Settings', icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
 	];
+	const navItems = $derived($transcoderEnabled ? allNavItems : allNavItems.filter(i => i.href !== '/transcoder'));
 
 	function isActive(href: string, pathname: string): boolean {
 		if (href === '/') return pathname === '/';
@@ -238,6 +240,7 @@
 								</svg>
 								Restart ARM
 							</button>
+							{#if $transcoderEnabled}
 							<button
 								type="button"
 								onclick={() => handleQuickAction('restart-transcoder')}
@@ -248,6 +251,7 @@
 								</svg>
 								Restart Transcoder
 							</button>
+							{/if}
 							<div class="my-1 border-t border-primary/10 dark:border-primary/20"></div>
 							<button
 								type="button"

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
+import { hydrateConfig } from '$lib/stores/config';
 
 export const prerender = false;
 export const ssr = false;
@@ -9,7 +10,15 @@ export const ssr = false;
 // since completing setup or clearing the DB are deliberate actions.
 let setupConfirmedComplete = false;
 
+// Hydrate feature flags once per page load.
+let configHydrated = false;
+
 export const load: LayoutLoad = async ({ url, fetch }) => {
+	if (!configHydrated) {
+		await hydrateConfig();
+		configHydrated = true;
+	}
+
 	// Skip setup check if already on /setup
 	if (url.pathname.startsWith('/setup')) return {};
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -18,6 +18,7 @@
 	import EmptyDashboardPanel from '$lib/components/EmptyDashboardPanel.svelte';
 	import { fadeIn, fadeOut } from '$lib/transitions';
 	import { fade } from 'svelte/transition';
+	import { transcoderEnabled } from '$lib/stores/config';
 
 	// --- Dashboard state (simple $state, no store) ---
 	let dash = $state<DashboardData>({
@@ -59,6 +60,7 @@
 	}));
 	let finishingJobs = $derived(dash.active_jobs.filter(j => {
 		const s = j.status?.toLowerCase();
+		if (!$transcoderEnabled && s === 'waiting_transcode') return false;
 		return s === 'copying' || s === 'ejecting' || s === 'waiting_transcode';
 	}));
 
@@ -416,7 +418,7 @@
 	{/if}
 
 	<!-- Active transcodes -->
-	{#if dash.active_transcodes.length > 0}
+	{#if $transcoderEnabled && dash.active_transcodes.length > 0}
 		<section in:fade={fadeIn} out:fade={fadeOut}>
 			<SectionFrame variant="full" accent="var(--color-primary)" label="TRANSCODING — {dash.active_transcodes.length} ACTIVE">
 				<div class="space-y-2">

--- a/frontend/src/routes/__tests__/transcoder-guard.test.ts
+++ b/frontend/src/routes/__tests__/transcoder-guard.test.ts
@@ -13,39 +13,25 @@ vi.mock('@sveltejs/kit', () => ({
 	}
 }));
 
-describe('transcoder route guard', () => {
+const GUARDED_ROUTES = [
+	{ name: 'transcoder route guard', path: '../transcoder/+page' },
+	{ name: 'logs/transcoder/[filename] route guard', path: '../logs/transcoder/[filename]/+page' },
+] as const;
+
+describe.each(GUARDED_ROUTES)('$name', ({ path }) => {
 	beforeEach(() => {
 		setTranscoderEnabled(true);
 	});
 
 	it('redirects to / when transcoder is disabled', async () => {
 		setTranscoderEnabled(false);
-		const { load } = await import('../transcoder/+page');
+		const { load } = await import(/* @vite-ignore */ path);
 		await expect(load({} as never)).rejects.toThrow(/redirect 302 \//);
 	});
 
 	it('passes through when transcoder is enabled', async () => {
 		setTranscoderEnabled(true);
-		const { load } = await import('../transcoder/+page');
-		const result = await load({} as never);
-		expect(result).toEqual({});
-	});
-});
-
-describe('logs/transcoder/[filename] route guard', () => {
-	beforeEach(() => {
-		setTranscoderEnabled(true);
-	});
-
-	it('redirects to / when transcoder is disabled', async () => {
-		setTranscoderEnabled(false);
-		const { load } = await import('../logs/transcoder/[filename]/+page');
-		await expect(load({} as never)).rejects.toThrow(/redirect 302 \//);
-	});
-
-	it('passes through when transcoder is enabled', async () => {
-		setTranscoderEnabled(true);
-		const { load } = await import('../logs/transcoder/[filename]/+page');
+		const { load } = await import(/* @vite-ignore */ path);
 		const result = await load({} as never);
 		expect(result).toEqual({});
 	});

--- a/frontend/src/routes/__tests__/transcoder-guard.test.ts
+++ b/frontend/src/routes/__tests__/transcoder-guard.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setTranscoderEnabled } from '$lib/stores/config';
+
+vi.mock('@sveltejs/kit', () => ({
+	redirect: (status: number, location: string) => {
+		const e = new Error(`redirect ${status} ${location}`) as Error & {
+			status: number;
+			location: string;
+		};
+		e.status = status;
+		e.location = location;
+		throw e;
+	}
+}));
+
+describe('transcoder route guard', () => {
+	beforeEach(() => {
+		setTranscoderEnabled(true);
+	});
+
+	it('redirects to / when transcoder is disabled', async () => {
+		setTranscoderEnabled(false);
+		const { load } = await import('../transcoder/+page');
+		await expect(load({} as never)).rejects.toThrow(/redirect 302 \//);
+	});
+
+	it('passes through when transcoder is enabled', async () => {
+		setTranscoderEnabled(true);
+		const { load } = await import('../transcoder/+page');
+		const result = await load({} as never);
+		expect(result).toEqual({});
+	});
+});
+
+describe('logs/transcoder/[filename] route guard', () => {
+	beforeEach(() => {
+		setTranscoderEnabled(true);
+	});
+
+	it('redirects to / when transcoder is disabled', async () => {
+		setTranscoderEnabled(false);
+		const { load } = await import('../logs/transcoder/[filename]/+page');
+		await expect(load({} as never)).rejects.toThrow(/redirect 302 \//);
+	});
+
+	it('passes through when transcoder is enabled', async () => {
+		setTranscoderEnabled(true);
+		const { load } = await import('../logs/transcoder/[filename]/+page');
+		const result = await load({} as never);
+		expect(result).toEqual({});
+	});
+});

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -23,6 +23,8 @@
 	import { formatDateTime, timeAgo, statusLabel } from '$lib/utils/format';
 	import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
 	import { buildMetadataFields } from '$lib/utils/job-fields';
+	import { transcoderEnabled } from '$lib/stores/config';
+	import { get } from 'svelte/store';
 	import LoadState from '$lib/components/LoadState.svelte';
 	import SkeletonCard from '$lib/components/SkeletonCard.svelte';
 
@@ -257,21 +259,23 @@
 				namingPreviews = {};
 			});
 			// Look up transcoder job info for this ARM job (logfile + progress)
-			fetchTranscoderLogForArmJob(id).then((info) => {
-				if (info.found) {
-					transcoderLogfile = info.logfile ?? null;
-					transcoderProgress = info.progress ?? null;
-					transcoderJobStatus = info.status ?? null;
-				} else {
+			if (get(transcoderEnabled)) {
+				fetchTranscoderLogForArmJob(id).then((info) => {
+					if (info.found) {
+						transcoderLogfile = info.logfile ?? null;
+						transcoderProgress = info.progress ?? null;
+						transcoderJobStatus = info.status ?? null;
+					} else {
+						transcoderLogfile = null;
+						transcoderProgress = null;
+						transcoderJobStatus = null;
+					}
+				}).catch(() => {
 					transcoderLogfile = null;
 					transcoderProgress = null;
 					transcoderJobStatus = null;
-				}
-			}).catch(() => {
-				transcoderLogfile = null;
-				transcoderProgress = null;
-				transcoderJobStatus = null;
-			});
+				});
+			}
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('404')) {
 				goto('/');
@@ -315,7 +319,7 @@
 			// Clear stale rip progress once the phase changes so 100% doesn't linger
 			ripProgress = null;
 		}
-		if (s === 'waiting_transcode' || s === 'transcoding' || s === 'copying') {
+		if ((s === 'waiting_transcode' || s === 'transcoding' || s === 'copying') && get(transcoderEnabled)) {
 			try {
 				const info = await fetchTranscoderLogForArmJob(job.job_id);
 				if (info.found) {
@@ -396,7 +400,7 @@
 
 				<!-- Action buttons pushed right -->
 				<div class="flex flex-wrap items-center gap-2 ml-auto">
-					{#if isVideoDisc && (job.status === 'success' || job.status === 'fail')}
+					{#if $transcoderEnabled && isVideoDisc && (job.status === 'success' || job.status === 'fail')}
 						<button
 							onclick={handleRetranscode}
 							disabled={retranscoding}
@@ -405,7 +409,7 @@
 							{retranscoding ? 'Queuing...' : 'Re-transcode'}
 						</button>
 					{/if}
-					{#if job.status === 'waiting_transcode'}
+					{#if $transcoderEnabled && job.status === 'waiting_transcode'}
 						<button
 							onclick={() => (showSkipConfirm = true)}
 							disabled={skippingTranscode}
@@ -498,7 +502,7 @@
 				{#if isVideoDisc && (job.video_type === 'series' || job.imdb_id)}
 					<button onclick={() => (activePanel = activePanel === 'tvdb' ? null : 'tvdb')} class={panelTabClass('tvdb')}>Episodes</button>
 				{/if}
-				{#if isVideoDisc}
+				{#if $transcoderEnabled && isVideoDisc}
 					<button onclick={() => (activePanel = activePanel === 'transcode' ? null : 'transcode')} class={panelTabClass('transcode')}>Transcode Settings</button>
 				{/if}
 				{#if hasCrcData}
@@ -527,7 +531,7 @@
 				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
 					<EpisodeMatch {job} onapply={loadJob} />
 				</div>
-			{:else if activePanel === 'transcode'}
+			{:else if $transcoderEnabled && activePanel === 'transcode'}
 				<div class="border-t border-primary/15 p-5 dark:border-primary/15">
 					<TranscodeOverrides {job} onsaved={loadJob} />
 				</div>
@@ -612,7 +616,7 @@
 		{#if job.logfile}
 			<InlineLogFeed logfile={job.logfile} maxEntries={15} title="ARM Ripper Log" />
 		{/if}
-		{#if transcoderLogfile && transcoderJobStatus && !isMusicDisc && job?.disctype !== 'data'}
+		{#if $transcoderEnabled && transcoderLogfile && transcoderJobStatus && !isMusicDisc && job?.disctype !== 'data'}
 			<InlineLogFeed
 				logfile={transcoderLogfile}
 				maxEntries={15}

--- a/frontend/src/routes/logs/+page.svelte
+++ b/frontend/src/routes/logs/+page.svelte
@@ -7,6 +7,7 @@
 	import { formatBytes, formatDateTime } from '$lib/utils/format';
 	import LoadState from '$lib/components/LoadState.svelte';
 	import SkeletonCard from '$lib/components/SkeletonCard.svelte';
+	import { transcoderEnabled } from '$lib/stores/config';
 
 	let deleting = $state<string | null>(null);
 	let deleteFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
@@ -36,6 +37,10 @@
 	}
 
 	let activeTab = $state<'arm' | 'transcoder'>('arm');
+
+	$effect(() => {
+		if (!$transcoderEnabled && activeTab === 'transcoder') activeTab = 'arm';
+	});
 	let armLogs = $state<LogFile[]>([]);
 	let transcoderLogs = $state<LogFile[]>([]);
 	let armLoading = $state(true);
@@ -171,6 +176,7 @@
 			>
 				ARM Ripper
 			</button>
+			{#if $transcoderEnabled}
 			<button
 				type="button"
 				onclick={() => switchTab('transcoder')}
@@ -181,6 +187,7 @@
 			>
 				Transcoder
 			</button>
+			{/if}
 		</nav>
 	</div>
 

--- a/frontend/src/routes/logs/transcoder/[filename]/+page.ts
+++ b/frontend/src/routes/logs/transcoder/[filename]/+page.ts
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+import { get } from 'svelte/store';
+import { transcoderEnabled } from '$lib/stores/config';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+	if (!get(transcoderEnabled)) {
+		throw redirect(302, '/');
+	}
+	return {};
+};

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -21,6 +21,8 @@
 	import PresetEditor from '$lib/components/PresetEditor.svelte';
 	import { fetchTranscoderScheme, fetchTranscoderPresets, createCustomPreset } from '$lib/api/settings';
 	import type { Scheme, Preset, Overrides, PresetEditorState } from '$lib/types/presets';
+	import { transcoderEnabled } from '$lib/stores/config';
+	import { get } from 'svelte/store';
 
 	let settings = $state<SettingsData | null>(null);
 	let settingsLoading = $state(true);
@@ -169,14 +171,21 @@
 	}
 
 	// --- Tab state ---
-	const validTabs = ['ripping', 'music', 'transcoding', 'notifications', 'appearance', 'drives', 'system'] as const;
-	type Tab = typeof validTabs[number];
+	const allTabs = ['ripping', 'music', 'transcoding', 'notifications', 'appearance', 'drives', 'system'] as const;
+	type Tab = typeof allTabs[number];
+	const validTabs = $derived(
+		$transcoderEnabled ? allTabs : (allTabs.filter(t => t !== 'transcoding') as readonly Tab[])
+	);
 
 	function parseHash(): { tab: Tab; panel: string | null } {
 		if (typeof window === 'undefined') return { tab: 'ripping', panel: null };
 		const hash = window.location.hash.replace('#', '');
 		const [tabPart, ...panelParts] = hash.split('/');
-		const tab = validTabs.includes(tabPart as Tab) ? (tabPart as Tab) : 'ripping';
+		const tcEnabled = get(transcoderEnabled);
+		const allowedTabs: readonly Tab[] = tcEnabled
+			? allTabs
+			: (allTabs.filter(t => t !== 'transcoding') as readonly Tab[]);
+		const tab = allowedTabs.includes(tabPart as Tab) ? (tabPart as Tab) : 'ripping';
 		const panel = panelParts.length > 0 ? decodeURIComponent(panelParts.join('/')) : null;
 		return { tab, panel };
 	}
@@ -842,7 +851,9 @@
 				{ keys: ['MAKEMKV_PERMA_KEY', 'MAKEMKV_COMMUNITY_KEYDB', 'MAX_CONCURRENT_MAKEMKVINFO', 'PRESCAN_TIMEOUT', 'PRESCAN_CACHE_MB', 'PRESCAN_RETRIES', 'DISC_ENUM_TIMEOUT'] },
 			]},
 			{ label: 'Post-Rip', subpanels: [
-				{ keys: ['SKIP_TRANSCODE', 'AUTO_EJECT', 'DELRAWFILES', 'RIP_POSTER'] },
+				{ keys: $transcoderEnabled
+					? ['SKIP_TRANSCODE', 'AUTO_EJECT', 'DELRAWFILES', 'RIP_POSTER']
+					: ['AUTO_EJECT', 'DELRAWFILES', 'RIP_POSTER'] },
 			]},
 			{ label: 'Media Directories', subpanels: [
 				{ keys: ['RAW_PATH', 'TRANSCODE_PATH', 'COMPLETED_PATH', 'MUSIC_PATH', 'INGRESS_PATH', 'EXTRAS_SUB'] },
@@ -874,11 +885,13 @@
 		],
 		notifications: [
 			{ label: 'Triggers', subpanels: [
-				{ keys: ['NOTIFY_RIP', 'NOTIFY_TRANSCODE', 'NOTIFY_JOBID'] },
+				{ keys: $transcoderEnabled
+					? ['NOTIFY_RIP', 'NOTIFY_TRANSCODE', 'NOTIFY_JOBID']
+					: ['NOTIFY_RIP', 'NOTIFY_JOBID'] },
 			]},
-			{ label: 'Transcoder', subpanels: [
+			...($transcoderEnabled ? [{ label: 'Transcoder', subpanels: [
 				{ keys: ['TRANSCODER_URL', 'TRANSCODER_WEBHOOK_SECRET', 'LOCAL_RAW_PATH', 'SHARED_RAW_PATH'] },
-			]},
+			]}] : []),
 			{ label: 'Apprise', subpanels: [
 				{ keys: ['JSON_URL', 'APPRISE'] },
 			]},
@@ -1337,7 +1350,9 @@
 			<nav class="-mb-px flex gap-4" aria-label="Settings tabs">
 				<button type="button" onclick={() => setTab('ripping')} class={tabClass('ripping')}>Ripping</button>
 				<button type="button" onclick={() => setTab('music')} class={tabClass('music')}>Music</button>
+				{#if $transcoderEnabled}
 				<button type="button" onclick={() => setTab('transcoding')} class={tabClass('transcoding')}>Transcoding</button>
+				{/if}
 				<button type="button" onclick={() => setTab('notifications')} class={tabClass('notifications')}>Notifications</button>
 				<button type="button" onclick={() => setTab('drives')} class={tabClass('drives')}>Drives</button>
 				<button type="button" onclick={() => setTab('appearance')} class={tabClass('appearance')}>Appearance</button>
@@ -1348,7 +1363,7 @@
 		<SystemHealth />
 
 		<!-- Transcoding Tab -->
-		{#if activeTab === 'transcoding'}
+		{#if activeTab === 'transcoding' && $transcoderEnabled}
 			<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
 			<div class="rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
 				These settings configure the <strong>dedicated transcoder service</strong>, a separate GPU-accelerated container that handles all transcoding. ARM rips discs and notifies this service to transcode.
@@ -2102,6 +2117,7 @@
 						</div>
 					</div>
 					<!-- Transcoder Restart -->
+					{#if $transcoderEnabled}
 					<div class="rounded-lg border border-red-200 bg-red-50/50 p-4 dark:border-red-800 dark:bg-red-900/10">
 						<div class="flex items-center justify-between">
 							<div>
@@ -2121,6 +2137,7 @@
 							</button>
 						</div>
 					</div>
+					{/if}
 				</div>
 			</section>
 		{/if}

--- a/frontend/src/routes/transcoder/+page.ts
+++ b/frontend/src/routes/transcoder/+page.ts
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+import { get } from 'svelte/store';
+import { transcoderEnabled } from '$lib/stores/config';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+	if (!get(transcoderEnabled)) {
+		throw redirect(302, '/');
+	}
+	return {};
+};

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,17 @@ async def app_client():
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             yield client
+
+
+@pytest.fixture
+async def ripper_only_app_client(monkeypatch):
+    """Async httpx client with transcoder_enabled=False. Use for rip-only assertions."""
+    from backend.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "transcoder_enabled", False)
+    with patch.object(system_cache, "refresh", new_callable=AsyncMock):
+        from backend.main import app
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ async def app_client():
         from backend.main import app
 
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # NOSONAR: httpx ASGI transport requires a base_url; no network call is made
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:  # NOSONAR
             yield client
 
 
@@ -56,5 +57,5 @@ async def ripper_only_app_client(monkeypatch):
         from backend.main import app
 
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:  # NOSONAR
             yield client

--- a/tests/routers/test_config.py
+++ b/tests/routers/test_config.py
@@ -1,0 +1,15 @@
+"""Tests for GET /api/config feature-flag discovery endpoint."""
+
+from __future__ import annotations
+
+
+async def test_config_endpoint_returns_flag_true_by_default(app_client):
+    resp = await app_client.get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json() == {"transcoder_enabled": True}
+
+
+async def test_config_endpoint_returns_flag_false_when_disabled(ripper_only_app_client):
+    resp = await ripper_only_app_client.get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json() == {"transcoder_enabled": False}

--- a/tests/routers/test_dashboard.py
+++ b/tests/routers/test_dashboard.py
@@ -131,3 +131,33 @@ async def test_makemkv_key_check_arm_error(app_client):
     ):
         resp = await app_client.post("/api/dashboard/makemkv-key-check")
     assert resp.status_code == 502
+
+
+# --- Ripper-only short-circuit ---
+
+async def test_dashboard_skips_transcoder_when_disabled(ripper_only_app_client, monkeypatch):
+    """Dashboard must return disabled transcoder payload without calling transcoder_client."""
+    from backend.services import transcoder_client
+
+    called = {"flag": False}
+
+    async def _should_not_be_called(*args, **kwargs):
+        called["flag"] = True
+        return None
+
+    monkeypatch.setattr(transcoder_client, "health", _should_not_be_called)
+    monkeypatch.setattr(transcoder_client, "get_stats", _should_not_be_called)
+    monkeypatch.setattr(transcoder_client, "get_jobs", _should_not_be_called)
+    monkeypatch.setattr(transcoder_client, "get_system_stats", _should_not_be_called)
+
+    with patch("backend.routers.dashboard.arm_client.get_system_stats", new_callable=AsyncMock, return_value=None):
+        resp = await ripper_only_app_client.get("/api/dashboard")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["transcoder_online"] is False
+    assert data["transcoder_stats"] is None
+    assert data["transcoder_system_stats"] is None
+    assert data["active_transcodes"] == []
+    assert data["transcoder_info"] is None
+    assert called["flag"] is False, "transcoder_client was called despite flag being off"

--- a/tests/routers/test_jobs.py
+++ b/tests/routers/test_jobs.py
@@ -236,3 +236,18 @@ async def test_get_naming_variables_arm_unreachable(app_client):
     with patch("backend.routers.jobs.arm_client.get_naming_variables", new_callable=AsyncMock, return_value=None):
         resp = await app_client.get("/api/naming/variables")
     assert resp.status_code == 503
+
+
+# --- Ripper-only gating ---
+
+async def test_transcode_config_gated_when_disabled(ripper_only_app_client):
+    resp = await ripper_only_app_client.patch("/api/jobs/1/transcode-config", json={})
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Transcoder disabled on this deployment"
+
+
+async def test_retranscode_gated_when_disabled(ripper_only_app_client):
+    resp = await ripper_only_app_client.post("/api/jobs/1/retranscode")
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Transcoder disabled on this deployment"
+

--- a/tests/routers/test_settings.py
+++ b/tests/routers/test_settings.py
@@ -314,3 +314,31 @@ async def test_transcoder_settings_gated_when_disabled(ripper_only_app_client, m
     resp = await ripper_only_app_client.request(method, path, json={})
     assert resp.status_code == 503
     assert resp.json()["detail"] == "Transcoder disabled on this deployment"
+
+
+async def test_settings_aggregate_skips_transcoder_when_disabled(ripper_only_app_client, monkeypatch):
+    """When flag is off, aggregate GET /api/settings must not call transcoder_client."""
+    from unittest.mock import AsyncMock, patch
+
+    from backend.services import transcoder_client
+
+    called = {"flag": False}
+
+    async def _should_not_be_called(*args, **kwargs):
+        called["flag"] = True
+        return None
+
+    monkeypatch.setattr(transcoder_client, "get_config", _should_not_be_called)
+    monkeypatch.setattr(transcoder_client, "health", _should_not_be_called)
+
+    with patch("backend.routers.settings.arm_client.get_config", new=AsyncMock(return_value=None)):
+        with patch("backend.routers.settings.arm_db.get_all_config_safe", return_value={}):
+            resp = await ripper_only_app_client.get("/api/settings")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["transcoder_config"] is None
+    assert data["transcoder_gpu_support"] is None
+    assert data["transcoder_auth_status"] is None
+    assert data["gpu_support"] is None
+    assert called["flag"] is False, "transcoder_client was called despite flag being off"

--- a/tests/routers/test_settings.py
+++ b/tests/routers/test_settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from unittest.mock import AsyncMock, patch
 
 
@@ -292,3 +293,24 @@ async def test_system_info_transcoder_version(app_client):
         resp = await app_client.get("/api/settings/system-info")
     assert resp.status_code == 200
     assert resp.json()["versions"]["transcoder"] == "10.9.1"
+
+
+# --- Ripper-only gating for transcoder-scoped settings ---
+
+TRANSCODER_SETTINGS_GATED_ENDPOINTS = [
+    ("GET", "/api/settings/transcoder/scheme"),
+    ("GET", "/api/settings/transcoder/presets"),
+    ("POST", "/api/settings/transcoder/presets"),
+    ("PATCH", "/api/settings/transcoder/presets/foo"),
+    ("DELETE", "/api/settings/transcoder/presets/foo"),
+    ("PATCH", "/api/settings/transcoder"),
+    ("POST", "/api/settings/transcoder/test-connection"),
+    ("POST", "/api/settings/transcoder/test-webhook"),
+]
+
+
+@pytest.mark.parametrize("method,path", TRANSCODER_SETTINGS_GATED_ENDPOINTS)
+async def test_transcoder_settings_gated_when_disabled(ripper_only_app_client, method, path):
+    resp = await ripper_only_app_client.request(method, path, json={})
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Transcoder disabled on this deployment"

--- a/tests/routers/test_transcoder.py
+++ b/tests/routers/test_transcoder.py
@@ -381,3 +381,26 @@ async def test_get_job_for_arm_filters_by_job_id_not_most_recent(app_client):
         f"to avoid stale-correlation; got kwargs={kwargs!r}"
     )
     assert "arm_job_id" not in kwargs
+
+
+# --- Ripper-only gating ---
+
+TRANSCODER_GATED_ENDPOINTS = [
+    ("GET", "/api/transcoder/workers"),
+    ("GET", "/api/transcoder/stats"),
+    ("GET", "/api/transcoder/jobs"),
+    ("POST", "/api/transcoder/jobs/1/retry"),
+    ("DELETE", "/api/transcoder/jobs/1"),
+    ("GET", "/api/transcoder/logs"),
+    ("GET", "/api/transcoder/logs/foo.log"),
+    ("GET", "/api/transcoder/logs/foo.log/structured"),
+    ("POST", "/api/transcoder/jobs/1/retranscode"),
+    ("GET", "/api/transcoder/job-for-arm/1"),
+]
+
+
+@pytest.mark.parametrize("method,path", TRANSCODER_GATED_ENDPOINTS)
+async def test_endpoint_returns_503_when_disabled(ripper_only_app_client, method, path):
+    resp = await ripper_only_app_client.request(method, path)
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Transcoder disabled on this deployment"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+import os
+
+import pytest
+
+from backend.config import Settings
+
+
+def test_transcoder_enabled_default_true(monkeypatch):
+    monkeypatch.delenv("ARM_UI_TRANSCODER_ENABLED", raising=False)
+    s = Settings()
+    assert s.transcoder_enabled is True
+
+
+def test_transcoder_enabled_false_from_env(monkeypatch):
+    monkeypatch.setenv("ARM_UI_TRANSCODER_ENABLED", "false")
+    s = Settings()
+    assert s.transcoder_enabled is False
+
+
+def test_transcoder_enabled_true_from_env(monkeypatch):
+    monkeypatch.setenv("ARM_UI_TRANSCODER_ENABLED", "true")
+    s = Settings()
+    assert s.transcoder_enabled is True

--- a/tests/test_require_transcoder_enabled.py
+++ b/tests/test_require_transcoder_enabled.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from backend.config import settings
+from backend.dependencies import require_transcoder_enabled
+
+
+@pytest.fixture
+def app_with_gated_route():
+    app = FastAPI()
+
+    @app.get("/gated", dependencies=[pytest.importorskip("fastapi").Depends(require_transcoder_enabled)])
+    async def gated():
+        return {"ok": True}
+
+    return app
+
+
+def test_raises_503_when_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "transcoder_enabled", False)
+    with pytest.raises(HTTPException) as exc:
+        require_transcoder_enabled()
+    assert exc.value.status_code == 503
+    assert "Transcoder disabled" in exc.value.detail
+
+
+def test_noop_when_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "transcoder_enabled", True)
+    # Should not raise
+    result = require_transcoder_enabled()
+    assert result is None

--- a/tests/test_require_transcoder_enabled.py
+++ b/tests/test_require_transcoder_enabled.py
@@ -27,6 +27,6 @@ def test_raises_503_when_disabled(monkeypatch):
 
 def test_noop_when_enabled(monkeypatch):
     monkeypatch.setattr(settings, "transcoder_enabled", True)
-    # Should not raise
-    result = require_transcoder_enabled()
-    assert result is None
+    # Should not raise. require_transcoder_enabled returns None implicitly;
+    # the contract is "does not raise", so we don't assert on the return.
+    require_transcoder_enabled()

--- a/tests/test_ripper_only_fixture.py
+++ b/tests/test_ripper_only_fixture.py
@@ -1,0 +1,14 @@
+"""Smoke test for the ripper_only_app_client fixture."""
+
+from __future__ import annotations
+
+
+async def test_ripper_only_fixture_sets_flag_off(ripper_only_app_client):
+    from backend.config import settings
+    assert settings.transcoder_enabled is False
+
+
+async def test_ripper_only_fixture_restores_default(app_client):
+    """After a ripper_only_app_client test, the default app_client keeps flag True."""
+    from backend.config import settings
+    assert settings.transcoder_enabled is True


### PR DESCRIPTION
## Summary

- Add `ARM_UI_TRANSCODER_ENABLED` env flag that gates UI surfaces and short-circuits backend transcoder HTTP calls when false.
- Backend: new `require_transcoder_enabled` FastAPI dependency applied to every `/api/transcoder/*` endpoint, transcoder-scoped `/api/settings/transcoder/*` endpoints, and `/api/jobs/{id}/{transcode-config,retranscode}`. Dashboard aggregate + settings aggregate short-circuit their transcoder-client calls when disabled. New `/api/config` endpoint exposes the flag to the frontend.
- Frontend: new `transcoderEnabled` store hydrated from `/api/config` in root layout. All transcoder UI surfaces hidden when false: nav link, dashboard TRANSCODING section + `waiting_transcode` filter, settings transcoding tab + transcoder subpanels + `SKIP_TRANSCODE` field, logs transcoder tab, job detail `TranscodeOverrides`/Re-transcode/Skip-and-Finalize/polling, `SidebarStats`/`BottomStatsBar` transcoder+GPU panels, `EmptyDashboardPanel` transcoder-online indicator, and route guards on `/transcoder` and `/logs/transcoder/*`.
- Default is `true`, so existing all-in-one and remote-transcoder deployments are unchanged.

Companion: https://github.com/uprightbass360/automatic-ripping-machine-neu (ripper repo docker-compose.ripper-only.yml + arm.yaml renderer guard).

Spec: `ai/arm-neu/docs/superpowers/specs/2026-04-23-ripper-only-deployment-design.md`
Plan: `ai/arm-neu/docs/superpowers/plans/2026-04-23-ripper-only-deployment.md`

## Test plan

- [x] Backend: 696 pytest pass (including new ripper-only gating, settings/dashboard short-circuit, /api/config endpoint tests)
- [x] Frontend: 859 vitest pass (including config store, route guard, existing coverage)
- [x] svelte-check: 0 errors
- [x] `npm run build`: clean production build
- [x] uvicorn smoke with `ARM_UI_TRANSCODER_ENABLED=false`:
  - `/api/config` returns `{"transcoder_enabled":false}`
  - `/api/transcoder/stats` returns 503
  - `/api/dashboard` returns disabled transcoder payload and does not call transcoder_client
  - `/api/jobs/1/retranscode` returns 503
- [ ] End-to-end docker-compose bring-up against companion ripper-repo PR (deferred - run when deploying)