### PR TITLE
feat(mobile): responsive enhancements across tables, layouts, drawer

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -135,6 +135,67 @@
 	/* Confirm dialog button variants */
 	.confirm-btn-danger  { @apply bg-red-600 text-white hover:bg-red-700; }
 	.confirm-btn-primary { @apply bg-primary text-on-primary hover:bg-primary/90; }
+
+	/* ------------------------------------------------------------------ */
+	/* Responsive table — stacks to cards below lg (1024px)               */
+	/*                                                                     */
+	/* Usage: add .responsive-table to the <table>. Each <td> that should  */
+	/* show a label when stacked must set data-label="Column Name".        */
+	/* The <thead> is hidden below lg; rows become cards with label cells. */
+	/* ------------------------------------------------------------------ */
+	@media (max-width: 1023.98px) {
+		.responsive-table,
+		.responsive-table thead,
+		.responsive-table tbody,
+		.responsive-table tr,
+		.responsive-table th,
+		.responsive-table td {
+			display: block;
+		}
+		.responsive-table thead {
+			position: absolute;
+			left: -9999px;
+		}
+		.responsive-table tr {
+			padding: 0.5rem 0.75rem;
+			border-bottom: 1px solid color-mix(in srgb, var(--color-primary) 15%, transparent);
+		}
+		.responsive-table tr:last-child { border-bottom: 0; }
+		.responsive-table td {
+			padding: 0.25rem 0;
+			border: 0;
+			max-width: 100%;
+		}
+		.responsive-table td[data-label]:not([data-label=""])::before {
+			content: attr(data-label);
+			display: block;
+			color: color-mix(in srgb, currentColor 55%, transparent);
+			font-size: 0.6875rem;
+			font-weight: 500;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			margin-bottom: 0.125rem;
+		}
+	}
+}
+
+/* Safe-area insets for mobile browsers */
+@layer utilities {
+	.safe-bottom { padding-bottom: max(0.5rem, env(safe-area-inset-bottom)); }
+	.safe-top    { padding-top:    max(0.5rem, env(safe-area-inset-top));    }
+}
+
+/* Metadata grid edge-border strip — column count changes at sm/lg */
+@layer components {
+	.metadata-grid .metadata-cell:nth-child(2n) { border-right-width: 0; }
+	@media (min-width: 640px) {
+		.metadata-grid .metadata-cell:nth-child(2n) { border-right-width: 1px; }
+		.metadata-grid .metadata-cell:nth-child(3n) { border-right-width: 0; }
+	}
+	@media (min-width: 1024px) {
+		.metadata-grid .metadata-cell:nth-child(3n) { border-right-width: 1px; }
+		.metadata-grid .metadata-cell:nth-child(4n) { border-right-width: 0; }
+	}
 }
 
 /* FOUC prevention: overrides the inline visibility:hidden in app.html.

--- a/frontend/src/lib/components/JobActions.svelte
+++ b/frontend/src/lib/components/JobActions.svelte
@@ -102,7 +102,7 @@
 </script>
 
 {#if canAbandon || canDelete || canFixPerms || canPurge}
-	<div class="contents">
+	<div class="flex flex-wrap items-center gap-1.5">
 		{#if canAbandon}
 			<button
 				onclick={handleAbandon}

--- a/frontend/src/lib/components/JobRow.svelte
+++ b/frontend/src/lib/components/JobRow.svelte
@@ -31,13 +31,13 @@
 {#if !job}
 	<tr aria-busy="true">
 		{#each { length: 9 } as _}
-			<td class="p-2"><Skeleton variant="line" width="80%" height="1rem" /></td>
+			<td class="p-2" data-label=""><Skeleton variant="line" width="80%" height="1rem" /></td>
 		{/each}
 	</tr>
 {:else}
 <tr class="border-b border-primary/20 hover:bg-page dark:border-primary/20 dark:hover:bg-primary/5 {selected ? 'bg-primary/[0.03] dark:bg-primary/[0.06]' : ''}">
 	<!-- Checkbox -->
-	<td class="px-4 py-3 w-8">
+	<td class="px-4 py-3 w-8" data-label="">
 		<input
 			type="checkbox"
 			checked={selected}
@@ -47,7 +47,7 @@
 	</td>
 
 	<!-- Title -->
-	<td class="px-4 py-3">
+	<td class="px-4 py-3" data-label="Title">
 		<div class="flex items-center gap-2">
 			<VideoTypeIcon icon={typeConfig.icon} class="h-4 w-4 shrink-0 {typeConfig.iconColor}" />
 			<div class="min-w-0">
@@ -62,7 +62,7 @@
 	</td>
 
 	<!-- Year + IMDB -->
-	<td class="px-4 py-3 text-sm">
+	<td class="px-4 py-3 text-sm" data-label="Year">
 		<div class="flex items-center gap-1.5">
 			{#if job.year}
 				<span>{job.year}</span>
@@ -79,7 +79,7 @@
 	</td>
 
 	<!-- Status + stage/error -->
-	<td class="px-4 py-3">
+	<td class="px-4 py-3" data-label="Status">
 		<div>
 			<StatusBadge status={job.status} />
 			{#if active && job.stage}
@@ -107,12 +107,12 @@
 	</td>
 
 	<!-- Type (colored badge) -->
-	<td class="px-4 py-3 text-sm">
+	<td class="px-4 py-3 text-sm" data-label="Type">
 		<span class="rounded-sm px-1.5 py-0.5 text-xs font-medium {typeConfig.badgeClasses}">{typeConfig.label}</span>
 	</td>
 
 	<!-- Disc -->
-	<td class="px-4 py-3 text-sm">
+	<td class="px-4 py-3 text-sm" data-label="Disc">
 		{#if job.disctype}
 			<span class="inline-flex items-center gap-1">
 				<DiscTypeIcon disctype={job.disctype} size="h-4 w-4" />
@@ -125,7 +125,7 @@
 	</td>
 
 	<!-- Device / Source -->
-	<td class="px-4 py-3 text-sm">
+	<td class="px-4 py-3 text-sm" data-label="Source">
 		{#if job.source_type === 'folder'}
 			<span class="inline-flex items-center gap-1 text-violet-600 dark:text-violet-400" title={job.source_path ?? ''}>
 				<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -139,7 +139,7 @@
 	</td>
 
 	<!-- Started + elapsed/duration sub-text -->
-	<td class="px-4 py-3 text-sm">
+	<td class="px-4 py-3 text-sm" data-label="Started">
 		{#if job.start_time}
 			<TimeAgo date={job.start_time} />
 			{#if active}
@@ -153,7 +153,7 @@
 	</td>
 
 	<!-- Actions -->
-	<td class="px-4 py-3">
+	<td class="px-4 py-3" data-label="">
 		<JobActions {job} compact {onaction} />
 	</td>
 </tr>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	let { children } = $props();
 
 	let sidebarOpen = $state(false);
+	let mobileDrawerView = $state<'menu' | 'stats'>('menu');
 	let togglingPause = $state(false);
 	let quickMenuOpen = $state(false);
 	const rippingCount = $derived($dashboard.active_jobs.filter(j => {
@@ -291,34 +292,57 @@
 			<div class="fixed inset-0 z-40 lg:hidden">
 				<button class="absolute inset-0 bg-black/50" aria-label="Close sidebar" onclick={() => sidebarOpen = false}></button>
 				<aside class="relative z-50 flex h-full w-64 flex-col bg-surface shadow-xl dark:bg-surface-dark">
-					<div data-logo class="flex items-center justify-center py-6">
-						<img src="/img/arm-logo-black.png" alt="ARM" class="h-24 w-24 dark:hidden" />
-						<img src="/img/arm-logo-white.png" alt="ARM" class="hidden h-24 w-24 dark:block" />
+					<div data-logo class="flex items-center justify-center py-4">
+						<img src="/img/arm-logo-black.png" alt="ARM" class="h-20 w-20 dark:hidden" />
+						<img src="/img/arm-logo-white.png" alt="ARM" class="hidden h-20 w-20 dark:block" />
 					</div>
 					<hr class="border-primary/20 dark:border-primary/20" />
-					<nav class="flex-1 space-y-1 px-3 py-4">
-						{#each navItems as item}
-							<a
-								href={item.href}
-								onclick={() => sidebarOpen = false}
-								data-active={isActive(item.href, $page.url.pathname) || undefined}
-								class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors
-									{isActive(item.href, $page.url.pathname)
-										? 'bg-primary-light-bg text-primary-text dark:bg-primary-light-bg-dark/30 dark:text-primary-text-dark'
-										: 'text-gray-700 hover:bg-primary/10 dark:text-gray-300 dark:hover:bg-primary/15'}"
-							>
-								<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={item.icon} />
-								</svg>
-								{item.label}
-								{#if item.href === '/notifications' && $dashboard.notification_count > 0}
-									<span class="ml-auto rounded-full bg-amber-500 px-2 py-0.5 text-xs font-medium text-white">{$dashboard.notification_count}</span>
+					<!-- Drawer view toggle (mobile) -->
+					<div class="px-3 pt-3">
+						<div class="flex rounded-sm bg-primary/10 p-0.5 dark:bg-primary/10">
+							<button
+								onclick={() => mobileDrawerView = 'menu'}
+								class="flex-1 rounded-sm px-2 py-1 text-[11px] font-semibold uppercase tracking-wider transition-colors
+									{mobileDrawerView === 'menu'
+										? 'bg-primary/20 text-primary-text shadow-xs dark:bg-primary/25 dark:text-primary-text-dark'
+										: 'text-primary-text/50 hover:text-primary-text dark:text-primary-text-dark/50 dark:hover:text-primary-text-dark'}"
+							>Menu</button>
+							<button
+								onclick={() => mobileDrawerView = 'stats'}
+								class="flex-1 rounded-sm px-2 py-1 text-[11px] font-semibold uppercase tracking-wider transition-colors
+									{mobileDrawerView === 'stats'
+										? 'bg-primary/20 text-primary-text shadow-xs dark:bg-primary/25 dark:text-primary-text-dark'
+										: 'text-primary-text/50 hover:text-primary-text dark:text-primary-text-dark/50 dark:hover:text-primary-text-dark'}"
+							>Stats</button>
+						</div>
+					</div>
+					{#if mobileDrawerView === 'menu'}
+						<nav class="flex-1 overflow-y-auto space-y-1 px-3 py-4">
+							{#each navItems as item}
+								<a
+									href={item.href}
+									onclick={() => sidebarOpen = false}
+									data-active={isActive(item.href, $page.url.pathname) || undefined}
+									class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors
+										{isActive(item.href, $page.url.pathname)
+											? 'bg-primary-light-bg text-primary-text dark:bg-primary-light-bg-dark/30 dark:text-primary-text-dark'
+											: 'text-gray-700 hover:bg-primary/10 dark:text-gray-300 dark:hover:bg-primary/15'}"
+								>
+									<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={item.icon} />
+									</svg>
+									{item.label}
+									{#if item.href === '/notifications' && $dashboard.notification_count > 0}
+										<span class="ml-auto rounded-full bg-amber-500 px-2 py-0.5 text-xs font-medium text-white">{$dashboard.notification_count}</span>
 								{/if}
-							</a>
-						{/each}
-					</nav>
-					<hr class="border-primary/20 dark:border-primary/20" />
-					<SidebarStats systemInfo={$dashboard.system_info} systemStats={$dashboard.system_stats} transcoderInfo={$dashboard.transcoder_info} transcoderStats={$dashboard.transcoder_system_stats} armOnline={$dashboard.arm_online} transcoderOnline={$dashboard.transcoder_online} />
+								</a>
+							{/each}
+						</nav>
+					{:else}
+						<div class="flex-1 overflow-y-auto">
+							<SidebarStats systemInfo={$dashboard.system_info} systemStats={$dashboard.system_stats} transcoderInfo={$dashboard.transcoder_info} transcoderStats={$dashboard.transcoder_system_stats} armOnline={$dashboard.arm_online} transcoderOnline={$dashboard.transcoder_online} />
+						</div>
+					{/if}
 				</aside>
 			</div>
 		{/if}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -513,7 +513,7 @@
 				{#snippet loadingSlot()}
 					{#if viewMode === 'table'}
 						<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-							<table class="w-full text-left text-sm">
+							<table class="responsive-table w-full text-left text-sm">
 								<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
 									<tr>
 										<th class="px-4 py-3 w-8"></th>
@@ -540,7 +540,7 @@
 				{#snippet ready(jobs)}
 					{#if viewMode === 'table'}
 						<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-							<table class="w-full text-left text-sm">
+							<table class="responsive-table w-full text-left text-sm">
 								<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
 									<tr>
 										<th class="px-4 py-3 w-8">

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -447,9 +447,9 @@
 			</div>
 
 			<!-- Poster + Metadata grid -->
-			<div class="flex items-start">
+			<div class="flex flex-col sm:flex-row items-start">
 				<!-- Poster -->
-				<div class="shrink-0 border-r border-primary/15 p-4 dark:border-primary/15">
+				<div class="shrink-0 border-b sm:border-b-0 sm:border-r border-primary/15 p-4 dark:border-primary/15">
 					<PosterImage
 						url={job.poster_url}
 						alt={job.title ?? 'Poster'}
@@ -459,10 +459,9 @@
 				</div>
 
 				<!-- Metadata grid -->
-				<div class="flex-1 grid grid-cols-4">
+				<div class="metadata-grid w-full sm:w-auto flex-1 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
 					{#each metadataFields as field, i}
-						{@const isRightEdge = (i + 1) % 4 === 0}
-						<div class="px-4 py-3 border-b border-primary/15 dark:border-primary/15 {!isRightEdge ? 'border-r' : ''}">
+						<div class="metadata-cell px-4 py-3 border-b border-r border-primary/15 dark:border-primary/15">
 							{#if !field.empty}
 								<div class="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">{field.label}</div>
 								{#if field.isSelect}
@@ -638,7 +637,7 @@
 					</h2>
 				</div>
 				<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-					<table class="w-full text-left text-sm">
+					<table class="responsive-table w-full text-left text-sm">
 						<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
 							<tr>
 								<th class="px-4 py-3 font-medium">#</th>
@@ -674,11 +673,11 @@
 							{#each job.tracks as track}
 								{@const tooShort = !isMusicDisc && isBelowMinlength(track)}
 								<tr class="{tooShort ? 'opacity-40' : ''} hover:bg-page dark:hover:bg-gray-800/50">
-									<td class="px-4 py-3">{track.track_number ?? ''}</td>
+									<td class="px-4 py-3" data-label="#">{track.track_number ?? ''}</td>
 									{#if isMusicDisc}
-										<td class="max-w-[300px] truncate px-4 py-3">{track.title || track.filename || '--'}</td>
+										<td class="max-w-[300px] truncate px-4 py-3" data-label="Name">{track.title || track.filename || '--'}</td>
 									{:else}
-										<td class="max-w-[250px] px-4 py-3">
+										<td class="max-w-[250px] px-4 py-3" data-label="Filename">
 											{#if !track.enabled}
 												<span class="text-xs text-gray-400"></span>
 											{:else if editingFilenameTrackId === track.track_id}
@@ -723,6 +722,7 @@
 									{#if !isMusicDisc}
 										<td
 											class="px-4 py-3 cursor-pointer hover:bg-primary/5 dark:hover:bg-primary/10"
+											data-label="Title"
 											onclick={() => { editingTrackId = editingTrackId === track.track_id ? null : track.track_id; }}
 										>
 											{#if track.title}
@@ -743,7 +743,7 @@
 										</td>
 									{/if}
 									{#if !isMusicDisc && job.video_type === 'series'}
-									<td class="px-4 py-3">
+									<td class="px-4 py-3" data-label="Episode">
 										<div class="flex items-center gap-1.5">
 											<input
 												type="text"
@@ -763,11 +763,11 @@
 										</div>
 									</td>
 								{/if}
-								<td class="px-4 py-3">{track.length != null ? `${Math.floor(track.length / 60)}:${String(track.length % 60).padStart(2, '0')}` : ''}</td>
+								<td class="px-4 py-3" data-label={isMusicDisc ? 'Duration' : 'Length'}>{track.length != null ? `${Math.floor(track.length / 60)}:${String(track.length % 60).padStart(2, '0')}` : ''}</td>
 									{#if !isMusicDisc}
-										<td class="px-4 py-3">{track.aspect_ratio ?? ''}</td>
-										<td class="px-4 py-3">{track.fps ?? ''}</td>
-										<td class="pl-1 pr-4 py-3">
+										<td class="px-4 py-3" data-label="Aspect">{track.aspect_ratio ?? ''}</td>
+										<td class="px-4 py-3" data-label="FPS">{track.fps ?? ''}</td>
+										<td class="pl-1 pr-4 py-3" data-label="Rip">
 											{#if tooShort}
 												<span class="ml-4 text-[10px] text-gray-400 dark:text-gray-500" title="Too short to rip (below {minlength}s minimum)">skip</span>
 											{:else}
@@ -781,7 +781,7 @@
 											{/if}
 										</td>
 									{/if}
-									<td class="px-4 py-3">
+									<td class="px-4 py-3" data-label="Ripped">
 										{#if track.enabled && !tooShort}
 											<span class="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold {track.ripped
 												? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
@@ -791,11 +791,11 @@
 											</span>
 										{/if}
 									</td>
-									<td class="px-4 py-3"><StatusBadge status={!track.enabled || tooShort ? 'skipped' : track.status} /></td>
+									<td class="px-4 py-3" data-label="Status"><StatusBadge status={!track.enabled || tooShort ? 'skipped' : track.status} /></td>
 									</tr>
 								{#if editingTrackId === track.track_id}
 									<tr>
-										<td colspan="99" class="px-4 py-3">
+										<td colspan="99" class="px-4 py-3" data-label="">
 											<TrackTitleSearch jobId={job.job_id} {track} onapply={handleTrackTitleApply} onclose={() => { editingTrackId = null; }} />
 										</td>
 									</tr>

--- a/frontend/src/routes/logs/+page.svelte
+++ b/frontend/src/routes/logs/+page.svelte
@@ -207,7 +207,7 @@
 			{/snippet}
 			{#snippet ready(items)}
 				<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-					<table class="w-full text-left text-sm">
+					<table class="responsive-table w-full text-left text-sm">
 						<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
 							<tr>
 								<th class="cursor-pointer select-none px-4 py-3 font-medium" onclick={() => toggleFileSort('filename')}>
@@ -228,14 +228,14 @@
 						<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
 							{#each sortedArmLogs as log}
 								<tr class="hover:bg-page dark:hover:bg-gray-800/50">
-									<td class="px-4 py-3">
+									<td class="px-4 py-3 break-all" data-label="Filename">
 										<a href="/logs/{log.filename}" class="text-primary-text hover:underline dark:text-primary-text-dark">
 											{log.filename}
 										</a>
 									</td>
-									<td class="px-4 py-3 text-gray-500 dark:text-gray-400">{formatBytes(log.size)}</td>
-									<td class="px-4 py-3 text-gray-500 dark:text-gray-400">{formatDateTime(log.modified)}</td>
-									<td class="px-4 py-3">
+									<td class="px-4 py-3 text-gray-500 dark:text-gray-400" data-label="Size">{formatBytes(log.size)}</td>
+									<td class="px-4 py-3 text-gray-500 dark:text-gray-400" data-label="Last Modified">{formatDateTime(log.modified)}</td>
+									<td class="px-4 py-3" data-label="Actions">
 										<div class="flex items-center gap-1.5">
 											<a
 												href={logDownloadUrl(log.filename)}
@@ -282,7 +282,7 @@
 			{/snippet}
 			{#snippet ready(items)}
 				<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-					<table class="w-full text-left text-sm">
+					<table class="responsive-table w-full text-left text-sm">
 						<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
 							<tr>
 								<th class="cursor-pointer select-none px-4 py-3 font-medium" onclick={() => toggleFileSort('filename')}>
@@ -302,13 +302,13 @@
 						<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
 							{#each sortedTranscoderLogs as log}
 								<tr class="hover:bg-page dark:hover:bg-gray-800/50">
-									<td class="px-4 py-3">
+									<td class="px-4 py-3 break-all" data-label="Filename">
 										<a href="/logs/transcoder/{log.filename}" class="text-primary-text hover:underline dark:text-primary-text-dark">
 											{log.filename}
 										</a>
 									</td>
-									<td class="px-4 py-3 text-gray-500 dark:text-gray-400">{formatBytes(log.size)}</td>
-									<td class="px-4 py-3 text-gray-500 dark:text-gray-400">{formatDateTime(log.modified)}</td>
+									<td class="px-4 py-3 text-gray-500 dark:text-gray-400" data-label="Size">{formatBytes(log.size)}</td>
+									<td class="px-4 py-3 text-gray-500 dark:text-gray-400" data-label="Last Modified">{formatDateTime(log.modified)}</td>
 								</tr>
 							{/each}
 						</tbody>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1346,7 +1346,7 @@
 		{@const settings = _}
 		<!-- Tab Bar -->
 		{@const tabClass = (tab: string) => `whitespace-nowrap border-b-2 px-1 py-2.5 text-sm font-medium transition-colors ${activeTab === tab ? 'border-primary text-primary-text dark:border-primary-text-dark dark:text-primary-text-dark' : 'border-transparent text-gray-500 hover:border-primary/30 hover:text-gray-700 dark:text-gray-400 dark:hover:border-primary/30 dark:hover:text-gray-300'}`}
-		<div class="border-b border-primary/20 dark:border-primary/20">
+		<div class="overflow-x-auto border-b border-primary/20 dark:border-primary/20">
 			<nav class="-mb-px flex gap-4" aria-label="Settings tabs">
 				<button type="button" onclick={() => setTab('ripping')} class={tabClass('ripping')}>Ripping</button>
 				<button type="button" onclick={() => setTab('music')} class={tabClass('music')}>Music</button>
@@ -1977,7 +1977,7 @@
 						<section>
 							<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Paths</h2>
 							<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
-								<table class="w-full text-left text-sm">
+								<table class="responsive-table w-full text-left text-sm">
 									<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
 										<tr>
 											<th class="px-4 py-3 font-medium">Setting</th>
@@ -1988,9 +1988,9 @@
 									<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
 										{#each systemInfo.paths as p}
 											<tr class="hover:bg-page dark:hover:bg-gray-800/50">
-												<td class="px-4 py-2 font-mono text-xs font-medium text-gray-500 dark:text-gray-400">{p.setting}</td>
-												<td class="px-4 py-2 font-mono text-xs text-gray-900 dark:text-white">{p.path}</td>
-												<td class="px-4 py-2">
+												<td class="px-4 py-2 font-mono text-xs font-medium text-gray-500 dark:text-gray-400" data-label="Setting">{p.setting}</td>
+												<td class="px-4 py-2 font-mono text-xs text-gray-900 dark:text-white break-all" data-label="Path">{p.path}</td>
+												<td class="px-4 py-2" data-label="Status">
 													{#if !p.exists}
 														<span class="inline-flex items-center gap-1 text-xs text-red-500">
 															<svg class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" /></svg>


### PR DESCRIPTION
## Summary

CSS-first mobile responsiveness pass across the UI. Enhances existing components instead of replacing them - no new dependencies, no component forks.

- **Tables** - new \`.responsive-table\` utility stacks tables into labeled cards below \`lg\` (1024px) via \`data-label\` attrs on each \`<td>\`. Applied to dashboard all-jobs, settings paths, logs (ARM + transcoder), and job-detail tracks.
- **Job detail** - metadata grid is now \`grid-cols-2 sm:grid-cols-3 lg:grid-cols-4\` with CSS-only edge-border strip at each breakpoint. Poster + metadata row becomes \`flex-col sm:flex-row\`.
- **Settings tab bar** - wrapped in \`overflow-x-auto\` so the 7 tabs can scroll on mobile instead of overflowing.
- **Mobile drawer** - adds a Menu / Stats segmented toggle so the SidebarStats panel is reachable inside the hamburger drawer without making the drawer permanently long.
- **JobActions** - wraps buttons in \`flex flex-wrap items-center gap-1.5\` instead of \`display: contents\`. Fixes ragged in-cell button layout on both desktop and mobile.
- **\`.safe-bottom\` / \`.safe-top\`** utilities for iOS safe-area insets (not used yet - available for future bottom-nav work).

## Test plan
- [ ] Dashboard table view renders as stacked cards at 360px/768px, normal table at 1024px+
- [ ] Job detail page: metadata grid reflows 2 → 3 → 4 cols; poster stacks above metadata at <640px
- [ ] Tracks table on job detail becomes labeled cards on mobile (label shows above value)
- [ ] Settings page tab bar scrolls horizontally on mobile; paths table stacks into cards
- [ ] Logs page (ARM + transcoder tabs): tables stack into cards with Download/Delete buttons visible
- [ ] JobActions buttons (Abandon / Fix Perms / Delete / Purge) stay grouped and wrap cleanly on desktop
- [ ] Mobile hamburger drawer: Menu/Stats toggle swaps views; stats scrolls independently
- [ ] All 16 themes still render correctly (spot-check Default, Terminal, LCARS)
- [ ] Existing \`npm test\` suite still green (859 tests passed locally)