### PR TITLE
fix(jobs): skip loading flicker on poll-driven refresh of /jobs/[id]

### DIFF
--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -244,7 +244,17 @@
 
 	async function loadJob() {
 		const id = Number($page.params.id);
-		jobLoading = true;
+		// Only flip into the loading state on the FIRST load. The 5s poll
+		// re-calls loadJob() and on a slow network that would unmount the
+		// rendered detail in favour of a skeleton, then remount when the
+		// fetch settles - the height change scrolls the page (and the user
+		// loses their scroll position). On refreshes we already have a
+		// previous `job` to render; just swap it in place when the new
+		// payload arrives.
+		const isInitialLoad = job == null;
+		if (isInitialLoad) {
+			jobLoading = true;
+		}
 		jobError = null;
 		try {
 			job = await fetchJob(id);


### PR DESCRIPTION
## Summary

User-reported: opening \`/jobs/167\` while a rip is active causes the page to jump every few seconds.

### Cause

\`+page.svelte\` polls \`loadJob()\` every 5s. It set \`jobLoading=true\` unconditionally at the top of every call. \`LoadState\` has a 150ms \`minDelay\` gate that hides the skeleton on fast loads - but on a slow network the response often crosses 150ms, so \`LoadState\` flips into the \`loading\` phase, unmounts the rendered detail in favour of \`SkeletonCard\`, then remounts the detail when the response arrives. The skeleton has a different height than the full detail, so the page visibly jumps and the user loses their scroll position.

### Fix

Only flip \`jobLoading=true\` on the FIRST load (when \`job == null\`). On refreshes there's already a previous payload to render; swap it in place when the new one arrives. The \`finally\` still clears \`jobLoading=false\` unconditionally (harmless on refreshes - it's already false).

## Test plan
- [x] \`npm run check\` clean
- [x] All 22 existing job-detail tests pass
- [ ] Manual: open \`/jobs/<active>\` and watch for ~30s, no skeleton flash on refresh