### PR TITLE
feat(settings): scale Versions card columns to entry count

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1985,7 +1985,7 @@
 					<!-- Versions -->
 					<section>
 						<h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Versions</h2>
-						<div class="grid grid-cols-2 gap-4 md:grid-cols-5">
+						<div class="grid grid-cols-2 gap-4 {Object.keys(systemInfo.versions).length === 4 ? 'md:grid-cols-4' : Object.keys(systemInfo.versions).length === 3 ? 'md:grid-cols-3' : Object.keys(systemInfo.versions).length === 2 ? 'md:grid-cols-2' : 'md:grid-cols-5'}">
 							{#each Object.entries(systemInfo.versions) as [name, version]}
 								{@const subtitle = name === 'transcoder' ? $dashboard.transcoder_system_stats?.gpu?.vendor : null}
 								<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -353,5 +353,42 @@ describe('Settings Page', () => {
 			});
 			expect(screen.queryByText('nvidia')).not.toBeInTheDocument();
 		});
+
+		it('uses md:grid-cols-4 when Versions card has 4 entries', async () => {
+			const settingsApi = await import('$lib/api/settings');
+			vi.mocked(settingsApi.fetchSystemInfo).mockResolvedValueOnce({
+				versions: { arm: '17.3.0-rc', makemkv: '1.18.3', transcoder: '17.5.0-rc', ui: '17.2.0-rc' },
+				endpoints: { api: { url: 'http://localhost:8888', reachable: true } },
+				paths: [],
+				database: { path: '/db/arm.db', size_bytes: 0, available: true, migration_current: 'a', migration_head: 'a', up_to_date: true },
+				drives: []
+			});
+			renderComponent(SettingsPage);
+			await waitFor(() => {
+				expect(screen.getByText('Music')).toBeInTheDocument();
+			});
+			const systemTab = screen.getAllByText('System');
+			await fireEvent.click(systemTab[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Versions')).toBeInTheDocument();
+			});
+			const grid = screen.getByText('Versions').parentElement?.querySelector('div.grid');
+			expect(grid?.className).toContain('md:grid-cols-4');
+		});
+
+		it('uses md:grid-cols-3 when Versions card has 3 entries (e.g. transcoder disabled)', async () => {
+			renderComponent(SettingsPage);
+			await waitFor(() => {
+				expect(screen.getByText('Music')).toBeInTheDocument();
+			});
+			const systemTab = screen.getAllByText('System');
+			await fireEvent.click(systemTab[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Versions')).toBeInTheDocument();
+			});
+			// Default mock has 3 versions: arm, transcoder, ui
+			const grid = screen.getByText('Versions').parentElement?.querySelector('div.grid');
+			expect(grid?.className).toContain('md:grid-cols-3');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Versions card was hardcoded to `md:grid-cols-5` but only ever has 3-4 entries (arm/transcoder/ui, plus makemkv when configured), leaving an empty column on the right. Switch to a dynamic class derived from `Object.keys(systemInfo.versions).length` so each card takes full row width.

| Entries | Class | Width per card |
|---------|-------|----------------|
| 4 | `md:grid-cols-4` | 25% — typical RC/release (arm + makemkv + transcoder + ui) |
| 3 | `md:grid-cols-3` | 33% — transcoder disabled |
| 2 | `md:grid-cols-2` | 50% |
| other | `md:grid-cols-5` | fallback |

Mobile stays at `grid-cols-2` (unchanged).

## Test plan

- [x] `npx vitest run src/routes/settings/__tests__/settings-page.test.ts` — 19/19 (was 17/17, +2 new tests)
- [x] `npx svelte-check` — 0 errors
- [ ] Verify in browser: Settings -> System -> Versions card fills full row width on desktop