### PR TITLE
fix(settings): UI polish on transcoder Configuration tab

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -57,11 +57,13 @@
 		@apply bg-page text-gray-900 dark:bg-page-dark dark:text-gray-100;
 	}
 
-	select option {
+	select option,
+	select optgroup {
 		background-color: var(--color-surface);
 		color: #111827;
 	}
-	.dark select option {
+	.dark select option,
+	.dark select optgroup {
 		background-color: var(--color-surface-dark);
 		color: #fff;
 	}

--- a/frontend/src/lib/components/BottomStatsBar.svelte
+++ b/frontend/src/lib/components/BottomStatsBar.svelte
@@ -22,9 +22,16 @@
 		}
 	});
 
-	const hasGpu = $derived($transcoderEnabled && transcoderOnline && transcoderStats?.gpu != null);
+	// Sticky last-known values so the bar does not blank out when a single
+	// dashboard poll returns null.
+	let stickySystemStats = $state<SystemStats | null>(null);
+	let stickyTranscoderStats = $state<SystemStats | null>(null);
+	$effect(() => { if (systemStats) stickySystemStats = systemStats; });
+	$effect(() => { if (transcoderStats) stickyTranscoderStats = transcoderStats; });
 
-	const activeStats = $derived(activePanel === 'ripper' ? (armOnline ? systemStats : null) : (transcoderOnline ? transcoderStats : null));
+	const hasGpu = $derived($transcoderEnabled && transcoderOnline && stickyTranscoderStats?.gpu != null);
+
+	const activeStats = $derived(activePanel === 'ripper' ? (armOnline ? stickySystemStats : null) : (transcoderOnline ? stickyTranscoderStats : null));
 	const isOffline = $derived(
 		activePanel === 'gpu'
 			? !transcoderOnline
@@ -62,7 +69,7 @@
 
 	// Use ripper storage paths for file links (file roots match ripper paths)
 	const rootPaths = $derived(
-		(systemStats?.storage ?? []).reduce<Record<string, string>>((acc, sp) => {
+		(stickySystemStats?.storage ?? []).reduce<Record<string, string>>((acc, sp) => {
 			const key = storageNameToRoot[sp.name];
 			if (key) acc[key] = sp.path.replace(/\/+$/, '');
 			return acc;
@@ -114,8 +121,8 @@
 	{#if activePanel === 'gpu'}
 		{#if !transcoderOnline}
 			<span class="text-xs text-orange-500 dark:text-orange-400">{offlineMessage}</span>
-		{:else if transcoderStats?.gpu}
-			{@const gpu = transcoderStats.gpu}
+		{:else if stickyTranscoderStats?.gpu}
+			{@const gpu = stickyTranscoderStats.gpu}
 			<!-- Vendor -->
 			<span class="shrink-0 rounded-full px-2 py-0.5 text-[9px] font-semibold capitalize {vendorPillClasses(gpu.vendor)}">{gpu.vendor}</span>
 

--- a/frontend/src/lib/components/SidebarStats.svelte
+++ b/frontend/src/lib/components/SidebarStats.svelte
@@ -23,17 +23,30 @@
 		}
 	});
 
-	const hasGpu = $derived($transcoderEnabled && transcoderOnline && transcoderStats?.gpu != null);
+	// Sticky last-known values so the panel does not blank out when a single
+	// dashboard poll returns null (eg. arm-neu /system/stats hiccup, transient
+	// timeout). Stays empty until first real value, then never reverts to null.
+	let stickySystemStats = $state<SystemStats | null>(null);
+	let stickyTranscoderStats = $state<SystemStats | null>(null);
+	let stickySystemInfo = $state<HardwareInfo | null>(null);
+	let stickyTranscoderInfo = $state<HardwareInfo | null>(null);
 
-	const activeHw = $derived(activePanel === 'ripper' ? (armOnline ? systemInfo : null) : (transcoderOnline ? transcoderInfo : null));
-	const activeStats = $derived(activePanel === 'ripper' ? (armOnline ? systemStats : null) : (transcoderOnline ? transcoderStats : null));
+	$effect(() => { if (systemStats) stickySystemStats = systemStats; });
+	$effect(() => { if (transcoderStats) stickyTranscoderStats = transcoderStats; });
+	$effect(() => { if (systemInfo) stickySystemInfo = systemInfo; });
+	$effect(() => { if (transcoderInfo) stickyTranscoderInfo = transcoderInfo; });
+
+	const hasGpu = $derived($transcoderEnabled && transcoderOnline && stickyTranscoderStats?.gpu != null);
+
+	const activeHw = $derived(activePanel === 'ripper' ? (armOnline ? stickySystemInfo : null) : (transcoderOnline ? stickyTranscoderInfo : null));
+	const activeStats = $derived(activePanel === 'ripper' ? (armOnline ? stickySystemStats : null) : (transcoderOnline ? stickyTranscoderStats : null));
 
 	// Map storage display names to file root keys for deep linking
 	const storageNameToRoot: Record<string, string> = {
 		'Raw': 'raw', 'Transcode': 'transcode', 'Work': 'transcode', 'Completed': 'completed',
 	};
 	const rootPaths = $derived(
-		(systemStats?.storage ?? []).reduce<Record<string, string>>((acc, sp) => {
+		(stickySystemStats?.storage ?? []).reduce<Record<string, string>>((acc, sp) => {
 			const key = storageNameToRoot[sp.name];
 			if (key) acc[key] = sp.path.replace(/\/+$/, '');
 			return acc;
@@ -90,8 +103,8 @@
 	{#if activePanel === 'gpu'}
 		{#if !transcoderOnline}
 			<p class="text-xs text-orange-500 dark:text-orange-400">Cannot reach the transcoder service</p>
-		{:else if transcoderStats?.gpu}
-			{@const gpu = transcoderStats.gpu}
+		{:else if stickyTranscoderStats?.gpu}
+			{@const gpu = stickyTranscoderStats.gpu}
 			<div class="mb-2 flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
 				<span class="rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize {vendorPillClasses(gpu.vendor)}">{gpu.vendor}</span>
 				{#if gpu.temperature_c != null}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1676,11 +1676,11 @@
 						{/if}
 
 						<!-- Logging settings -->
-						{#if settings.transcoder_config.updatable_keys.some((k) => TC_LOGGING_KEYS.includes(k))}
+						{#if (settings.transcoder_config?.updatable_keys ?? []).some((k) => TC_LOGGING_KEYS.includes(k))}
 							<div class="space-y-4 rounded-md border border-primary/15 bg-page p-4 dark:border-primary/20 dark:bg-primary/5">
 								<h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Logging</h3>
 								<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-									{#each TC_LOGGING_KEYS.filter((k) => settings.transcoder_config.updatable_keys.includes(k)) as key}
+									{#each TC_LOGGING_KEYS.filter((k) => (settings.transcoder_config?.updatable_keys ?? []).includes(k)) as key}
 										{@const selectOpts = tcSelectOptions(key)}
 										<div class="relative {isTcFieldDirty(key) ? 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50' : ''}">
 											<div class="{isTcFieldDirty(key) ? 'px-3 py-3' : ''}">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -665,7 +665,12 @@
 		// Preset-managed keys (rendered in the PresetEditor section, not as raw fields)
 		'global_overrides',
 		'selected_preset_slug',
+		// Logging keys rendered in their own sub-panel below Operational
+		'log_level',
+		'log_level_libraries',
 	]);
+
+	const TC_LOGGING_KEYS = ['log_level', 'log_level_libraries'];
 
 	// Transcoder number fields: key → [min, max, step?]
 	const TC_NUMBER_FIELDS: Record<string, [number, number, number?]> = {
@@ -1285,14 +1290,18 @@
 	</div>
 {/snippet}
 
-<!-- Reusable snippet for GPU support cards -->
+<!-- Reusable snippet for GPU support cards.
+     Filters to the detected vendor's group(s); falls back to showing all
+     groups when nothing is detected so the user can see what's missing. -->
 {#snippet gpuCards(gpu: Record<string, boolean>)}
+	{@const detected = HW_GROUPS.filter((g) => hasAny(gpu, g.keys))}
+	{@const visibleGroups = detected.length > 0 ? detected : HW_GROUPS}
 	<section>
 		<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
 			Hardware Encoding
 		</h2>
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-			{#each HW_GROUPS as group}
+			{#each visibleGroups as group}
 				{@const available = hasAny(gpu, group.keys)}
 				<div
 					class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark"
@@ -1656,6 +1665,51 @@
 													/>
 												{/if}
 
+												{#if TC_HELP[key]}
+													<p class="mt-1 text-xs text-gray-400">{TC_HELP[key]}</p>
+												{/if}
+											</div>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{/if}
+
+						<!-- Logging settings -->
+						{#if settings.transcoder_config.updatable_keys.some((k) => TC_LOGGING_KEYS.includes(k))}
+							<div class="space-y-4 rounded-md border border-primary/15 bg-page p-4 dark:border-primary/20 dark:bg-primary/5">
+								<h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Logging</h3>
+								<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+									{#each TC_LOGGING_KEYS.filter((k) => settings.transcoder_config.updatable_keys.includes(k)) as key}
+										{@const selectOpts = tcSelectOptions(key)}
+										<div class="relative {isTcFieldDirty(key) ? 'rounded-lg ring-2 ring-primary/40 dark:ring-primary/50' : ''}">
+											<div class="{isTcFieldDirty(key) ? 'px-3 py-3' : ''}">
+												<div class="mb-1 flex items-center gap-1">
+													<label for="tc-{key}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+														{TC_LABELS[key] ?? key}
+													</label>
+													{#if isTcFieldDirty(key)}
+														<span class="ml-1 h-1.5 w-1.5 rounded-full bg-primary" title="Modified"></span>
+													{/if}
+												</div>
+												{#if selectOpts}
+													<select
+														id="tc-{key}"
+														class={inputClass}
+														bind:value={tcForm[key]}
+													>
+														{#each selectOpts as opt}
+															<option value={opt}>{opt}</option>
+														{/each}
+													</select>
+												{:else}
+													<input
+														id="tc-{key}"
+														type="text"
+														class={inputClass}
+														bind:value={tcForm[key]}
+													/>
+												{/if}
 												{#if TC_HELP[key]}
 													<p class="mt-1 text-xs text-gray-400">{TC_HELP[key]}</p>
 												{/if}


### PR DESCRIPTION
## Summary

Four small UI fixes from the production smoke-test of v17.2.0-rc.

1. **Hardware Encoding** filtered to the detected vendor only (instead of showing all 4 vendor groups). Falls back to showing all when nothing is detected so the user can still see what's missing.
2. **Preset dropdown** \`<optgroup>\` labels were unstyled on dark themes (browser default = white-on-white). Added optgroup to the existing app.css \`select option\` rule.
3. **log_level + log_level_libraries** moved from "Operational" sub-panel into their own "Logging" sub-panel.
4. **Sidebar stats blanking out** on auto-refresh. Root cause: when the BFF dashboard endpoint returns \`system_stats: null\` for one poll cycle (arm-neu /system/stats hiccup), the dashboard store overwrites previous good data with null. Fix: keep last-known values sticky in SidebarStats + BottomStatsBar.

## Test plan

- [x] frontend tests: 859 passed
- [x] backend tests: 618 passed
- [x] frontend rebuilt + verified locally on dev stack
- [ ] CI green