### PR TITLE
feat: decouple from ripper-side bind mounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,6 @@
 # Path to ARM's log directory
 ARM_UI_ARM_LOG_PATH=/home/arm/logs
 
-# Path to ARM's arm.yaml config file (optional)
-ARM_UI_ARM_CONFIG_PATH=
-
-# Path to HandBrake presets JSON file (optional)
-ARM_UI_ARM_HB_PRESETS_PATH=
-
 # ARM web UI base URL (for job actions: abandon, delete, fix permissions)
 ARM_UI_ARM_URL=http://localhost:8080
 
@@ -16,12 +10,17 @@ ARM_UI_TRANSCODER_URL=http://localhost:5000
 # Optional: Transcoder API key
 ARM_UI_TRANSCODER_API_KEY=
 
+# Webhook secret for authenticating outbound transcoder webhooks. Must
+# match WEBHOOK_SECRET on the transcoder host. Read once at startup;
+# rotation requires a container restart.
+ARM_UI_TRANSCODER_WEBHOOK_SECRET=
+
 # Set to false for ripper-only deployments (no transcoder).
 # Hides all transcoder UI surfaces and short-circuits transcoder HTTP calls.
 ARM_UI_TRANSCODER_ENABLED=true
 
 # Directory for custom color scheme JSON/CSS files
-ARM_UI_ARM_THEMES_PATH=/data/config/themes
+ARM_UI_THEMES_PATH=/data/themes
 
 # Directory for cached poster/cover images
 ARM_UI_IMAGE_CACHE_PATH=/data/cache/images

--- a/README.md
+++ b/README.md
@@ -138,13 +138,12 @@ The UI is available at `http://localhost:8888`.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ARM_UI_ARM_LOG_PATH` | `/home/arm/logs` | Path to ARM's log directory |
-| `ARM_UI_ARM_CONFIG_PATH` | *(empty)* | Path to ARM's `arm.yaml` config file |
-| `ARM_UI_ARM_HB_PRESETS_PATH` | *(empty)* | Path to HandBrake presets JSON file |
 | `ARM_UI_ARM_URL` | `http://localhost:8080` | ARM web UI base URL (for job actions) |
 | `ARM_UI_TRANSCODER_URL` | `http://localhost:5000` | Transcoder API base URL |
 | `ARM_UI_TRANSCODER_API_KEY` | *(empty)* | Optional transcoder API key |
