### PR TITLE
feat(version): stamp build identity into VERSION at image-build time

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -52,6 +52,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            IMAGE_TAG=${{ steps.version.outputs.version }}
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:latest
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -62,6 +62,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            IMAGE_TAG=${{ steps.version.outputs.version }}-rc
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}-rc
             ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}-rc

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,18 @@ COPY backend/ backend/
 # Copy built frontend into place for static serving
 COPY --from=frontend-build /app/frontend/build frontend/build
 
+# Stamp VERSION with the actual build identity so the running image can
+# distinguish release / RC / dev builds in the Settings -> Versions panel.
+# - Release workflow passes IMAGE_TAG=<version>           -> e.g. 17.3.0
+# - RC workflow passes      IMAGE_TAG=<version>-rc        -> e.g. 17.3.0-rc
+# - Local docker compose build with no arg                -> e.g. 17.3.0-dev
+ARG IMAGE_TAG=
+RUN if [ -n "$IMAGE_TAG" ]; then \
+        echo "$IMAGE_TAG" > /app/VERSION; \
+    else \
+        echo "$(cat /app/VERSION)-dev" > /app/VERSION; \
+    fi
+
 EXPOSE 8888
 
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8888"]


### PR DESCRIPTION
## Summary
The Settings -> Versions panel will now show the actual build identity instead of the bare source semver:

- Release image (\`:17.1.0\`)  -> \`17.1.0\`
- RC image     (\`:17.2.0-rc\`) -> \`17.2.0-rc\` _(was: \`17.2.0\`)_
- Dev image    (\`arm-ui:dev\`) -> \`17.1.0-dev\` _(was: \`17.1.0\`)_

## Why
Today \`/app/VERSION\` is just the source value (last release-please bump). An RC image and a dev image of the same base look identical from the UI side, which is what surfaced today.

## Approach
Append a final \`ARG IMAGE_TAG=\` + \`RUN\` to the Dockerfile that either writes the supplied tag or suffixes \`-dev\`. Workflows pass the corresponding \`IMAGE_TAG\` build-arg.

Pairs with:
- arm-neu PR https://github.com/uprightbass360/automatic-ripping-machine-neu/pull/288 (also drops the source VERSION bind in dev compose)
- arm-transcoder PR https://github.com/uprightbass360/automatic-ripping-machine-transcoder/pull/127

## Verified locally
\`\`\`
$ docker build -t arm-ui:dev-test .
$ docker run --rm arm-ui:dev-test cat /app/VERSION
17.1.0-dev
\`\`\`

## Test plan
- [x] Local docker build verified.
- [ ] CI: tests + codecov + SonarCloud + CodeQL pass.
- [ ] After local rebuild, Settings -> Versions on dev shows \`ui 17.1.0-dev\`.