### PR TITLE
fix(dashboard): stop notification badge flicker on auto-refresh

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -299,12 +299,15 @@ class SystemStatsSchema(BaseModel):
 class DashboardResponse(BaseModel):
     db_available: bool = True
     arm_online: bool = False
-    active_jobs: list[JobSchema] = []
+    # Per-field optionality: None signals "this ARM endpoint blipped on
+    # this poll, frontend should keep its prior value" rather than
+    # overwriting with zero/empty and flickering badges to nothing.
+    active_jobs: list[JobSchema] | None = None
     system_info: HardwareInfoSchema | None = None
-    drives_online: int = 0
-    drive_names: dict[str, str] = {}
-    notification_count: int = 0
-    ripping_enabled: bool = True
+    drives_online: int | None = None
+    drive_names: dict[str, str] | None = None
+    notification_count: int | None = None
+    ripping_enabled: bool | None = None
     makemkv_key_valid: bool | None = None
     makemkv_key_checked_at: str | None = None
     transcoder_online: bool = False

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -29,13 +29,15 @@ async def _fetch_transcoder() -> tuple[bool, dict | None, list]:
     return True, stats, active
 
 
-async def _fetch_arm_state() -> tuple[bool, list, int, dict[str, str], int, bool]:
+async def _fetch_arm_state() -> tuple[bool, list | None, int | None, dict[str, str] | None, int | None, bool | None]:
     """Fetch all ARM-derived dashboard state via the ripper REST API.
 
     Returns (db_available, active_jobs, drives_online, drive_names,
     notification_count, ripping_paused). All four endpoints are issued
-    concurrently. db_available is True iff every call succeeded; any
-    None response degrades the dashboard to its empty-state values.
+    concurrently. db_available is True iff at least one call succeeded;
+    each derived field is None when its specific endpoint failed, so the
+    BFF response can carry None and the polling store keeps the prior
+    value instead of overwriting with zero on a transient blip.
     """
     active_data, drives_data, notif_count_data, ripping_data = await asyncio.gather(
         arm_client.get_active_jobs(),
@@ -44,24 +46,27 @@ async def _fetch_arm_state() -> tuple[bool, list, int, dict[str, str], int, bool
         arm_client.get_ripping_enabled(),
     )
 
-    db_available = all(d is not None for d in (active_data, drives_data, notif_count_data, ripping_data))
-    if not db_available:
-        return False, [], 0, {}, 0, False
+    db_available = any(d is not None for d in (active_data, drives_data, notif_count_data, ripping_data))
 
-    active_jobs = active_data.get("jobs") or []
-    drives = drives_data.get("drives") or []
-    drives_online = sum(1 for d in drives if not d.get("stale", False))
-    # Normalize mount paths - drives store /mnt/dev/sr0, jobs store /dev/sr0
-    drive_names: dict[str, str] = {}
-    for d in drives:
-        mount, name = d.get("mount"), d.get("name")
-        if mount and name:
-            drive_names[mount] = name
-            basename = mount.rsplit("/", 1)[-1]
-            drive_names[f"/dev/{basename}"] = name
-    notification_count = notif_count_data.get("unseen", 0)
-    ripping_paused = not ripping_data.get("ripping_enabled", True)
-    return True, active_jobs, drives_online, drive_names, notification_count, ripping_paused
+    active_jobs = (active_data.get("jobs") or []) if active_data is not None else None
+
+    drives_online: int | None = None
+    drive_names: dict[str, str] | None = None
+    if drives_data is not None:
+        drives = drives_data.get("drives") or []
+        drives_online = sum(1 for d in drives if not d.get("stale", False))
+        # Normalize mount paths - drives store /mnt/dev/sr0, jobs store /dev/sr0
+        drive_names = {}
+        for d in drives:
+            mount, name = d.get("mount"), d.get("name")
+            if mount and name:
+                drive_names[mount] = name
+                basename = mount.rsplit("/", 1)[-1]
+                drive_names[f"/dev/{basename}"] = name
+
+    notification_count = notif_count_data.get("unseen", 0) if notif_count_data is not None else None
+    ripping_paused = (not ripping_data.get("ripping_enabled", True)) if ripping_data is not None else None
+    return db_available, active_jobs, drives_online, drive_names, notification_count, ripping_paused
 
 
 async def _fetch_transcoder_system_stats() -> SystemStatsSchema | None:
@@ -105,12 +110,12 @@ async def get_dashboard():
     return DashboardResponse(
         db_available=db_available,
         arm_online=arm_online,
-        active_jobs=[JobSchema(**j) for j in active_jobs],
+        active_jobs=[JobSchema(**j) for j in active_jobs] if active_jobs is not None else None,
         system_info=HardwareInfoSchema(**arm_hw) if arm_hw else None,
         drives_online=drives_online,
         drive_names=drive_names,
         notification_count=notification_count,
-        ripping_enabled=not ripping_paused,
+        ripping_enabled=(not ripping_paused) if ripping_paused is not None else None,
         makemkv_key_valid=makemkv_key_valid,
         makemkv_key_checked_at=makemkv_key_checked_at,
         transcoder_online=transcoder_online,

--- a/frontend/src/lib/stores/__tests__/dashboard.test.ts
+++ b/frontend/src/lib/stores/__tests__/dashboard.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+// Mock fetchDashboard before the store imports it. We control its return
+// value per-test to drive the sticky-merge behavior.
+const fetchDashboardMock = vi.fn();
+vi.mock('$lib/api/dashboard', () => ({
+	fetchDashboard: fetchDashboardMock
+}));
+
+describe('dashboard store sticky merge', () => {
+	beforeEach(() => {
+		fetchDashboardMock.mockReset();
+		// Re-import the store fresh each test so the lastGood module-level
+		// cache resets. vitest resets module cache via vi.resetModules.
+		vi.resetModules();
+	});
+
+	function fullPayload(overrides: Record<string, unknown> = {}) {
+		return {
+			db_available: true,
+			arm_online: true,
+			active_jobs: [{ id: 1 } as unknown],
+			system_info: null,
+			drives_online: 2,
+			drive_names: { '/dev/sr0': 'Drive 1' },
+			notification_count: 7,
+			ripping_enabled: true,
+			makemkv_key_valid: null,
+			makemkv_key_checked_at: null,
+			transcoder_online: false,
+			transcoder_stats: null,
+			transcoder_system_stats: null,
+			active_transcodes: [],
+			system_stats: null,
+			transcoder_info: null,
+			...overrides
+		};
+	}
+
+	it('keeps prior notification_count when BFF sends null on next poll', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ notification_count: 7 }))
+			.mockResolvedValueOnce(fullPayload({ notification_count: null }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		expect(get(dashboard).notification_count).toBe(7);
+		await dashboard.refresh();
+		// Sticky: still 7, not 0, even though BFF sent null.
+		expect(get(dashboard).notification_count).toBe(7);
+	});
+
+	it('keeps prior drives_online + drive_names when BFF sends null', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ drives_online: 3, drive_names: { '/dev/sr0': 'A' } }))
+			.mockResolvedValueOnce(fullPayload({ drives_online: null, drive_names: null }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		await dashboard.refresh();
+		expect(get(dashboard).drives_online).toBe(3);
+		expect(get(dashboard).drive_names).toEqual({ '/dev/sr0': 'A' });
+	});
+
+	it('uses fresh value when BFF sends a non-null value', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ notification_count: 7 }))
+			.mockResolvedValueOnce(fullPayload({ notification_count: 12 }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		await dashboard.refresh();
+		expect(get(dashboard).notification_count).toBe(12);
+	});
+
+	it('uses fresh zero when BFF sends 0 (not null) - 0 is a real count', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ notification_count: 7 }))
+			.mockResolvedValueOnce(fullPayload({ notification_count: 0 }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		await dashboard.refresh();
+		// 0 is a real value (user cleared all notifications), not a sentinel.
+		expect(get(dashboard).notification_count).toBe(0);
+	});
+
+	it('does not stick non-sticky fields like transcoder_online', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ transcoder_online: true }))
+			.mockResolvedValueOnce(fullPayload({ transcoder_online: false }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		await dashboard.refresh();
+		expect(get(dashboard).transcoder_online).toBe(false);
+	});
+});

