### PR TITLE
fix(jobs): purge redirects on detail page; bulk-purge pages under per_page cap

### DIFF
--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -163,8 +163,10 @@ async def _resolve_job_ids(req: BulkJobRequest) -> list[int]:
         if not data:
             return ids
         if data.get("success") is False:
+            safe_status = str(req.status).replace("\n", "").replace("\r", "")
+            safe_err = str(data.get("error")).replace("\n", "").replace("\r", "")
             log.warning("ARM rejected paginated lookup for status=%s: %s",
-                        req.status, data.get("error"))
+                        safe_status, safe_err)
             return ids
         page_jobs = data.get("jobs") or []
         ids.extend(j["job_id"] for j in page_jobs if "job_id" in j)

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -142,17 +142,35 @@ async def bulk_purge_jobs(req: BulkJobRequest):
 
 
 async def _resolve_job_ids(req: BulkJobRequest) -> list[int]:
-    """Resolve a bulk request to a list of job IDs (explicit IDs or by-status query)."""
+    """Resolve a bulk request to a list of job IDs (explicit IDs or by-status query).
+
+    Pages through ARM at the per_page=100 cap (Query(le=100) on /jobs/paginated)
+    so a `Purge All Failed` on a deployment with hundreds of failed jobs still
+    catches everything, instead of getting 422'd into a silent zero.
+    """
     if req.job_ids:
         return req.job_ids
-    if req.status:
+    if not req.status:
+        return []
+
+    page_size = 100
+    ids: list[int] = []
+    page = 1
+    while True:
         data = await arm_client.get_jobs_paginated(
-            page=1, per_page=10000, status=req.status,
+            page=page, per_page=page_size, status=req.status,
         )
         if not data:
-            return []
-        return [j["job_id"] for j in (data.get("jobs") or []) if "job_id" in j]
-    return []
+            return ids
+        if data.get("success") is False:
+            log.warning("ARM rejected paginated lookup for status=%s: %s",
+                        req.status, data.get("error"))
+            return ids
+        page_jobs = data.get("jobs") or []
+        ids.extend(j["job_id"] for j in page_jobs if "job_id" in j)
+        if len(page_jobs) < page_size or page >= (data.get("pages") or page):
+            return ids
+        page += 1
 
 
 @router.get("/jobs/{job_id}", response_model=JobDetailSchema, responses=_404_JOB)

