### PR TITLE
chore(deps): drop unused pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ httpx>=0.27,<1
 pydantic>=2.0,<3
 pydantic-settings>=2.0,<3
 python-multipart>=0.0.26,<1
-pyyaml>=6.0,<7
 -e components/contracts


### PR DESCRIPTION
## Summary

- The arm-ui backend has zero \`import yaml\` after the bind-mount decoupling work retired the YAML reads (per the v17.0+ work that decoupled arm-ui from the ripper filesystem).
- Dropping the explicit pin keeps the dep tree honest.
- Supersedes dependabot PR #258 (which would have bumped the dead dep).

## Test Plan

- [x] \`pytest tests/\` (640 passed)
- [ ] Image build is unaffected (no Dockerfile changes; pip resolves the rest cleanly)