### PR TITLE
feat(phase): surface transcoder sub-status on job detail page

### DIFF
--- a/backend/routers/transcoder.py
+++ b/backend/routers/transcoder.py
@@ -146,6 +146,7 @@ async def get_transcoder_job_for_arm(arm_job_id: int) -> dict[str, Any]:
         "logfile": job.get("logfile"),
         "transcoder_job_id": job.get("id"),
         "status": job.get("status"),
+        "phase": job.get("phase"),
         "progress": job.get("progress"),
         "current_fps": job.get("current_fps"),
     }

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -72,6 +72,10 @@ export async function fetchTranscoderLogForArmJob(
 	logfile?: string;
 	transcoder_job_id?: number;
 	status?: string;
+	/** Sub-status inside JobStatus.processing — surfaces what the worker is doing
+	 * during periods where no encoder progress is being reported. Wire values
+	 * come from arm_contracts.TranscodePhase. */
+	phase?: string | null;
 	progress?: number | null;
 	current_fps?: number | null;
 }> {

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -40,6 +40,7 @@
 	let transcoderProgress = $state<number | null>(null);
 	let transcoderFps = $state<number | null>(null);
 	let transcoderJobStatus = $state<string | null>(null);
+	let transcoderPhase = $state<string | null>(null);
 	let ripProgress = $state<RipProgress | null>(null);
 
 	let isFolderImport = $derived(job?.source_type === 'folder');
@@ -277,17 +278,20 @@
 						transcoderProgress = info.progress ?? null;
 						transcoderFps = info.current_fps ?? null;
 						transcoderJobStatus = info.status ?? null;
+						transcoderPhase = info.phase ?? null;
 					} else {
 						transcoderLogfile = null;
 						transcoderProgress = null;
 						transcoderFps = null;
 						transcoderJobStatus = null;
+						transcoderPhase = null;
 					}
 				}).catch(() => {
 					transcoderLogfile = null;
 					transcoderProgress = null;
 					transcoderFps = null;
 					transcoderJobStatus = null;
+					transcoderPhase = null;
 				});
 			}
 		} catch (e) {
@@ -341,14 +345,17 @@
 					transcoderProgress = info.progress ?? null;
 					transcoderFps = info.current_fps ?? null;
 					transcoderJobStatus = info.status ?? null;
+					transcoderPhase = info.phase ?? null;
 				} else {
 					transcoderProgress = null;
 					transcoderFps = null;
 					transcoderJobStatus = null;
+					transcoderPhase = null;
 				}
 			} catch {
 				transcoderProgress = null;
 				transcoderFps = null;
+				transcoderPhase = null;
 			}
 		}
 	}
@@ -594,15 +601,31 @@
 		{:else if job.status === 'transcoding'}
 			<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 				<div class="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
-					<span>Transcoding</span>
-					{#if transcoderJobStatus}
+					<span>
+						{#if transcoderPhase === 'copying_source'}
+							Copying source files
+						{:else if transcoderPhase === 'finalizing'}
+							Finalizing
+						{:else}
+							Transcoding
+						{/if}
+					</span>
+					{#if transcoderPhase === 'copying_source'}
+						<span class="text-xs text-gray-500 dark:text-gray-400">Moving source files to local scratch.</span>
+					{:else if transcoderPhase === 'finalizing'}
+						<span class="text-xs text-gray-500 dark:text-gray-400">Moving output to completed and running cleanup.</span>
+					{:else if transcoderJobStatus}
 						<span class="text-xs text-gray-500 dark:text-gray-400">({transcoderJobStatus})</span>
 					{/if}
-					{#if typeof transcoderFps === 'number' && transcoderFps > 0}
+					{#if transcoderPhase === 'encoding' && typeof transcoderFps === 'number' && transcoderFps > 0}
 						<span class="ml-auto font-mono text-xs text-gray-500 dark:text-gray-400" title="Encoder frames per second">{transcoderFps.toFixed(1)} fps</span>
 					{/if}
 				</div>
-				{#if transcoderProgress != null}
+				{#if transcoderPhase === 'copying_source' || transcoderPhase === 'finalizing'}
+					<div class="h-2.5 overflow-hidden rounded-full bg-primary/15">
+						<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
+					</div>
+				{:else if transcoderProgress != null}
 					<ProgressBar value={transcoderProgress} color="bg-primary" />
 				{:else}
 					<div class="h-2.5 overflow-hidden rounded-full bg-primary/15">

--- a/tests/routers/test_transcoder.py
+++ b/tests/routers/test_transcoder.py
@@ -336,6 +336,38 @@ async def test_get_job_for_arm_passes_progress_field(app_client):
     assert result["status"] == "processing"
 
 
+async def test_get_job_for_arm_passes_phase_field(app_client):
+    """phase field is surfaced so the detail page can show 'Copying source files'
+    or 'Finalizing' instead of an empty 0% bar / stale 97% during periods where
+    no encoder progress is being reported."""
+    data = {"jobs": [{
+        "id": 10, "logfile": "job_10.log", "status": "processing",
+        "progress": 0.0, "phase": "copying_source",
+    }]}
+    with patch(
+        "backend.routers.transcoder.transcoder_client.get_jobs",
+        new_callable=AsyncMock,
+        return_value=data,
+    ):
+        resp = await app_client.get("/api/transcoder/job-for-arm/42")
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["phase"] == "copying_source"
+
+
+async def test_get_job_for_arm_phase_none_when_missing(app_client):
+    """Older transcoder builds without phase column return None (forwards-compat)."""
+    data = {"jobs": [{"id": 10, "logfile": "job_10.log", "status": "completed", "progress": 100.0}]}
+    with patch(
+        "backend.routers.transcoder.transcoder_client.get_jobs",
+        new_callable=AsyncMock,
+        return_value=data,
+    ):
+        resp = await app_client.get("/api/transcoder/job-for-arm/42")
+    assert resp.status_code == 200
+    assert resp.json()["phase"] is None
+
+
 async def test_get_job_for_arm_not_found(app_client):
     """GET job-for-arm returns found=False when no matching jobs."""
     with patch(


### PR DESCRIPTION
## Summary

- Plumbs the new \`phase\` field from the transcoder \`/jobs\` endpoint through the BFF (\`/api/transcoder/job-for-arm/{id}\`) and into the job detail page transcoding widget.
- When \`phase=copying_source\`: shows "Copying source files" with indeterminate slider (instead of empty 0% bar during source copy).
- When \`phase=finalizing\`: shows "Finalizing" with indeterminate slider (instead of stale 97% / stale fps during file move / cleanup).
- When \`phase=encoding\` or missing (older transcoder builds): falls back to existing progress + fps rendering.
- Bumps \`components/contracts\` submodule to \`230a4a8\` for the \`TranscodePhase\` enum.

## Test Plan

- [x] BFF: \`pytest tests/routers/test_transcoder.py\` (2 new phase tests + 34 existing pass)
- [x] BFF full: \`pytest tests/\` (640 passed)
- [x] Frontend type-check: \`npm run check\` (no new warnings)
- [x] Frontend tests: \`npm test -- --run\` (872 passed)
- [ ] Cut RC, deploy to hifi-server, observe a folder rip - phases should transition copying_source -> encoding -> finalizing without empty / stale bars