--- a/frontend/src/lib/components/JobActions.svelte
+++ b/frontend/src/lib/components/JobActions.svelte
@@ -84,6 +84,10 @@
 		feedback = null;
 		try {
 			await bulkPurgeJobs({ job_ids: [job.job_id] });
+			if (ondelete) {
+				ondelete();
+				return;
+			}
 			feedback = { type: 'success', message: 'Job purged' };
 			onaction?.();
 		} catch (e) {

--- a/frontend/src/lib/components/JobActions.test.ts
+++ b/frontend/src/lib/components/JobActions.test.ts
@@ -7,13 +7,15 @@ import { createJob } from './__fixtures__/job';
 vi.mock('$lib/api/jobs', () => ({
 	abandonJob: vi.fn(() => Promise.resolve()),
 	deleteJob: vi.fn(() => Promise.resolve()),
-	fixJobPermissions: vi.fn(() => Promise.resolve())
+	fixJobPermissions: vi.fn(() => Promise.resolve()),
+	bulkPurgeJobs: vi.fn(() => Promise.resolve({ purged: 1, errors: [] }))
 }));
 
-import { abandonJob, deleteJob, fixJobPermissions } from '$lib/api/jobs';
+import { abandonJob, deleteJob, fixJobPermissions, bulkPurgeJobs } from '$lib/api/jobs';
 const mockAbandon = vi.mocked(abandonJob);
 const mockDelete = vi.mocked(deleteJob);
 const mockFixPerms = vi.mocked(fixJobPermissions);
+const mockPurge = vi.mocked(bulkPurgeJobs);
 
 // Mock window.confirm
 vi.stubGlobal('confirm', vi.fn(() => true));
@@ -160,6 +162,23 @@ describe('JobActions', () => {
 			});
 			await fireEvent.click(screen.getByText('Delete'));
 			await waitFor(() => {
+				expect(ondelete).toHaveBeenCalled();
+				expect(onaction).not.toHaveBeenCalled();
+			});
+		});
+
+		it('calls ondelete after purge so detail page redirects (job is gone)', async () => {
+			// Bug guard: Purge wipes the job record, so the detail page must
+			// navigate away via ondelete just like Delete does. Without this
+			// the user sees a stale detail page that 404s on next refresh.
+			const ondelete = vi.fn();
+			const onaction = vi.fn();
+			renderComponent(JobActions, {
+				props: { job: createJob({ status: 'fail' }), ondelete, onaction }
+			});
+			await fireEvent.click(screen.getByText('Purge'));
+			await waitFor(() => {
+				expect(mockPurge).toHaveBeenCalledWith({ job_ids: [1] });
 				expect(ondelete).toHaveBeenCalled();
 				expect(onaction).not.toHaveBeenCalled();
 			});

--- a/tests/routers/test_jobs_bulk.py
+++ b/tests/routers/test_jobs_bulk.py
@@ -106,3 +106,33 @@ async def test_bulk_delete_by_status_handles_arm_error(app_client):
     assert resp.json()["deleted"] == 0
     assert paginated_mock.call_count == 1  # one attempt, no retry loop
     assert mock_del.call_count == 0
+
+
+async def test_bulk_delete_strips_crlf_from_logged_user_input(app_client, caplog):
+    """User-controlled status + ARM error string must be CRLF-stripped before
+    logging. Sonar python:S5145 (log injection): a malicious status containing
+    \\n could otherwise forge fake log lines."""
+    import logging
+    error_dict = {"success": False, "error": "boom\nFAKE LOG LINE\rmore"}
+    paginated_mock = AsyncMock(return_value=error_dict)
+    with patch(
+        "backend.routers.jobs.arm_client.get_jobs_paginated", paginated_mock,
+    ), patch("backend.routers.jobs.arm_client.delete_job", AsyncMock()), \
+         caplog.at_level(logging.WARNING, logger="backend.routers.jobs"):
+        resp = await app_client.post(
+            "/api/jobs/bulk-delete",
+            json={"status": "fail\ninjected"},
+        )
+    assert resp.status_code == 200
+    msgs = [r.getMessage() for r in caplog.records]
+    assert msgs, "expected warning to be emitted"
+    combined = "\n".join(msgs)
+    # The warning text itself uses \n as a record separator between log
+    # records; the assertion is that no individual record contains an
+    # embedded \n or \r from the user-controlled fields.
+    for record in caplog.records:
+        assert "\n" not in record.getMessage()
+        assert "\r" not in record.getMessage()
+    # And the sanitized values still appear, just without the CRLF.
+    assert "failinjected" in combined
+    assert "boomFAKE LOG LINEmore" in combined

--- a/tests/routers/test_jobs_bulk.py
+++ b/tests/routers/test_jobs_bulk.py
@@ -22,7 +22,7 @@ async def test_bulk_delete_empty_ids(app_client):
 async def test_bulk_delete_by_status(app_client):
     paginated = {
         "jobs": [make_job_dict(job_id=i, status="fail") for i in range(1, 4)],
-        "total": 3, "page": 1, "per_page": 10000, "pages": 1,
+        "total": 3, "page": 1, "per_page": 100, "pages": 1,
     }
     mock_del = AsyncMock(return_value={"success": True})
     with patch(
@@ -58,3 +58,51 @@ async def test_bulk_purge_empty_ids(app_client):
     resp = await app_client.post("/api/jobs/bulk-purge", json={"job_ids": []})
     assert resp.status_code == 200
     assert resp.json()["purged"] == 0
+
+
+async def test_bulk_delete_by_status_pages_under_per_page_cap(app_client):
+    """ARM caps /jobs/paginated at per_page=100. The BFF must page through
+    rather than ask for per_page=10000 (which 422s into a silent zero).
+
+    Reproduces the 'Purge All Failed shows 0 purged' bug: 150 failed jobs
+    spread across two ARM pages, BFF must catch all of them.
+    """
+    page_one = {
+        "jobs": [make_job_dict(job_id=i, status="fail") for i in range(1, 101)],
+        "total": 150, "page": 1, "per_page": 100, "pages": 2,
+    }
+    page_two = {
+        "jobs": [make_job_dict(job_id=i, status="fail") for i in range(101, 151)],
+        "total": 150, "page": 2, "per_page": 100, "pages": 2,
+    }
+    paginated_mock = AsyncMock(side_effect=[page_one, page_two])
+    mock_del = AsyncMock(return_value={"success": True})
+    with patch(
+        "backend.routers.jobs.arm_client.get_jobs_paginated",
+        paginated_mock,
+    ), patch("backend.routers.jobs.arm_client.delete_job", mock_del):
+        resp = await app_client.post("/api/jobs/bulk-delete", json={"status": "fail"})
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 150
+    assert paginated_mock.call_count == 2
+    # Must request at-or-under ARM's le=100 cap, not the old per_page=10000
+    for call in paginated_mock.call_args_list:
+        assert call.kwargs["per_page"] <= 100
+
+
+async def test_bulk_delete_by_status_handles_arm_error(app_client):
+    """If ARM returns an error dict (e.g. validation failure), don't loop
+    forever or silently treat it as 'no jobs'; surface zero with a logged
+    warning. Regression guard for the silent-zero bug."""
+    error_dict = {"success": False, "error": "ARM error (422): ..."}
+    paginated_mock = AsyncMock(return_value=error_dict)
+    mock_del = AsyncMock(return_value={"success": True})
+    with patch(
+        "backend.routers.jobs.arm_client.get_jobs_paginated",
+        paginated_mock,
+    ), patch("backend.routers.jobs.arm_client.delete_job", mock_del):
+        resp = await app_client.post("/api/jobs/bulk-delete", json={"status": "fail"})
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 0
+    assert paginated_mock.call_count == 1  # one attempt, no retry loop
+    assert mock_del.call_count == 0


### PR DESCRIPTION
## Summary

Two UI bugs surfaced together when testing bulk-purge on hifi-server.

### Bug 1: Purge on the job detail page doesn't redirect

`JobActions.handleDelete` short-circuits via the `ondelete` prop (which `/jobs/[id]` wires to `goto('/')`); `handlePurge` did not. After purge succeeds the job record is gone, but the user is stuck on a stale detail page that 404s on the next refresh.

Fix: mirror the `handleDelete` flow in `handlePurge`.

### Bug 2: "Purge All Failed" silently returns 0 purged

The BFF resolver asked ARM for `status='fail'` with `per_page=10000`, but `arm-neu`'s `/api/v1/jobs/paginated` declares `per_page: Annotated[int, Query(ge=1, le=100)]` and rejects with HTTP 422. The error dict was truthy-but-jobless, so `_resolve_job_ids` silently returned `[]` and the user saw "Purged 0 job(s)" no matter how many failed jobs existed.

Fix: page through at the 100-cap, log a warning if ARM rejects the lookup, stop on the last partial page or the response's reported `pages`.

## Why the tests didn't catch this

`test_bulk_delete_by_status` mocked an out-of-spec response (`per_page=10000` echoed back as if ARM had honoured it). The mock contradicted the real API contract, so the BFF's bug was invisible.

## Test plan

- [x] Backend: 7 tests pass in `tests/routers/test_jobs_bulk.py` (2 new: pagination at 100-cap with 150 jobs across 2 pages; ARM-error-dict short-circuits without a retry loop)
- [x] Frontend: 18 tests pass in `JobActions.test.ts` (1 new: purge fires `ondelete` when wired)
- [x] Full BFF suite: 642 passed
- [x] Full frontend suite: 873 passed
- [ ] Smoke on hifi-server after merge: purge on detail page redirects to home; "Purge All Failed" actually purges