### PR TITLE
fix(settings): polish settings page layout (tabs, drives, system health)

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1288,7 +1288,7 @@
 <!-- Reusable snippet for GPU support cards -->
 {#snippet gpuCards(gpu: Record<string, boolean>)}
 	<section>
-		<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+		<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
 			Hardware Encoding
 		</h2>
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -1347,8 +1347,10 @@
 		<!-- Tab Bar -->
 		{@const tabClass = (tab: string) => `whitespace-nowrap border-b-2 px-1 py-2.5 text-sm font-medium transition-colors ${activeTab === tab ? 'border-primary text-primary-text dark:border-primary-text-dark dark:text-primary-text-dark' : 'border-transparent text-gray-500 hover:border-primary/30 hover:text-gray-700 dark:text-gray-400 dark:hover:border-primary/30 dark:hover:text-gray-300'}`}
 		<!-- overflow-y-hidden prevents the 1px vertical scroll that
-			 -mb-px + border-b-2 would otherwise trigger inside overflow-x-auto -->
-		<div class="overflow-x-auto overflow-y-hidden border-b border-primary/20 dark:border-primary/20">
+			 -mb-px + border-b-2 would otherwise trigger inside overflow-x-auto.
+			 mb-2 adds breathing room below the tab strip on top of the
+			 outer space-y-6 - tabs feel cramped against headings otherwise. -->
+		<div class="mb-2 overflow-x-auto overflow-y-hidden border-b border-primary/20 dark:border-primary/20">
 			<nav class="-mb-px flex gap-4" aria-label="Settings tabs">
 				<button type="button" onclick={() => setTab('ripping')} class={tabClass('ripping')}>Ripping</button>
 				<button type="button" onclick={() => setTab('music')} class={tabClass('music')}>Music</button>
@@ -1364,14 +1366,14 @@
 
 		<!-- Transcoding Tab -->
 		{#if activeTab === 'transcoding' && $transcoderEnabled}
-			<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
+			<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
 			<div class="rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
 				These settings configure the <strong>dedicated transcoder service</strong>, a separate GPU-accelerated container that handles all transcoding. ARM rips discs and notifies this service to transcode.
 			</div>
 
 			<!-- Service Status -->
 			<section>
-				<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Service Status</h2>
+				<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Service Status</h2>
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 					<!-- Connection card -->
 					<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
@@ -1474,7 +1476,7 @@
 
 			{#if settings.transcoder_config?.config}
 				<section>
-					<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+					<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
 						Configuration
 					</h2>
 
@@ -1759,7 +1761,7 @@
 		<!-- Ripping Tab -->
 		{#if activeTab === 'ripping'}
 			<section>
-				<div class="mb-3 flex items-center justify-between gap-3">
+				<div class="mb-4 flex items-center justify-between gap-3">
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Ripping</h2>
 					{@render armSearchBar()}
 				</div>
@@ -1770,7 +1772,7 @@
 		<!-- Music Tab -->
 		{#if activeTab === 'music'}
 			<section>
-				<div class="mb-3 flex items-center justify-between gap-3">
+				<div class="mb-4 flex items-center justify-between gap-3">
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Music</h2>
 					{@render armSearchBar()}
 				</div>
@@ -1904,7 +1906,7 @@
 		<!-- Notifications Tab -->
 		{#if activeTab === 'notifications'}
 			<section>
-				<div class="mb-3 flex items-center justify-between gap-3">
+				<div class="mb-4 flex items-center justify-between gap-3">
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Notifications</h2>
 					{@render armSearchBar()}
 				</div>
@@ -1925,7 +1927,7 @@
 
 					<!-- Versions -->
 					<section>
-						<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Versions</h2>
+						<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Versions</h2>
 						<div class="grid grid-cols-2 gap-4 md:grid-cols-5">
 							{#each Object.entries(systemInfo.versions) as [name, version]}
 								<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
@@ -1942,7 +1944,7 @@
 					<!-- Service Endpoints -->
 					{#if systemInfo.endpoints}
 						<section>
-							<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Service Endpoints</h2>
+							<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Service Endpoints</h2>
 							<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 								{#each Object.entries(systemInfo.endpoints) as [name, ep]}
 									{@const envVar = name === 'arm' ? 'ARM_UI_ARM_URL' : name === 'transcoder' ? 'ARM_UI_TRANSCODER_URL' : name.toUpperCase() + '_URL'}
@@ -1979,7 +1981,7 @@
 					<!-- Paths -->
 					{#if systemInfo.paths.length > 0}
 						<section>
-							<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Paths</h2>
+							<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Paths</h2>
 							<div class="overflow-x-auto rounded-lg border border-primary/20 dark:border-primary/20">
 								<table class="responsive-table w-full text-left text-sm">
 									<thead class="bg-page text-gray-600 dark:bg-primary/5 dark:text-gray-400">
@@ -2022,7 +2024,7 @@
 
 					<!-- Database -->
 					<section>
-						<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Database</h2>
+						<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Database</h2>
 						<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 							<dl class="grid grid-cols-2 gap-4 text-sm md:grid-cols-4">
 								<div>
@@ -2089,7 +2091,7 @@
 
 			<!-- Editable ARM system settings below diagnostics -->
 			<section>
-				<div class="mb-3 flex items-center justify-between gap-3">
+				<div class="mb-4 flex items-center justify-between gap-3">
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Configuration</h2>
 					{@render armSearchBar()}
 				</div>
@@ -2098,7 +2100,7 @@
 
 			<!-- Service Control -->
 			<section class="mt-6">
-				<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Service Control</h2>
+				<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Service Control</h2>
 				<div class="space-y-3">
 					<!-- ARM Restart -->
 					<div class="rounded-lg border border-red-200 bg-red-50/50 p-4 dark:border-red-800 dark:bg-red-900/10">
@@ -2148,7 +2150,7 @@
 
 		<!-- Appearance Tab -->
 		{#if activeTab === 'appearance'}
-			<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Appearance</h2>
+			<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Appearance</h2>
 			<section class="space-y-6">
 				<!-- Feedback toast -->
 				{#if themeFeedback}
@@ -2366,7 +2368,7 @@
 		{/if}
 
 		{#if activeTab === 'drives'}
-			<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Drives</h2>
+			<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Drives</h2>
 			<section class="space-y-6">
 				{#if $driveError}
 					<div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1346,7 +1346,9 @@
 		{@const settings = _}
 		<!-- Tab Bar -->
 		{@const tabClass = (tab: string) => `whitespace-nowrap border-b-2 px-1 py-2.5 text-sm font-medium transition-colors ${activeTab === tab ? 'border-primary text-primary-text dark:border-primary-text-dark dark:text-primary-text-dark' : 'border-transparent text-gray-500 hover:border-primary/30 hover:text-gray-700 dark:text-gray-400 dark:hover:border-primary/30 dark:hover:text-gray-300'}`}
-		<div class="overflow-x-auto border-b border-primary/20 dark:border-primary/20">
+		<!-- overflow-y-hidden prevents the 1px vertical scroll that
+			 -mb-px + border-b-2 would otherwise trigger inside overflow-x-auto -->
+		<div class="overflow-x-auto overflow-y-hidden border-b border-primary/20 dark:border-primary/20">
 			<nav class="-mb-px flex gap-4" aria-label="Settings tabs">
 				<button type="button" onclick={() => setTab('ripping')} class={tabClass('ripping')}>Ripping</button>
 				<button type="button" onclick={() => setTab('music')} class={tabClass('music')}>Music</button>
@@ -1359,8 +1361,6 @@
 				<button type="button" onclick={() => setTab('system')} class={tabClass('system')}>System</button>
 			</nav>
 		</div>
-
-		<SystemHealth />
 
 		<!-- Transcoding Tab -->
 		{#if activeTab === 'transcoding' && $transcoderEnabled}
@@ -1919,6 +1919,10 @@
 			{:else if systemInfo}
 				<div class="space-y-6">
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">System</h2>
+
+					<!-- Health check (API keys + path permissions) -->
+					<SystemHealth />
+
 					<!-- Versions -->
 					<section>
 						<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Versions</h2>
@@ -2362,22 +2366,7 @@
 		{/if}
 
 		{#if activeTab === 'drives'}
-			<div class="flex items-center justify-between">
-				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Drives</h2>
-				<div class="flex gap-2">
-					<button
-						onclick={async () => { rescanning = true; await rescanDrives(); await drives.refresh(); rescanning = false; }}
-						disabled={rescanning}
-						class="rounded-lg border border-primary/20 px-3 py-1.5 text-xs font-medium text-primary-text transition-colors hover:bg-primary/10 dark:border-primary/20 dark:text-primary-text-dark dark:hover:bg-primary/15"
-					>{rescanning ? 'Scanning...' : 'Rescan'}</button>
-					<button
-						onclick={async () => { rescanning = true; await rescanDrives(true); await drives.refresh(); rescanning = false; }}
-						disabled={rescanning}
-						class="rounded-lg border border-amber-300 px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-900/20"
-						title="Delete all stale drive records and re-detect from hardware"
-					>{rescanning ? 'Scanning...' : 'Force Rescan'}</button>
-				</div>
-			</div>
+			<h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Drives</h2>
 			<section class="space-y-6">
 				{#if $driveError}
 					<div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
@@ -2398,8 +2387,23 @@
 					</div>
 				{/if}
 
-				<!-- Diagnostics — collapsible panel -->
+				<!-- Maintenance & Diagnostics -->
 				<hr class="my-2 opacity-20" />
+				<div class="flex flex-wrap items-center gap-2">
+					<span class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Maintenance</span>
+					<button
+						onclick={async () => { rescanning = true; await rescanDrives(); await drives.refresh(); rescanning = false; }}
+						disabled={rescanning}
+						class="ml-auto rounded-lg border border-primary/20 px-3 py-1.5 text-xs font-medium text-primary-text transition-colors hover:bg-primary/10 disabled:opacity-50 dark:border-primary/20 dark:text-primary-text-dark dark:hover:bg-primary/15"
+						title="Re-detect optical drives and refresh database records"
+					>{rescanning ? 'Scanning...' : 'Rescan'}</button>
+					<button
+						onclick={async () => { rescanning = true; await rescanDrives(true); await drives.refresh(); rescanning = false; }}
+						disabled={rescanning}
+						class="rounded-lg border border-amber-300 px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-50 disabled:opacity-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-900/20"
+						title="Delete all stale drive records and re-detect from hardware"
+					>{rescanning ? 'Scanning...' : 'Force Rescan'}</button>
+				</div>
 				<div data-diag>
 					<button
 						onclick={() => { diagOpen = !diagOpen; }}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1366,9 +1366,12 @@
 
 		<!-- Transcoding Tab -->
 		{#if activeTab === 'transcoding' && $transcoderEnabled}
-			<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
-			<div class="rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
-				These settings configure the <strong>dedicated transcoder service</strong>, a separate GPU-accelerated container that handles all transcoding. ARM rips discs and notifies this service to transcode.
+		<div class="space-y-6">
+			<div>
+				<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
+				<div class="rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
+					These settings configure the <strong>dedicated transcoder service</strong>, a separate GPU-accelerated container that handles all transcoding. ARM rips discs and notifies this service to transcode.
+				</div>
 			</div>
 
 			<!-- Service Status -->
@@ -1669,6 +1672,7 @@
 			{:else}
 				<p class="text-sm text-gray-400">Transcoder offline or not configured.</p>
 			{/if}
+		</div>
 		{/if}
 
 		<!-- Reusable ARM settings renderer -->

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1367,11 +1367,9 @@
 		<!-- Transcoding Tab -->
 		{#if activeTab === 'transcoding' && $transcoderEnabled}
 		<div class="space-y-6">
-			<div>
-				<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
-				<div class="rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
-					These settings configure the <strong>dedicated transcoder service</strong>, a separate GPU-accelerated container that handles all transcoding. ARM rips discs and notifies this service to transcode.
-				</div>
+			<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Transcoding</h2>
+			<div class="rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
+				These settings configure the <strong>dedicated transcoder service</strong>, a separate GPU-accelerated container that handles all transcoding. ARM rips discs and notifies this service to transcode.
 			</div>
 
 			<!-- Service Status -->


### PR DESCRIPTION
## Summary

Four small fixes reported on \`/settings\`:

1. **Tab nav showed a vertical scroll spinner.** \`-mb-px\` on the nav lifts the active tab's \`border-b-2\` 1px above its parent. Inside \`overflow-x-auto\` (which leaves \`overflow-y\` at \`visible\`), some browsers exposed that 1px lift as a vertical scrollbar with up/down buttons. Setting \`overflow-y-hidden\` on the scroll container clips it cleanly.
2. **\`<SystemHealth />\` was rendered globally above every settings tab.** Moved it into the System tab body where it belongs.
3. **Drives heading was misaligned vs other tabs.** Other tabs use either a bare \`<h2>\` or \`<section><h2 class=\"mb-3\">\` - the Drives heading was inline with action buttons and missing \`mb-3\`. Now it stands alone with the same spacing as its peers.
4. **Rescan / Force Rescan felt out of place** sharing the heading row. Moved both into a MAINTENANCE strip above the Diagnostics collapsible, grouping all drive-inventory operations together.

## Test plan
- [x] \`npm run check\` clean (0 errors)
- [x] All 14 settings tests still pass
- [ ] Manual: open /settings, walk every tab, confirm SystemHealth only on System tab, no scrollbar on the tab strip, Drives heading spacing matches Ripping/Music/Notifications, Rescan + Force Rescan visible under "MAINTENANCE" label above Diagnostics