--- a/frontend/src/lib/stores/dashboard.ts
+++ b/frontend/src/lib/stores/dashboard.ts
@@ -21,5 +21,30 @@ const emptyDashboard: DashboardData = {
 	transcoder_info: null
 };
 
+// Fields the BFF marks `null` when their underlying ARM endpoint blipped on
+// this poll. We hold the previous value for these so a transient timeout
+// doesn't flicker badges/counts to zero.
+const STICKY_FIELDS = [
+	'active_jobs',
+	'drives_online',
+	'drive_names',
+	'notification_count',
+	'ripping_enabled'
+] as const satisfies readonly (keyof DashboardData)[];
+
+let lastGood: DashboardData = emptyDashboard;
+
+async function fetchDashboardSticky(): Promise<DashboardData> {
+	const fresh = (await fetchDashboard()) as DashboardData & Partial<Record<(typeof STICKY_FIELDS)[number], unknown>>;
+	const merged = { ...fresh } as DashboardData;
+	for (const key of STICKY_FIELDS) {
+		if (fresh[key] === null || fresh[key] === undefined) {
+			(merged[key] as unknown) = lastGood[key];
+		}
+	}
+	lastGood = merged;
+	return merged;
+}
+
 /** Singleton dashboard store — survives page navigations, retains last-known data. */
-export const dashboard = createPollingStore(fetchDashboard, emptyDashboard, 5000);
+export const dashboard = createPollingStore(fetchDashboardSticky, emptyDashboard, 5000);

