### PR TITLE
docs: refresh README architecture for HTTP-only BFF + drop dead DriveSchema fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,15 @@ The original upstream project: [automatic-ripping-machine/automatic-ripping-mach
 flowchart LR
     subgraph ui["ARM UI"]
         FE["SvelteKit Frontend"]
-        BE["FastAPI Backend"]
+        BE["FastAPI BFF"]
     end
 
     FE -- "REST /api/*" --> BE
-    BE -- "read-only" --> DB["ARM SQLite DB"]
-    BE -- "JSON API" --> ARM["ARM Service"]
+    BE -- "REST /api/v1/*" --> ARM["ARM Ripper"]
     BE -- "REST API" --> TC["ARM Transcoder"]
 ```
 
-The backend reads ARM's SQLite database directly (read-only) for job data, calls ARM's JSON API for actions (abandon, delete, fix permissions), and talks to the transcoder's REST API for transcode job monitoring.
+The backend is a thin BFF (backend-for-frontend) that aggregates calls to the ripper's HTTP API and the transcoder's REST API into single dashboard-shaped responses for the SvelteKit frontend. As of v17.0.0 the BFF holds no database connection - all job data, drives, notifications, and config live behind the ripper's `/api/v1/*` endpoints. Requires arm-neu >= v17.0.0.
 
 ## Features
 
@@ -96,7 +95,7 @@ The backend reads ARM's SQLite database directly (read-only) for job data, calls
 
 **Frontend:** SvelteKit 2, Svelte 5, TypeScript 6, Tailwind CSS 4, Vite 8
 
-**Backend:** FastAPI, SQLAlchemy 2 (read-only), httpx, Pydantic Settings, Uvicorn
+**Backend:** FastAPI BFF, httpx, Pydantic Settings, Uvicorn (HTTP-only against the ripper - no DB driver)
 
 ## Docker Images
 

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -225,9 +225,7 @@ class DriveSchema(BaseModel):
     model: str | None = None
     serial: str | None = None
     connection: str | None = None
-    read_cd: bool | None = None
-    read_dvd: bool | None = None
-    read_bd: bool | None = None
+    capabilities: list[str] | None = None
     firmware: str | None = None
     location: str | None = None
     stale: bool | None = None


### PR DESCRIPTION
## Summary
- README "Architecture" section refreshed for v17.0.0: mermaid diagram drops the SQLite arrow, prose paragraph rewritten as a BFF description, Tech Stack drops SQLAlchemy. Calls out the arm-neu >= v17.0.0 requirement.
- \`backend/models/schemas.py\` DriveSchema swaps the dead \`read_cd\`/\`read_dvd\`/\`read_bd\` booleans for \`capabilities: list[str] | None\` to match the v17 ripper shape. Schema isn't currently wired into any router but would silently drop the new field if revived.

## Test plan
- [x] 644 backend tests passing locally
- [ ] CI green