### PR TITLE
fix(preflight): bump BFF timeout 30s -> 60s

### DIFF
--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -498,16 +498,18 @@ async def check_makemkv_key() -> dict[str, Any] | None:
 async def run_preflight() -> dict[str, Any] | None:
     """Run ARM preflight checks. Returns None if ARM is unreachable.
 
-    Uses a 30-second timeout: preflight includes MakeMKV key validation
-    (which may fetch the beta key from forum.makemkv.com) plus per-path
-    stat/chown probes, so the default 10s is too tight.
+    Uses a 60-second timeout: preflight includes MakeMKV key validation
+    (which may fetch the beta key from forum.makemkv.com via curl with
+    a 15s cap) plus per-path stat/chown probes. 30s used to be enough,
+    but a slow forum.makemkv.com round-trip plus the API key probes can
+    push us past it; the upstream caps the MakeMKV step itself.
     """
-    return await _request("POST", "/api/v1/system/preflight", timeout=30.0)
+    return await _request("POST", "/api/v1/system/preflight", timeout=60.0)
 
 
 async def fix_preflight(items: list[str]) -> dict[str, Any] | None:
     """Fix specified preflight issues, then re-check. Returns None if ARM is unreachable."""
-    return await _request("POST", "/api/v1/system/preflight/fix", json={"fix": items}, timeout=30.0)
+    return await _request("POST", "/api/v1/system/preflight/fix", json={"fix": items}, timeout=60.0)
 
 
 # --- Jobs (read-side, replaces direct DB access via backend.services.arm_db) ---

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -433,12 +433,12 @@ async def test_restart_arm_unreachable(mock_client):
 # --- run_preflight / fix_preflight ---
 
 
-async def test_run_preflight_uses_30s_timeout(mock_client):
-    """run_preflight uses a 30s timeout to absorb slow ARM preflight responses."""
+async def test_run_preflight_uses_60s_timeout(mock_client):
+    """run_preflight uses a 60s timeout to absorb slow ARM preflight responses."""
     _set_request_response(mock_client, {"checks": [], "paths": []})
     result = await arm_client.run_preflight()
     assert result == {"checks": [], "paths": []}
-    mock_client.request.assert_awaited_once_with("POST", "/api/v1/system/preflight", timeout=30.0)
+    mock_client.request.assert_awaited_once_with("POST", "/api/v1/system/preflight", timeout=60.0)
 
 
 async def test_run_preflight_unreachable(mock_client):
@@ -446,8 +446,8 @@ async def test_run_preflight_unreachable(mock_client):
     assert await arm_client.run_preflight() is None
 
 
-async def test_fix_preflight_uses_30s_timeout(mock_client):
-    """fix_preflight uses a 30s timeout since it re-runs preflight after applying fixes."""
+async def test_fix_preflight_uses_60s_timeout(mock_client):
+    """fix_preflight uses a 60s timeout since it re-runs preflight after applying fixes."""
     _set_request_response(mock_client, {"checks": [], "paths": []})
     result = await arm_client.fix_preflight(["RAW_PATH", "LOGPATH"])
     assert result == {"checks": [], "paths": []}
@@ -455,7 +455,7 @@ async def test_fix_preflight_uses_30s_timeout(mock_client):
         "POST",
         "/api/v1/system/preflight/fix",
         json={"fix": ["RAW_PATH", "LOGPATH"]},
-        timeout=30.0,
+        timeout=60.0,
     )
 
 


### PR DESCRIPTION
## Summary
- `run_preflight` and `fix_preflight` now use a 60s httpx timeout (was 30s).
- Pairs with the arm-neu fix at https://github.com/uprightbass360/automatic-ripping-machine-neu/pull/fix-preflight-event-loop-blocking which caps the upstream MakeMKV curl at 15s, so the upstream can no longer exceed this client budget.

## Why
When forum.makemkv.com is slow, arm-neu's preflight can take ~45s end-to-end. The 30s BFF timeout was tripping a 503 ("ARM web UI is unreachable") even when the upstream eventually succeeded, leaving the System Health card stuck on "Running health checks...".

## Test plan
- [x] Existing test renamed `test_run_preflight_uses_30s_timeout` -> `test_run_preflight_uses_60s_timeout` and asserts the new value.
- [x] Same for `fix_preflight`.
- [ ] CI tests, codecov, SonarCloud, CodeQL pass.
- [ ] Smoke test on hifi: System Health card transitions to results within 60s instead of hanging.