--- a/tests/routers/test_dashboard.py
+++ b/tests/routers/test_dashboard.py
@@ -95,7 +95,13 @@ async def test_dashboard_full(app_client):
 
 
 async def test_dashboard_db_unavailable(app_client):
-    """Dashboard degrades gracefully when the ripper API is unreachable."""
+    """Dashboard degrades gracefully when ALL ripper endpoints fail.
+
+    db_available flips False; sticky fields (active_jobs, drives_online,
+    drive_names, notification_count, ripping_enabled) come back as None
+    so the polling store keeps the prior value rather than overwriting
+    with zero/empty (which flickered badges/counts to nothing).
+    """
     with (
         patch("backend.routers.dashboard.arm_client.get_active_jobs",
               new_callable=AsyncMock, return_value=None),
@@ -116,11 +122,48 @@ async def test_dashboard_db_unavailable(app_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["db_available"] is False
-    assert data["active_jobs"] == []
-    assert data["drives_online"] == 0
-    assert data["notification_count"] == 0
+    assert data["active_jobs"] is None
+    assert data["drives_online"] is None
+    assert data["drive_names"] is None
+    assert data["notification_count"] is None
+    assert data["ripping_enabled"] is None
     assert data["transcoder_online"] is False
     assert data["system_stats"] is None
+
+
+async def test_dashboard_partial_arm_failure_keeps_other_fields(app_client):
+    """When SOME ripper endpoints blip, only those specific fields come back
+    None. Independent endpoints keep their fresh values, so notification
+    count doesn't flicker to zero just because the drives endpoint timed out.
+    """
+    with (
+        patch("backend.routers.dashboard.arm_client.get_active_jobs",
+              new_callable=AsyncMock, return_value={"jobs": []}),
+        patch("backend.routers.dashboard.arm_client.get_drives",
+              new_callable=AsyncMock, return_value=None),  # this one blips
+        patch("backend.routers.dashboard.arm_client.get_notification_count",
+              new_callable=AsyncMock, return_value={"unseen": 7}),
+        patch("backend.routers.dashboard.arm_client.get_ripping_enabled",
+              new_callable=AsyncMock, return_value={"ripping_enabled": True}),
+        patch("backend.routers.dashboard.transcoder_client.health",
+              new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.dashboard.arm_client.get_system_stats",
+              new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.dashboard.system_cache.get_arm_info", return_value=None),
+        patch("backend.routers.dashboard.system_cache.get_transcoder_info", return_value=None),
+    ):
+        resp = await app_client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    # ARM partially up: db_available is True (at least one endpoint succeeded).
+    assert data["db_available"] is True
+    # The succeeding endpoints carry their fresh values through.
+    assert data["active_jobs"] == []
+    assert data["notification_count"] == 7
+    assert data["ripping_enabled"] is True
+    # Only the blipped endpoint's fields are None (frontend sticky-merges).
+    assert data["drives_online"] is None
+    assert data["drive_names"] is None
 
 
 async def test_dashboard_transcoder_offline(app_client):


### PR DESCRIPTION
## Summary

Notification badge (and other ARM-derived counts: drives_online, active_jobs, ripping_enabled) flickered to zero on auto-refresh whenever any one of the four upstream ripper endpoints had a transient timeout.

**Root cause:** \`backend/routers/dashboard.py:_fetch_arm_state()\` used all-or-nothing degradation. If ANY of the four endpoints returned None, the BFF zeroed every ARM-derived field. The polling store then overwrote its prior values with those zeros - badge gone for one tick, back next poll.

## Fix

**Two halves:**

1. **BFF** (\`backend/routers/dashboard.py\` + \`schemas.py\`): degrade per-field. Each derived field is None when its specific endpoint failed, non-None otherwise. \`db_available\` now means 'at least one ARM endpoint succeeded' (true outage), not 'every endpoint succeeded'. \`DashboardResponse\` marks the affected fields as Optional, with None signaling 'use prior value'.

2. **Frontend** (\`frontend/src/lib/stores/dashboard.ts\`): wrap \`fetchDashboard\` with a sticky-merge that fills any null/undefined sticky field from the previous poll before publishing. The \`DashboardData\` type that consumers see stays non-nullable, so no layout / page changes are needed and \`?.\` guards aren't sprayed through the codebase. \`0\` is treated as a real value (user cleared notifications), only \`null\`/\`undefined\` trigger the merge.

**Sticky fields:** \`active_jobs\`, \`drives_online\`, \`drive_names\`, \`notification_count\`, \`ripping_enabled\`.

## Test plan

- [x] \`pytest tests/routers/test_dashboard.py\` - 10/10 (was 9, +1 new partial-failure test)
- [x] \`vitest run\` (full frontend) - 869/869 (was 864, +5 new sticky-merge tests)
- [x] \`svelte-check\` - 0 errors
- [ ] Verify in deployed RC: notification badge stays at 7 across multiple poll cycles, even if one ARM endpoint blips