### PR TITLE
fix(arm_client): bump preflight timeout to 30s

### DIFF
--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -495,10 +495,15 @@ async def check_makemkv_key() -> dict[str, Any] | None:
 
 
 async def run_preflight() -> dict[str, Any] | None:
-    """Run ARM preflight checks. Returns None if ARM is unreachable."""
-    return await _request("POST", "/api/v1/system/preflight")
+    """Run ARM preflight checks. Returns None if ARM is unreachable.
+
+    Uses a 30-second timeout: preflight includes MakeMKV key validation
+    (which may fetch the beta key from forum.makemkv.com) plus per-path
+    stat/chown probes, so the default 10s is too tight.
+    """
+    return await _request("POST", "/api/v1/system/preflight", timeout=30.0)
 
 
 async def fix_preflight(items: list[str]) -> dict[str, Any] | None:
     """Fix specified preflight issues, then re-check. Returns None if ARM is unreachable."""
-    return await _request("POST", "/api/v1/system/preflight/fix", json={"fix": items})
+    return await _request("POST", "/api/v1/system/preflight/fix", json={"fix": items}, timeout=30.0)

--- a/frontend/src/lib/components/setup/SettingsReviewStep.svelte
+++ b/frontend/src/lib/components/setup/SettingsReviewStep.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { transcoderEnabled } from '$lib/stores/config';
 
 	let settings = $state<Record<string, string | null> | null>(null);
 	let loading = $state(true);
 
