### PR TITLE
feat(settings): show transcoder GPU vendor under version

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -22,6 +22,7 @@
 	import { fetchTranscoderScheme, fetchTranscoderPresets, createCustomPreset } from '$lib/api/settings';
 	import type { Scheme, Preset, Overrides, PresetEditorState } from '$lib/types/presets';
 	import { transcoderEnabled } from '$lib/stores/config';
+	import { dashboard } from '$lib/stores/dashboard';
 	import { get } from 'svelte/store';
 
 	let settings = $state<SettingsData | null>(null);
@@ -1986,12 +1987,16 @@
 						<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Versions</h2>
 						<div class="grid grid-cols-2 gap-4 md:grid-cols-5">
 							{#each Object.entries(systemInfo.versions) as [name, version]}
+								{@const subtitle = name === 'transcoder' ? $dashboard.transcoder_system_stats?.gpu?.vendor : null}
 								<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 									<p class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{name}</p>
 									<div class="mt-1 flex items-center gap-2">
 										<div class="h-2 w-2 rounded-full {version === 'offline' ? 'bg-red-400' : version === 'unknown' ? 'bg-gray-400' : 'bg-green-400'}"></div>
 										<p class="text-sm font-semibold text-gray-900 dark:text-white">{version}</p>
 									</div>
+									{#if subtitle}
+										<p class="mt-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{subtitle}</p>
+									{/if}
 								</div>
 							{/each}
 						</div>

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -41,7 +41,7 @@ vi.mock('$lib/api/settings', () => ({
 	testTranscoderConnection: vi.fn(() => Promise.resolve({ reachable: true, auth_ok: true, auth_required: false, gpu_support: null, worker_running: true, queue_size: 0, error: null })),
 	testTranscoderWebhook: vi.fn(() => Promise.resolve({ reachable: true, secret_ok: true, secret_required: true, error: null })),
 	fetchSystemInfo: vi.fn(() => Promise.resolve({
-		versions: { arm: '2.0.0', python: '3.12' },
+		versions: { arm: '2.0.0', transcoder: '17.4.0', ui: '17.1.0' },
 		endpoints: { api: { url: 'http://localhost:8888', reachable: true } },
 		paths: [{ setting: 'RAW_PATH', path: '/raw', exists: true, writable: true }],
 		database: { path: '/db/arm.db', size_bytes: 102400, available: true, migration_current: 'abc', migration_head: 'abc', up_to_date: true },
@@ -113,6 +113,17 @@ vi.mock('$lib/stores/polling', async () => {
 		}))
 	};
 });
+
+// Lifted so individual tests can swap dashboard state via mockDashboard.set(...).
+// async vi.hoisted runs before module imports but supports dynamic import().
+const mockDashboard = await vi.hoisted(async () => {
+	const { writable } = await import('svelte/store');
+	return writable<{ transcoder_system_stats: { gpu: { vendor: string } | null } | null }>({
+		transcoder_system_stats: null
+	});
+});
+
+vi.mock('$lib/stores/dashboard', () => ({ dashboard: mockDashboard }));
 
 describe('Settings Page', () => {
 	afterEach(() => cleanup());
@@ -292,6 +303,55 @@ describe('Settings Page', () => {
 			});
 			// Run Check button should not be visible when collapsed
 			expect(screen.queryByText('Run Check')).not.toBeInTheDocument();
+		});
+
+		it('shows transcoder GPU vendor as subtitle on Versions card when present', async () => {
+			mockDashboard.set({
+				transcoder_system_stats: { gpu: { vendor: 'nvidia' } }
+			});
+			renderComponent(SettingsPage);
+			await waitFor(() => {
+				expect(screen.getByText('Music')).toBeInTheDocument();
+			});
+			const systemTab = screen.getAllByText('System');
+			await fireEvent.click(systemTab[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Versions')).toBeInTheDocument();
+			});
+			// Vendor subtitle renders as visible text alongside the version
+			expect(screen.getByText('nvidia')).toBeInTheDocument();
+		});
+
+		it('omits GPU vendor subtitle when transcoder has no GPU monitor', async () => {
+			mockDashboard.set({
+				transcoder_system_stats: { gpu: null }
+			});
+			renderComponent(SettingsPage);
+			await waitFor(() => {
+				expect(screen.getByText('Music')).toBeInTheDocument();
+			});
+			const systemTab = screen.getAllByText('System');
+			await fireEvent.click(systemTab[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Versions')).toBeInTheDocument();
+			});
+			expect(screen.queryByText('nvidia')).not.toBeInTheDocument();
+			expect(screen.queryByText('intel')).not.toBeInTheDocument();
+			expect(screen.queryByText('amd')).not.toBeInTheDocument();
+		});
+
+		it('omits GPU vendor subtitle when transcoder is offline (no stats)', async () => {
+			mockDashboard.set({ transcoder_system_stats: null });
+			renderComponent(SettingsPage);
+			await waitFor(() => {
+				expect(screen.getByText('Music')).toBeInTheDocument();
+			});
+			const systemTab = screen.getAllByText('System');
+			await fireEvent.click(systemTab[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Versions')).toBeInTheDocument();
+			});
+			expect(screen.queryByText('nvidia')).not.toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
The Settings -> Versions card for \`transcoder\` now shows the active GPU vendor (NVIDIA / INTEL / AMD) as a small uppercase subtitle below the version string.

## Why
Currently \"transcoder 17.4.0\" gives no indication of which GPU layer (\`Dockerfile.nvidia\` / \`.intel\` / \`.amd\`) is running, making it harder to confirm the right image is deployed.

## Approach
Reuses the existing dashboard stream — \`$dashboard.transcoder_system_stats.gpu.vendor\` is already populated for SidebarStats / BottomStatsBar / the Transcoder page. No new BFF endpoint, no new type, no extra HTTP round-trip on the settings page.

## Behavior
- **GPU image (any of nvidia/intel/amd)**: shows the vendor pill text under the version.
- **CPU-only deployment (no GPU monitor)**: subtitle hidden.
- **Transcoder offline**: subtitle hidden.

## Test plan
- [x] svelte-check clean.
- [ ] Manual: load Settings -> Configuration -> Versions on a GPU-enabled deployment; vendor appears under 'transcoder'.
- [ ] Manual: same on a CPU-only deployment; no subtitle.