### PR TITLE
feat(transcoder): surface current encoder FPS during transcode

### DIFF
--- a/backend/routers/transcoder.py
+++ b/backend/routers/transcoder.py
@@ -147,4 +147,5 @@ async def get_transcoder_job_for_arm(arm_job_id: int) -> dict[str, Any]:
         "transcoder_job_id": job.get("id"),
         "status": job.get("status"),
         "progress": job.get("progress"),
+        "current_fps": job.get("current_fps"),
     }

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -73,6 +73,7 @@ export async function fetchTranscoderLogForArmJob(
 	transcoder_job_id?: number;
 	status?: string;
 	progress?: number | null;
+	current_fps?: number | null;
 }> {
 	return apiFetch(`/api/transcoder/job-for-arm/${armJobId}`);
 }

--- a/frontend/src/lib/components/TranscodeCard.svelte
+++ b/frontend/src/lib/components/TranscodeCard.svelte
@@ -86,6 +86,13 @@
 			</div>
 		{/if}
 
+		<!-- FPS (when actively encoding) -->
+		{#if isActive && typeof job.current_fps === 'number' && job.current_fps > 0}
+			<span class="shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400" title="Encoder frames per second">
+				{job.current_fps.toFixed(1)} fps
+			</span>
+		{/if}
+
 		<!-- Elapsed -->
 		{#if job.started_at}
 			<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{elapsedTime(job.started_at)}</span>
@@ -176,7 +183,12 @@
 							</tr>
 							<tr>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Progress</td>
-								<td class="py-1 text-gray-900 dark:text-white">{typeof job.progress === 'number' ? `${job.progress}%` : '—'}</td>
+								<td class="py-1 text-gray-900 dark:text-white">
+									{typeof job.progress === 'number' ? `${job.progress}%` : '—'}
+									{#if isActive && typeof job.current_fps === 'number' && job.current_fps > 0}
+										<span class="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400">{job.current_fps.toFixed(1)} fps</span>
+									{/if}
+								</td>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">Created</td>
 								<td class="py-1 text-gray-900 dark:text-white">{#if job.created_at}<TimeAgo date={job.created_at} />{:else}—{/if}</td>
 							</tr>

--- a/frontend/src/lib/components/TranscodeCard.test.ts
+++ b/frontend/src/lib/components/TranscodeCard.test.ts
@@ -10,6 +10,7 @@ function createTranscodeJob(overrides: Partial<TranscoderJob> = {}): TranscoderJ
 		source_path: '/media/raw/my_movie.mkv',
 		status: 'processing',
 		progress: 45,
+		current_fps: null,
 		error: null,
 		logfile: null,
 		video_type: 'movie',

--- a/frontend/src/lib/types/transcoder.ts
+++ b/frontend/src/lib/types/transcoder.ts
@@ -4,6 +4,7 @@ export interface TranscoderJob {
 	source_path: string;
 	status: string;
 	progress: number;
+	current_fps: number | null;
 	error: string | null;
 	logfile: string | null;
 	video_type: string | null;

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -38,6 +38,7 @@
 	let retranscodeFeedback = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 	let transcoderLogfile = $state<string | null>(null);
 	let transcoderProgress = $state<number | null>(null);
+	let transcoderFps = $state<number | null>(null);
 	let transcoderJobStatus = $state<string | null>(null);
 	let ripProgress = $state<RipProgress | null>(null);
 
@@ -264,15 +265,18 @@
 					if (info.found) {
 						transcoderLogfile = info.logfile ?? null;
 						transcoderProgress = info.progress ?? null;
+						transcoderFps = info.current_fps ?? null;
 						transcoderJobStatus = info.status ?? null;
 					} else {
 						transcoderLogfile = null;
 						transcoderProgress = null;
+						transcoderFps = null;
 						transcoderJobStatus = null;
 					}
 				}).catch(() => {
 					transcoderLogfile = null;
 					transcoderProgress = null;
+					transcoderFps = null;
 					transcoderJobStatus = null;
 				});
 			}
@@ -325,13 +329,16 @@
 				if (info.found) {
 					transcoderLogfile = info.logfile ?? null;
 					transcoderProgress = info.progress ?? null;
+					transcoderFps = info.current_fps ?? null;
 					transcoderJobStatus = info.status ?? null;
 				} else {
 					transcoderProgress = null;
+					transcoderFps = null;
 					transcoderJobStatus = null;
 				}
 			} catch {
 				transcoderProgress = null;
+				transcoderFps = null;
 			}
 		}
 	}
@@ -580,6 +587,9 @@
 					<span>Transcoding</span>
 					{#if transcoderJobStatus}
 						<span class="text-xs text-gray-500 dark:text-gray-400">({transcoderJobStatus})</span>
+					{/if}
+					{#if typeof transcoderFps === 'number' && transcoderFps > 0}
+						<span class="ml-auto font-mono text-xs text-gray-500 dark:text-gray-400" title="Encoder frames per second">{transcoderFps.toFixed(1)} fps</span>
 					{/if}
 				</div>
 				{#if transcoderProgress != null}


### PR DESCRIPTION
## Summary

UI half of upstream issue [#1702](https://github.com/automatic-ripping-machine/automatic-ripping-machine/issues/1702) (FPS readout). Pairs with transcoder PR [#115](https://github.com/uprightbass360/automatic-ripping-machine-transcoder/pull/115) which adds the \`current_fps\` field on the transcoder's job records.

- \`TranscoderJob\` type gains \`current_fps: number | null\`
- Forward \`current_fps\` through \`/api/transcoder/job-for-arm\` proxy and the typed fetcher
- \`TranscodeCard\` shows "NN.N fps" next to the elapsed time on the dashboard row and on the Progress row of the expanded card - only while actively encoding and a non-zero sample is available
- Job detail page shows fps next to the Transcoding header during the transcoding phase

Compatible with older transcoders: when \`current_fps\` is missing the UI silently omits the readout.

## Test plan
- [x] Type check passes (\`npm run check\` 0 errors)
- [x] All 859 frontend tests pass
- [x] All 700 backend tests pass
- [ ] Manual: kick a transcode and confirm the fps readout appears next to the progress bar in dashboard, expanded card, and job detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)