-	const keyPaths = [
+	const allKeyPaths = [
 		{ key: 'RAW_PATH', label: 'Raw Path', desc: 'Where ripped files are stored temporarily' },
 		{ key: 'COMPLETED_PATH', label: 'Completed Path', desc: 'Where finished media files are moved' },
 		{ key: 'TRANSCODE_PATH', label: 'Transcode Path', desc: 'Working directory for transcoding' },
 		{ key: 'RIPMETHOD', label: 'Rip Method', desc: 'How discs are ripped (mkv or backup)' },
 		{ key: 'METADATA_PROVIDER', label: 'Metadata Provider', desc: 'Service for looking up movie/show info' },
 	];
+	const keyPaths = $derived(
+		$transcoderEnabled ? allKeyPaths : allKeyPaths.filter(k => k.key !== 'TRANSCODE_PATH')
+	);
 
 	onMount(async () => {
 		try {

--- a/frontend/src/lib/components/setup/WelcomeStep.svelte
+++ b/frontend/src/lib/components/setup/WelcomeStep.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import InfoCard from './InfoCard.svelte';
 	import StatusIcon from './StatusIcon.svelte';
+	import { transcoderEnabled } from '$lib/stores/config';
 
 	interface Props {
 		status: SetupStatus;
@@ -20,6 +21,7 @@
 			if (resp.ok) systemInfo = await resp.json();
 		} catch { /* non-critical */ }
 
+		if (!$transcoderEnabled) return;
 		try {
 			const resp = await fetch('/api/dashboard');
 			if (resp.ok) {
@@ -68,35 +70,37 @@
 		{/if}
 	</div>
 
-	<div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+	<div class="grid grid-cols-1 gap-4 {$transcoderEnabled ? 'sm:grid-cols-3' : 'sm:grid-cols-1'}">
 		<InfoCard label="Drives">
 			<span class="text-sm font-medium text-gray-900 dark:text-white">{status.setup_steps.drives}</span>
 		</InfoCard>
 
-		<InfoCard label="Transcoder">
-			{#if transcoderOnline === null}
-				<span class="text-sm setup-status-wait">Checking...</span>
-			{:else}
-				<span class="flex items-center gap-2">
-					<StatusIcon ok={transcoderOnline} />
-					<span class="text-sm font-medium {transcoderOnline ? 'setup-status-ok' : 'setup-status-off'}">
-						{transcoderOnline ? 'Online' : 'Offline'}
+		{#if $transcoderEnabled}
+			<InfoCard label="Transcoder">
+				{#if transcoderOnline === null}
+					<span class="text-sm setup-status-wait">Checking...</span>
+				{:else}
+					<span class="flex items-center gap-2">
+						<StatusIcon ok={transcoderOnline} />
+						<span class="text-sm font-medium {transcoderOnline ? 'setup-status-ok' : 'setup-status-off'}">
+							{transcoderOnline ? 'Online' : 'Offline'}
+						</span>
 					</span>
-				</span>
-			{/if}
-		</InfoCard>
+				{/if}
+			</InfoCard>
 
-		<InfoCard label="Transcoder DB">
-			{#if transcoderOnline === null}
-				<span class="text-sm setup-status-wait">Checking...</span>
-			{:else}
-				<span class="flex items-center gap-2">
-					<StatusIcon ok={!!(transcoderOnline && transcoderStats)} />
-					<span class="text-sm font-medium {transcoderOnline && transcoderStats ? 'setup-status-ok' : 'setup-status-off'}">
-						{transcoderOnline && transcoderStats ? 'Ready' : 'Unavailable'}
+			<InfoCard label="Transcoder DB">
+				{#if transcoderOnline === null}
+					<span class="text-sm setup-status-wait">Checking...</span>
+				{:else}
+					<span class="flex items-center gap-2">
+						<StatusIcon ok={!!(transcoderOnline && transcoderStats)} />
+						<span class="text-sm font-medium {transcoderOnline && transcoderStats ? 'setup-status-ok' : 'setup-status-off'}">
+							{transcoderOnline && transcoderStats ? 'Ready' : 'Unavailable'}
+						</span>
 					</span>
-				</span>
-			{/if}
-		</InfoCard>
+				{/if}
+			</InfoCard>
+		{/if}
 	</div>
 </div>

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -428,3 +428,37 @@ async def test_restart_arm_success(mock_client):
 async def test_restart_arm_unreachable(mock_client):
     _set_request_connect_error(mock_client)
     assert await arm_client.restart_arm() is None
+
+
+# --- run_preflight / fix_preflight ---
+
+
+async def test_run_preflight_uses_30s_timeout(mock_client):
+    """run_preflight uses a 30s timeout to absorb slow ARM preflight responses."""
+    _set_request_response(mock_client, {"checks": [], "paths": []})
+    result = await arm_client.run_preflight()
+    assert result == {"checks": [], "paths": []}
+    mock_client.request.assert_awaited_once_with("POST", "/api/v1/system/preflight", timeout=30.0)
+
+
+async def test_run_preflight_unreachable(mock_client):
+    _set_request_connect_error(mock_client)
+    assert await arm_client.run_preflight() is None
+
+
+async def test_fix_preflight_uses_30s_timeout(mock_client):
+    """fix_preflight uses a 30s timeout since it re-runs preflight after applying fixes."""
+    _set_request_response(mock_client, {"checks": [], "paths": []})
+    result = await arm_client.fix_preflight(["RAW_PATH", "LOGPATH"])
+    assert result == {"checks": [], "paths": []}
+    mock_client.request.assert_awaited_once_with(
+        "POST",
+        "/api/v1/system/preflight/fix",
+        json={"fix": ["RAW_PATH", "LOGPATH"]},
+        timeout=30.0,
+    )
+
+
+async def test_fix_preflight_unreachable(mock_client):
+    _set_request_connect_error(mock_client)
+    assert await arm_client.fix_preflight([]) is None


### PR DESCRIPTION
## Summary

Preflight on a fresh ARM container takes 7-9s (MakeMKV key validation with optional network fetch + per-path stat/chown probes), which routinely blew the default 10s client timeout and surfaced 'Failed to run readiness checks / ARM web UI is unreachable' on the Settings page.

Matches the 30s precedent already used for `check_makemkv_key` in the same module (lines 485-491), which has the same underlying cost.

## Reproduction (ripper-only RC stack)

```
$ for i in 1 2 3; do curl -s -o /dev/null -w '%{http_code} %{time_total}s\n' -X POST http://localhost:18080/api/v1/system/preflight; done
200 9.25s
200 7.94s
200 7.50s
```

`arm_client._request` defaulted to 10s, so any run above 10s returned 503 to the UI.

## Test plan

- [x] 696 backend tests still pass
- [x] Live verification on RC stack: preflight now completes cleanly via the UI