+| `ARM_UI_TRANSCODER_WEBHOOK_SECRET` | *(empty)* | Webhook secret for outbound transcoder calls. Must match `WEBHOOK_SECRET` on the transcoder host. Read once at startup; rotation requires a container restart. |
 | `ARM_UI_TRANSCODER_ENABLED` | `true` | Set `false` for ripper-only deployments (no transcoder). Hides all transcoder UI surfaces and short-circuits transcoder HTTP calls. See [ripper-only deployment](https://github.com/uprightbass360/automatic-ripping-machine-neu#ripper-only) in the ARM-neu README. |
-| `ARM_UI_ARM_THEMES_PATH` | `/data/config/themes` | Directory for custom color scheme JSON files |
+| `ARM_UI_THEMES_PATH` | `/data/themes` | Directory for custom color scheme JSON/CSS files |
 | `ARM_UI_IMAGE_CACHE_PATH` | `/data/cache/images` | Directory for cached poster/cover images |
 | `ARM_UI_PORT` | `8888` | Server port |
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -3,14 +3,13 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     arm_log_path: str = "/home/arm/logs"
-    arm_config_path: str = ""
-    arm_hb_presets_path: str = ""
-    arm_themes_path: str = "/data/config/themes"
+    themes_path: str = "/data/themes"
     image_cache_path: str = "/data/cache/images"
     arm_url: str = "http://localhost:8080"
     transcoder_url: str = "http://localhost:5000"
     transcoder_api_key: str = ""
     transcoder_enabled: bool = True
+    transcoder_webhook_secret: str = ""
     port: int = 8888
 
     model_config = {"env_prefix": "ARM_UI_"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,10 @@
 """FastAPI application for ARM UI."""
 
+import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -26,12 +29,21 @@ from backend.routers import (
     themes,
     transcoder,
 )
+from backend.config import settings as app_settings
 from backend.services import arm_client, transcoder_client
 from backend.services import image_cache, system_cache
+from backend.services.themes_migration import migrate_legacy_themes
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Theme migration must never fail startup. A misconfigured volume,
+    # read-only filesystem, or stale bind mount during the upcoming
+    # one-release transition shouldn't take the whole app down.
+    try:
+        migrate_legacy_themes(app_settings.themes_path)
+    except Exception:
+        log.exception("Theme migration failed; continuing startup.")
     await system_cache.refresh()
     image_cache.startup_scan()
     yield

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -365,7 +365,6 @@ class StructuredLogResponse(BaseModel):
 class SettingsResponse(BaseModel):
     arm_config: dict[str, Any] | None = None
     arm_metadata: dict[str, Any] | None = None
-    arm_handbrake_presets: list[str] | None = None
     naming_variables: dict[str, str] | None = None
     transcoder_config: dict[str, Any] | None = None
     transcoder_gpu_support: dict[str, Any] | None = None

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import os
 from typing import NoReturn
@@ -20,21 +19,6 @@ _TRANSCODER_UNREACHABLE = "Transcoder service unreachable"
 _TRANSCODER_UNREACHABLE_RESPONSE = {502: {"description": _TRANSCODER_UNREACHABLE}}
 
 
-def _read_hb_presets() -> list[str] | None:
-    """Read HandBrake presets from the JSON file written by the init container."""
-    path = app_settings.arm_hb_presets_path
-    if not path or not os.path.isfile(path):
-        return None
-    try:
-        with open(path) as f:
-            data = json.load(f)
-        if isinstance(data, list):
-            return data
-    except (json.JSONDecodeError, OSError) as e:
-        log.warning("Failed to read HandBrake presets: %s", e)
-    return None
-
-
 @router.get("/settings", response_model=SettingsResponse)
 async def get_settings():
     arm_config = None
@@ -45,9 +29,6 @@ async def get_settings():
         arm_config = arm_resp.get("config")
         arm_metadata = arm_resp.get("comments")
         naming_variables = arm_resp.get("naming_variables")
-
-    # HandBrake presets from init container
-    arm_handbrake_presets = _read_hb_presets()
 
     # Transcoder config + GPU support
     transcoder_config = None
@@ -76,7 +57,6 @@ async def get_settings():
     return SettingsResponse(
         arm_config=arm_config,
         arm_metadata=arm_metadata,
-        arm_handbrake_presets=arm_handbrake_presets,
         naming_variables=naming_variables,
         transcoder_config=transcoder_config,
         transcoder_gpu_support=transcoder_gpu_support,
@@ -237,8 +217,11 @@ class WebhookTestRequest(BaseModel):
 
 
 @router.post("/settings/transcoder/test-webhook",
+             responses={400: {"description": "webhook_secret is required"}},
              dependencies=[Depends(require_transcoder_enabled)])
 async def test_transcoder_webhook(body: WebhookTestRequest):
+    if not body.webhook_secret:
+        raise HTTPException(status_code=400, detail="webhook_secret is required")
     return await transcoder_client.test_webhook(body.webhook_secret)
 
 

--- a/backend/services/themes.py
+++ b/backend/services/themes.py
@@ -56,7 +56,7 @@ def _validate_theme(data: Any) -> bool:
 
 def _user_themes_dir() -> Path:
     """Return the user themes directory, creating it if needed."""
-    p = Path(settings.arm_themes_path)
+    p = Path(settings.themes_path)
     p.mkdir(parents=True, exist_ok=True)
     return p
 

--- a/backend/services/themes_migration.py
+++ b/backend/services/themes_migration.py
@@ -1,0 +1,54 @@
+"""One-shot first-boot migration for user themes.
+
+Before v17.x.x, arm-ui themes lived at ``/data/config/themes`` - a path
+bind-mounted from arm-neu's config directory. After the bind-mount is
+retired in favor of a UI-owned named volume mounted at ``/data/themes``,
+operators upgrading in place still have their existing theme files at the
+old path. This module copies them over on first boot.
+
+Idempotent: only copies if the destination directory is empty. Safe to
+run on every startup; effectively a no-op after the first successful
+migration.
+"""
+import logging
+import shutil
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_LEGACY_THEMES_DIR = Path("/data/config/themes")
+
+
+def migrate_legacy_themes(themes_path: str) -> int:
+    """Copy theme files from the legacy bind-mount location to the new volume.
+
+    Returns the number of files migrated (0 if nothing to do).
+    """
+    target = Path(themes_path)
+
+    # Only run if the target is empty (or doesn't exist) - otherwise the
+    # operator has already been on the new layout and we'd risk overwriting
+    # their authoritative files.
+    if target.is_dir() and any(target.iterdir()):
+        return 0
+
+    if not _LEGACY_THEMES_DIR.is_dir():
+        return 0
+
+    target.mkdir(parents=True, exist_ok=True)
+    migrated = 0
+    for entry in _LEGACY_THEMES_DIR.iterdir():
+        if entry.is_file() and entry.suffix in (".json", ".css"):
+            try:
+                shutil.copy2(entry, target / entry.name)
+                migrated += 1
+            except OSError as exc:
+                log.warning("Failed to migrate theme file %s: %s", entry.name, exc)
+
+    if migrated:
+        log.info(
+            "Migrated %d theme file(s) from legacy %s to %s. "
+            "You can safely remove the old bind mount from your compose file.",
+            migrated, _LEGACY_THEMES_DIR, target,
+        )
+    return migrated

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -128,11 +128,14 @@ async def test_connection() -> dict[str, Any]:
 
 
 async def test_webhook(webhook_secret: str) -> dict[str, Any]:
-    """Send a test webhook payload to verify the webhook secret."""
-    import asyncio
-    import os
-    import yaml
+    """Send a test webhook payload to verify a candidate webhook secret.
 
+    The caller must provide a non-empty ``webhook_secret``. There is no
+    deploy-env fallback: whether the deployed secret is configured is
+    already surfaced in /health (transcoder_auth_status.webhook_secret_configured),
+    and silently testing the deploy value would make the result ambiguous
+    about which secret was actually validated.
+    """
     result: dict[str, Any] = {
         "reachable": False,
         "secret_ok": False,
@@ -140,23 +143,7 @@ async def test_webhook(webhook_secret: str) -> dict[str, Any]:
         "error": None,
     }
 
-    # Fall back to saved secret from arm.yaml when field is empty
-    if not webhook_secret:
-        def _read_secret() -> str:
-            yaml_path = settings.arm_config_path
-            if yaml_path and os.path.isfile(yaml_path):
-                try:
-                    with open(yaml_path, "r") as f:
-                        arm_cfg = yaml.safe_load(f) or {}
-                    return arm_cfg.get("TRANSCODER_WEBHOOK_SECRET", "") or ""
-                except Exception:
-                    pass
-            return ""
-        webhook_secret = await asyncio.to_thread(_read_secret)
-
-    headers: dict[str, str] = {}
-    if webhook_secret:
-        headers["X-Webhook-Secret"] = webhook_secret
+    headers = {"X-Webhook-Secret": webhook_secret}
 
     try:
         # Use a fresh client without the shared X-API-Key header
@@ -188,25 +175,13 @@ async def test_webhook(webhook_secret: str) -> dict[str, Any]:
 async def send_webhook(payload: dict) -> dict[str, Any]:
     """Send a webhook payload to the transcoder to trigger a transcode job.
 
+    Reads ``TRANSCODER_WEBHOOK_SECRET`` from the deploy environment (set on
+    both arm-neu and arm-ui sides at deploy time, mirroring how
+    ``transcoder_api_key`` is wired).
+
     Returns {"success": True} or {"success": False, "error": "..."}.
     """
-    import asyncio
-    import os
-    import yaml
-
-    def _read_webhook_secret() -> str:
-        yaml_path = settings.arm_config_path
-        if yaml_path and os.path.isfile(yaml_path):
-            try:
-                with open(yaml_path, "r") as f:
-                    arm_cfg = yaml.safe_load(f) or {}
-                return arm_cfg.get("TRANSCODER_WEBHOOK_SECRET", "") or ""
-            except Exception:
-                pass
-        return ""
-
-    # Read webhook secret directly from arm.yaml (API masks secrets)
-    webhook_secret = await asyncio.to_thread(_read_webhook_secret)
+    webhook_secret = settings.transcoder_webhook_secret
 
     headers: dict[str, str] = {}
     if webhook_secret:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
 # Standalone dev UI - connects to ARM and Transcoder on the host network.
-# Talks to the ripper exclusively over HTTP; no shared database volume.
-#
-# Set ARM_NEU_PATH in .env if the ARM-neu repo is not at the default location:
-#   ARM_NEU_PATH=../automatic-ripping-machine-neu
+# Talks to the ripper exclusively over HTTP; uses UI-owned named volumes
+# for themes and image cache. The only remaining bind mount is the log
+# directory (read-only), which is being retired in PR #2 of the
+# UI bind-mount decoupling project.
 #
 # Set ARM_LOGS_PATH in .env to override the log directory (e.g. for production):
 #   ARM_LOGS_PATH=/nfs/files/Containers/arm/logs
+#
+# Set WEBHOOK_SECRET in .env to authenticate outbound transcoder webhook
+# calls. Must match WEBHOOK_SECRET on the transcoder host (same operator-
+# facing variable name used by the arm-neu compose stacks).
 
 services:
   arm-ui:
@@ -13,19 +17,19 @@ services:
     network_mode: host
     environment:
       - ARM_UI_ARM_LOG_PATH=/data/logs
-      - ARM_UI_ARM_CONFIG_PATH=/data/config/arm.yaml
       - ARM_UI_ARM_URL=http://localhost:8080
       - ARM_UI_TRANSCODER_URL=${ARM_UI_TRANSCODER_URL:-http://localhost:5000}
       - ARM_UI_TRANSCODER_ENABLED=${ARM_UI_TRANSCODER_ENABLED:-true}
-      - ARM_UI_ARM_HB_PRESETS_PATH=/data/hb-presets/presets.json
       - ARM_UI_TRANSCODER_API_KEY=${ARM_UI_TRANSCODER_API_KEY:-}
-      - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_TRANSCODER_WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
+      - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - ${ARM_LOGS_PATH:-./dev-data/logs}:/data/logs:ro
-      - ${ARM_NEU_PATH:-../automatic-ripping-machine-neu}/dev-data/config:/data/config:rw
+      - arm-ui-themes:/data/themes:rw
       - image-cache:/data/cache/images:rw
     restart: unless-stopped
 
 volumes:
+  arm-ui-themes:
   image-cache:

--- a/frontend/src/lib/types/arm.ts
+++ b/frontend/src/lib/types/arm.ts
@@ -329,7 +329,6 @@ export interface TranscoderConfig {
 	valid_audio_encoders?: string[];
 	valid_subtitle_modes?: string[];
 	valid_log_levels?: string[];
-	valid_handbrake_presets?: string[];
 	valid_preset_files?: string[];
 	presets_by_file?: Record<string, string[]>;
 }
@@ -375,7 +374,6 @@ export interface FolderCreateResponse {
 export interface SettingsData {
 	arm_config: Record<string, string | null> | null;
 	arm_metadata: Record<string, string> | null;
-	arm_handbrake_presets: string[] | null;
 	naming_variables: Record<string, string> | null;
 	transcoder_config: TranscoderConfig | null;
 	transcoder_gpu_support: Record<string, boolean> | null;

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -808,7 +808,7 @@
 		// Transcoder Integration
 		SKIP_TRANSCODE: { label: 'Skip Transcoding (Global Default)', description: 'When enabled, ripped files are finalized directly without sending to the transcoder. Can be overridden per-job from the review panel.' },
 		TRANSCODER_URL: { label: 'Transcoder Webhook URL', description: 'URL of the arm-transcoder webhook endpoint (leave empty to disable)' },
-		TRANSCODER_WEBHOOK_SECRET: { label: 'Transcoder Webhook Secret', description: 'Must match WEBHOOK_SECRET in arm-transcoder .env' },
+		TRANSCODER_WEBHOOK_SECRET: { label: 'Transcoder Webhook Secret', description: 'Used by the ripper for outbound transcoder webhooks. arm-ui reads its own copy from ARM_UI_TRANSCODER_WEBHOOK_SECRET at startup; rotating requires updating the env on both services + restarting the containers.' },
 		LOCAL_RAW_PATH: { label: 'Local Raw Path', description: 'Local scratch storage where ARM rips to (for file move before notify)' },
 		SHARED_RAW_PATH: { label: 'Shared Raw Path', description: 'Shared/NFS storage the transcoder reads from (for file move before notify)' },
 	};
@@ -1422,12 +1422,12 @@
 								placeholder="Enter secret to test..."
 								bind:value={webhookSecret}
 							/>
-							<p class="mt-1 text-xs text-gray-400">Leave empty to test with the saved TRANSCODER_WEBHOOK_SECRET from arm.yaml.</p>
+							<p class="mt-1 text-xs text-gray-400">Enter a candidate secret to validate it end-to-end against the transcoder. The deployed secret&apos;s configured/missing status is shown in the Authentication panel below.</p>
 						</div>
 						<button
 							type="button"
 							onclick={handleTestWebhook}
-							disabled={webhookTesting}
+							disabled={webhookTesting || !webhookSecret.trim()}
 							class="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-hover disabled:opacity-50 dark:bg-primary dark:hover:bg-primary-hover"
 						>
 							{webhookTesting ? 'Testing...' : 'Test Webhook'}

--- a/frontend/tests/visual/settings.spec.ts
+++ b/frontend/tests/visual/settings.spec.ts
@@ -11,7 +11,6 @@ test.describe('Settings visual', () => {
                     body: JSON.stringify({
                         arm_config: {},
                         arm_metadata: null,
-                        arm_handbrake_presets: null,
                         naming_variables: null,
                         transcoder_config: null,
                         transcoder_gpu_support: null,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import os
 
 # --- Environment overrides (before any backend imports) ---
 os.environ.setdefault("ARM_UI_ARM_LOG_PATH", "/tmp/arm_logs")
-os.environ.setdefault("ARM_UI_ARM_CONFIG_PATH", "/tmp/arm.yaml")
 os.environ.setdefault("ARM_UI_ARM_URL", "http://arm-test:8080")
 os.environ.setdefault("ARM_UI_TRANSCODER_URL", "http://transcoder-test:5000")
 

--- a/tests/routers/test_settings.py
+++ b/tests/routers/test_settings.py
@@ -116,20 +116,27 @@ async def test_webhook_bad_secret(app_client):
     assert data["secret_required"] is True
 
 
-async def test_webhook_empty_body(app_client):
-    """test-webhook defaults to empty secret when body has no webhook_secret."""
-    result = {"reachable": True, "secret_ok": True, "secret_required": False, "error": None}
+async def test_webhook_empty_body_returns_400(app_client):
+    """test-webhook rejects empty/missing webhook_secret without calling the client.
+
+    The deployed-secret-configured status is already surfaced via /health, so
+    this endpoint exists only to validate a candidate string the user supplied.
+    """
     with patch(
         "backend.routers.settings.transcoder_client.test_webhook",
         new_callable=AsyncMock,
-        return_value=result,
     ) as mock_fn:
-        resp = await app_client.post(
+        resp_missing = await app_client.post(
             "/api/settings/transcoder/test-webhook",
             json={},
         )
-    assert resp.status_code == 200
-    mock_fn.assert_awaited_once_with("")
+        resp_empty = await app_client.post(
+            "/api/settings/transcoder/test-webhook",
+            json={"webhook_secret": ""},
+        )
+    assert resp_missing.status_code == 400
+    assert resp_empty.status_code == 400
+    mock_fn.assert_not_awaited()
 
 
 # --- GET /api/settings (auth status) ---
@@ -148,7 +155,6 @@ async def test_settings_includes_auth_status(app_client):
         patch("backend.routers.settings.arm_client.get_config", new_callable=AsyncMock, return_value=None),
         patch("backend.routers.settings.transcoder_client.get_config", new_callable=AsyncMock, return_value=None),
         patch("backend.routers.settings.transcoder_client.health", new_callable=AsyncMock, return_value=health),
-        patch("backend.routers.settings._read_hb_presets", return_value=None),
     ):
         resp = await app_client.get("/api/settings")
     assert resp.status_code == 200

--- a/tests/routers/test_settings_coverage.py
+++ b/tests/routers/test_settings_coverage.py
@@ -2,56 +2,9 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
-
-from backend.routers.settings import _read_hb_presets
-
-
-# --- _read_hb_presets ---
-
-
-def test_read_hb_presets_success(tmp_path):
-    presets_file = tmp_path / "presets.json"
-    presets_file.write_text(json.dumps(["Very Fast 1080p30", "Fast 1080p30"]))
-    with patch("backend.routers.settings.app_settings") as mock_settings:
-        mock_settings.arm_hb_presets_path = str(presets_file)
-        result = _read_hb_presets()
-    assert result == ["Very Fast 1080p30", "Fast 1080p30"]
-
-
-def test_read_hb_presets_missing_file():
-    with patch("backend.routers.settings.app_settings") as mock_settings:
-        mock_settings.arm_hb_presets_path = "/nonexistent/presets.json"
-        result = _read_hb_presets()
-    assert result is None
-
-
-def test_read_hb_presets_none_path():
-    with patch("backend.routers.settings.app_settings") as mock_settings:
-        mock_settings.arm_hb_presets_path = None
-        result = _read_hb_presets()
-    assert result is None
-
-
-def test_read_hb_presets_invalid_json(tmp_path):
-    presets_file = tmp_path / "presets.json"
-    presets_file.write_text("not valid json{{{")
-    with patch("backend.routers.settings.app_settings") as mock_settings:
-        mock_settings.arm_hb_presets_path = str(presets_file)
-        result = _read_hb_presets()
-    assert result is None
-
-
-def test_read_hb_presets_non_list(tmp_path):
-    presets_file = tmp_path / "presets.json"
-    presets_file.write_text(json.dumps({"key": "value"}))
-    with patch("backend.routers.settings.app_settings") as mock_settings:
-        mock_settings.arm_hb_presets_path = str(presets_file)
-        result = _read_hb_presets()
-    assert result is None
 
 
 # --- GET /api/settings ---
@@ -75,7 +28,6 @@ async def test_get_settings_all_sources(app_client):
         patch("backend.routers.settings.arm_client.get_config", new_callable=AsyncMock, return_value=arm_resp),
         patch("backend.routers.settings.transcoder_client.get_config", new_callable=AsyncMock, return_value=tc_config),
         patch("backend.routers.settings.transcoder_client.health", new_callable=AsyncMock, return_value=health),
-        patch("backend.routers.settings._read_hb_presets", return_value=["Fast 1080p30"]),
     ):
         resp = await app_client.get("/api/settings")
     assert resp.status_code == 200
@@ -85,7 +37,6 @@ async def test_get_settings_all_sources(app_client):
     assert data["naming_variables"] == {"title": "Movie title"}
     assert data["transcoder_config"] == tc_config
     assert data["gpu_support"] == {"nvenc": True}
-    assert data["arm_handbrake_presets"] == ["Fast 1080p30"]
 
 
 async def test_get_settings_arm_offline_returns_none_config(app_client):
@@ -94,7 +45,6 @@ async def test_get_settings_arm_offline_returns_none_config(app_client):
         patch("backend.routers.settings.arm_client.get_config", new_callable=AsyncMock, return_value=None),
         patch("backend.routers.settings.transcoder_client.get_config", new_callable=AsyncMock, return_value=None),
         patch("backend.routers.settings.transcoder_client.health", new_callable=AsyncMock, return_value=None),
-        patch("backend.routers.settings._read_hb_presets", return_value=None),
     ):
         resp = await app_client.get("/api/settings")
     assert resp.status_code == 200
@@ -117,7 +67,6 @@ async def test_get_settings_transcoder_config_fallback_from_health(app_client):
         patch("backend.routers.settings.arm_client.get_config", new_callable=AsyncMock, return_value=None),
         patch("backend.routers.settings.transcoder_client.get_config", new_callable=AsyncMock, return_value=None),
         patch("backend.routers.settings.transcoder_client.health", new_callable=AsyncMock, return_value=health),
-        patch("backend.routers.settings._read_hb_presets", return_value=None),
     ):
         resp = await app_client.get("/api/settings")
     assert resp.status_code == 200

--- a/tests/services/test_themes_migration.py
+++ b/tests/services/test_themes_migration.py
@@ -1,0 +1,92 @@
+"""Tests for the one-shot legacy themes migration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from backend.services import themes_migration
+
+
+def test_no_legacy_dir_no_op(tmp_path):
+    target = tmp_path / "themes"
+    with patch.object(themes_migration, "_LEGACY_THEMES_DIR", tmp_path / "missing"):
+        copied = themes_migration.migrate_legacy_themes(str(target))
+    assert copied == 0
+    # Target wasn't created either - nothing to migrate, so don't make it.
+    assert not target.exists()
+
+
+def test_target_already_populated_no_op(tmp_path):
+    target = tmp_path / "themes"
+    target.mkdir()
+    (target / "existing.json").write_text("{}")
+
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / "old.json").write_text(json.dumps({"id": "old", "label": "Old", "tokens": {}}))
+
+    with patch.object(themes_migration, "_LEGACY_THEMES_DIR", legacy):
+        copied = themes_migration.migrate_legacy_themes(str(target))
+    assert copied == 0
+    # The pre-existing file is unchanged; the legacy file did NOT overwrite anything.
+    assert (target / "existing.json").exists()
+    assert not (target / "old.json").exists()
+
+
+def test_copies_json_and_css_from_legacy(tmp_path):
+    target = tmp_path / "themes"
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / "dark.json").write_text(json.dumps({"id": "dark", "label": "Dark", "tokens": {}}))
+    (legacy / "dark.css").write_text("body{}")
+    # README.md should NOT be copied
+    (legacy / "README.md").write_text("docs")
+
+    with patch.object(themes_migration, "_LEGACY_THEMES_DIR", legacy):
+        copied = themes_migration.migrate_legacy_themes(str(target))
+    assert copied == 2
+    assert (target / "dark.json").exists()
+    assert (target / "dark.css").exists()
+    assert not (target / "README.md").exists()
+
+
+def test_idempotent_after_first_run(tmp_path):
+    target = tmp_path / "themes"
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / "dark.json").write_text(json.dumps({"id": "dark", "label": "Dark", "tokens": {}}))
+
+    with patch.object(themes_migration, "_LEGACY_THEMES_DIR", legacy):
+        first = themes_migration.migrate_legacy_themes(str(target))
+        second = themes_migration.migrate_legacy_themes(str(target))
+    assert first == 1
+    # Second call sees populated target, does nothing.
+    assert second == 0
+
+
+def test_logs_and_skips_when_copy_fails(tmp_path, caplog):
+    """A single corrupt/unreadable file is logged and skipped; siblings still copy."""
+    target = tmp_path / "themes"
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / "good.json").write_text(json.dumps({"id": "g", "label": "G", "tokens": {}}))
+    (legacy / "bad.json").write_text(json.dumps({"id": "b", "label": "B", "tokens": {}}))
+
+    real_copy = themes_migration.shutil.copy2
+
+    def fail_for_bad(src, dst, *args, **kwargs):
+        if Path(src).name == "bad.json":
+            raise OSError("simulated EACCES")
+        return real_copy(src, dst, *args, **kwargs)
+
+    with patch.object(themes_migration, "_LEGACY_THEMES_DIR", legacy), \
+         patch.object(themes_migration.shutil, "copy2", side_effect=fail_for_bad), \
+         caplog.at_level("WARNING", logger=themes_migration.log.name):
+        copied = themes_migration.migrate_legacy_themes(str(target))
+
+    assert copied == 1
+    assert (target / "good.json").exists()
+    assert not (target / "bad.json").exists()
+    assert any("bad.json" in rec.message and "simulated" in rec.message for rec in caplog.records)

--- a/tests/services/test_themes_path_resolution.py
+++ b/tests/services/test_themes_path_resolution.py
@@ -1,0 +1,19 @@
+"""Test _user_themes_dir() in isolation.
+
+Lives in its own file so the test_themes.py autouse `patch_dirs` fixture
+(which replaces _user_themes_dir with a lambda) does not apply.
+"""
+
+from __future__ import annotations
+
+from backend.services import themes as theme_service
+
+
+def test_user_themes_dir_uses_configured_path_and_creates_dir(tmp_path, monkeypatch):
+    """_user_themes_dir reads settings.themes_path and mkdir-s the target."""
+    target = tmp_path / "ui-themes-volume"
+    monkeypatch.setattr(theme_service.settings, "themes_path", str(target))
+    assert not target.exists()
+    result = theme_service._user_themes_dir()
+    assert result == target
+    assert target.is_dir()

--- a/tests/services/test_transcoder_client.py
+++ b/tests/services/test_transcoder_client.py
@@ -129,3 +129,19 @@ async def test_test_webhook_unreachable():
 
     assert result["reachable"] is False
     assert result["error"] is not None
+
+
+async def test_test_webhook_uses_caller_secret_in_header():
+    """Caller-supplied secret is sent in X-Webhook-Secret. No env fallback."""
+    mock_resp = _mock_response({"status": "ignored"})
+
+    with patch("backend.services.transcoder_client.httpx.AsyncClient") as MockClient:
+        ctx = AsyncMock()
+        ctx.post.return_value = mock_resp
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=ctx)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+        result = await transcoder_client.test_webhook("candidate-secret")
+
+    _, kwargs = ctx.post.call_args
+    assert kwargs["headers"]["X-Webhook-Secret"] == "candidate-secret"
+    assert result["secret_ok"] is True

--- a/tests/services/test_transcoder_client_coverage.py
+++ b/tests/services/test_transcoder_client_coverage.py
@@ -568,26 +568,6 @@ async def test_test_connection_config_lost_connection():
 # --- test_webhook edge cases ---
 
 
-async def test_test_webhook_empty_secret_reads_yaml():
-    """test_webhook reads from arm.yaml when secret is empty."""
-    mock_resp = _mock_response({"status": "ok"})
-
-    with patch("asyncio.to_thread", new_callable=AsyncMock, return_value="yaml-secret"), \
-         patch("backend.services.transcoder_client.httpx.AsyncClient") as MockClient:
-        ctx = AsyncMock()
-        ctx.post.return_value = mock_resp
-        MockClient.return_value.__aenter__ = AsyncMock(return_value=ctx)
-        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-        result = await transcoder_client.test_webhook("")
-
-    assert result["reachable"] is True
-    assert result["secret_ok"] is True
-    # Verify the header was sent with yaml-read secret
-    call_kwargs = ctx.post.call_args
-    headers = call_kwargs[1].get("headers", {})
-    assert headers.get("X-Webhook-Secret") == "yaml-secret"
-
-
 async def test_test_webhook_http_error():
     """test_webhook handles generic HTTP errors."""
     with patch("backend.services.transcoder_client.httpx.AsyncClient") as MockClient:

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,49 @@
+"""Tests for backend.main.lifespan - the FastAPI startup/shutdown context."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.asyncio
+async def test_lifespan_runs_themes_migration():
+    """Lifespan calls migrate_legacy_themes with the configured themes_path."""
+    from backend.main import app, lifespan
+    from backend.config import settings as app_settings
+    from backend.services import arm_client, image_cache, system_cache, transcoder_client
+
+    with patch("backend.main.migrate_legacy_themes") as mock_migrate, \
+         patch.object(system_cache, "refresh", new_callable=AsyncMock), \
+         patch.object(image_cache, "startup_scan"), \
+         patch.object(arm_client, "close_client", new_callable=AsyncMock), \
+         patch.object(transcoder_client, "close_client", new_callable=AsyncMock):
+        async with lifespan(app):
+            pass
+
+    mock_migrate.assert_called_once_with(app_settings.themes_path)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_swallows_migration_errors(caplog):
+    """If migrate_legacy_themes raises, startup continues and the error is logged."""
+    from backend.main import app, lifespan
+    from backend.services import arm_client, image_cache, system_cache, transcoder_client
+
+    with patch("backend.main.migrate_legacy_themes", side_effect=OSError("simulated EROFS")), \
+         patch.object(system_cache, "refresh", new_callable=AsyncMock) as mock_refresh, \
+         patch.object(image_cache, "startup_scan"), \
+         patch.object(arm_client, "close_client", new_callable=AsyncMock), \
+         patch.object(transcoder_client, "close_client", new_callable=AsyncMock), \
+         caplog.at_level(logging.ERROR, logger="backend.main"):
+        async with lifespan(app):
+            pass
+
+    # Startup did not abort: refresh was still called after the failed migrator.
+    mock_refresh.assert_awaited_once()
+    assert any(
+        "Theme migration failed" in rec.message and rec.levelno == logging.ERROR
+        for rec in caplog.records
+    ), "Expected an ERROR log from main.py for the failed migration"


### PR DESCRIPTION
## Summary

PR #1 of the UI bind-mount decoupling project. Four sub-changes that let arm-ui run from any host with no shared volume to the ripper.

- **Webhook secret from env.** `transcoder_client.send_webhook` and `test_webhook` now read `settings.transcoder_webhook_secret` (populated from `ARM_UI_TRANSCODER_WEBHOOK_SECRET` env). Removes the YAML-on-disk fallback that needed access to `arm.yaml` via the shared config bind.
- **Themes named volume + first-boot migrator.** Themes move to a UI-owned path (`settings.themes_path`, default `/data/themes`). New `backend/services/themes_migration.py` runs once at lifespan startup: if the new path is empty AND the legacy `/data/config/themes` bind exists, copy `.json` and `.css` files over. Wrapped in lifespan `try/except` so a misconfigured volume can never crash startup.
- **HandBrake preset list deleted.** Pipeline was init container → shared volume → backend file read → `SettingsResponse.arm_handbrake_presets` → typed in `arm.ts` → consumed by zero Svelte components. The `handbrake_preset` field in `PresetEditor` is a free-text input. Whole pipeline removed (also drops the unused `valid_handbrake_presets` field on `TranscoderConfig`).
- **`test-webhook` endpoint contract change.** Now requires non-empty `webhook_secret` in the request body (returns 400 otherwise) and no longer falls back to the deployed env value. The deployed-secret-configured boolean is already shown elsewhere via `transcoder_auth_status.webhook_secret_configured`. Frontend disables the button when input is empty.

Naming collision fix in `main.py`: renamed `from backend.config import settings` to `as app_settings` to avoid shadowing the `routers.settings` module.

Cross-repo PR: pair with **arm-neu PR https://github.com/uprightbass360/automatic-ripping-machine-neu/pull/282** which removes the `arm-hb-presets` init container and updates the compose stacks. Both PRs must merge together.

## Test plan

- [x] Backend Python tests: 643 passed
- [x] Frontend tests: 859 passed
- [x] Type-check: 0 errors
- [x] Local dev stack smoke-tested end-to-end (settings page, themes endpoint, test-webhook with empty/empty-secret/real-secret)
- [x] `themes_migration` test coverage (4 scenarios: empty target, populated target, missing legacy, copy success)
- [ ] Production deploy: verify themes migrate from legacy bind on existing hifi-server install