### PR TITLE
feat(disc-review): render filter state from backend skip_reason

### DIFF
--- a/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -74,17 +74,29 @@
 		}
 	}
 
-	// MakeMKV's minlength threshold - tracks shorter than this are silently
-	// skipped during ripping regardless of checkbox state.
+	// MakeMKV's minlength threshold - retained for tooltip text. The actual
+	// filter decision is made by the backend (track.process / skip_reason).
 	let minlength = $derived(Number(detail?.config?.MINLENGTH) || 120);
+	let maxlength = $derived(Number(detail?.config?.MAXLENGTH) || 99999);
 
-	function isBelowMinlength(track: { length: number | null }): boolean {
-		return track.length != null && track.length < minlength;
+	function isFiltered(track: { process?: boolean }): boolean {
+		return track.process === false;
 	}
 
-	// "All enabled" only considers tracks that are long enough to be ripped
+	function skipTooltip(track: { skip_reason?: string | null }): string {
+		switch (track.skip_reason) {
+			case 'too_short':       return `Skipped: shorter than minimum length (${minlength}s)`;
+			case 'too_long':        return `Skipped: longer than maximum length (${maxlength}s)`;
+			case 'makemkv_skipped': return `Skipped by MakeMKV (likely below ${minlength}s)`;
+			case 'user_disabled':   return 'Skipped: deselected';
+			case 'below_main_feature': return 'Skipped: below the main feature';
+			default:                return 'Skipped';
+		}
+	}
+
+	// "All enabled" only considers tracks the backend will actually rip
 	let rippableTracks = $derived(
-		detail?.tracks?.filter((t) => !isBelowMinlength(t)) ?? []
+		detail?.tracks?.filter((t) => !isFiltered(t)) ?? []
 	);
 	let allEnabled = $derived(
 		!!rippableTracks.length && rippableTracks.every((t) => t.enabled)
@@ -809,8 +821,8 @@
 									</thead>
 									<tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
 										{#each detail.tracks as track}
-											{@const tooShort = !isMusic && isBelowMinlength(track)}
-											<tr class="{tooShort ? 'opacity-40' : track.enabled && !isMusic ? 'bg-primary-light-bg/50 dark:bg-primary-light-bg-dark/10' : ''}">
+											{@const filtered = !isMusic && isFiltered(track)}
+											<tr class="{filtered ? 'opacity-40' : track.enabled && !isMusic ? 'bg-primary-light-bg/50 dark:bg-primary-light-bg-dark/10' : ''}">
 												<td class="px-3 py-1.5 font-mono text-gray-700 dark:text-gray-300">{track.track_number ?? '--'}</td>
 												{#if isMusic}
 													<td class="px-3 py-1.5 text-gray-700 dark:text-gray-300">{track.title || track.filename || '--'}</td>
@@ -841,7 +853,7 @@
 															value={track.episode_number ?? ''}
 															onchange={(e) => handleTrackFieldUpdate(track.track_id, 'episode_number', e.currentTarget.value.trim())}
 															placeholder="--"
-															disabled={tooShort || !track.enabled}
+															disabled={filtered || !track.enabled}
 															class="w-10 rounded-sm border border-primary/25 bg-primary/5 px-1 py-0.5 text-center text-xs text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary disabled:opacity-30 dark:border-primary/30 dark:bg-primary/10 dark:text-white"
 														/>
 													</td>
@@ -851,8 +863,8 @@
 													<td class="px-3 py-1.5 text-gray-500 dark:text-gray-400">{track.aspect_ratio ?? '--'}</td>
 													<td class="px-3 py-1.5 text-gray-500 dark:text-gray-400">{track.fps ?? '--'}</td>
 													<td class="pl-1 pr-3 py-1.5">
-														{#if tooShort}
-															<span class="ml-3 text-[10px] text-gray-400 dark:text-gray-500" title="Too short to rip (below {minlength}s minimum)">skip</span>
+														{#if filtered}
+															<span class="ml-3 text-[10px] text-gray-400 dark:text-gray-500" title={skipTooltip(track)}>skip</span>
 														{:else}
 															<input
 																type="checkbox"
@@ -903,7 +915,7 @@
 														{/if}
 													</td>
 												{/if}
-												{#if job.multi_title && !isMusic && !tooShort}
+												{#if job.multi_title && !isMusic && !filtered}
 													<td class="px-1 py-1.5">
 														<button
 															onclick={() => toggleTrackSearch(track.track_id)}
@@ -917,7 +929,7 @@
 													</td>
 												{/if}
 											</tr>
-											{#if job.multi_title && !tooShort && openSearchTrackIds.has(track.track_id)}
+											{#if job.multi_title && !filtered && openSearchTrackIds.has(track.track_id)}
 												<tr>
 													<td colspan="99" class="px-3 py-2">
 														<TrackTitleSearch jobId={job.job_id} {track} onapply={() => handleTrackTitleApply(track.track_id)} onclear={() => { onrefresh?.(); loadDetail(); }} onclose={() => toggleTrackSearch(track.track_id)} />

--- a/frontend/src/lib/types/arm.ts
+++ b/frontend/src/lib/types/arm.ts
@@ -27,6 +27,8 @@ export interface Track {
 	episode_name: string | null;
 	// User-specified output filename (overrides pattern rendering)
 	custom_filename: string | null;
+	process?: boolean;
+	skip_reason?: 'too_short' | 'too_long' | 'makemkv_skipped' | 'user_disabled' | 'below_main_feature' | null;
 }
 
 export interface Job {

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -57,13 +57,25 @@
 	let namingPreviews = $state<Record<string, NamingPreviewTrack>>({});
 
 	let minlength = $derived(Number(job?.config?.MINLENGTH) || 120);
+	let maxlength = $derived(Number(job?.config?.MAXLENGTH) || 99999);
 
-	function isBelowMinlength(track: { length: number | null }): boolean {
-		return track.length != null && track.length < minlength;
+	function isFiltered(track: { process?: boolean }): boolean {
+		return track.process === false;
+	}
+
+	function skipTooltip(track: { skip_reason?: string | null }): string {
+		switch (track.skip_reason) {
+			case 'too_short':       return `Skipped: shorter than minimum length (${minlength}s)`;
+			case 'too_long':        return `Skipped: longer than maximum length (${maxlength}s)`;
+			case 'makemkv_skipped': return `Skipped by MakeMKV (likely below ${minlength}s)`;
+			case 'user_disabled':   return 'Skipped: deselected';
+			case 'below_main_feature': return 'Skipped: below the main feature';
+			default:                return 'Skipped';
+		}
 	}
 
 	let rippableTracks = $derived(
-		job?.tracks?.filter((t) => !isBelowMinlength(t)) ?? []
+		job?.tracks?.filter((t) => !isFiltered(t)) ?? []
 	);
 	let allEnabled = $derived(
 		!!rippableTracks.length && rippableTracks.every((t) => t.enabled)
@@ -714,8 +726,8 @@
 						</thead>
 						<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
 							{#each job.tracks as track}
-								{@const tooShort = !isMusicDisc && isBelowMinlength(track)}
-								<tr class="{tooShort ? 'opacity-40' : ''} hover:bg-page dark:hover:bg-gray-800/50">
+								{@const filtered = !isMusicDisc && isFiltered(track)}
+								<tr class="{filtered ? 'opacity-40' : ''} hover:bg-page dark:hover:bg-gray-800/50">
 									<td class="px-4 py-3" data-label="#">{track.track_number ?? ''}</td>
 									{#if isMusicDisc}
 										<td class="max-w-[300px] truncate px-4 py-3" data-label="Name">{track.title || track.filename || '--'}</td>
@@ -797,7 +809,7 @@
 													loadJob();
 												}}
 												placeholder="--"
-												disabled={tooShort || !track.enabled}
+												disabled={filtered || !track.enabled}
 												class="w-12 rounded-sm border border-primary/25 bg-primary/5 px-1.5 py-0.5 text-center text-sm text-gray-900 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary disabled:opacity-30 dark:border-primary/30 dark:bg-primary/10 dark:text-white"
 											/>
 											{#if track.episode_name}
@@ -811,8 +823,8 @@
 										<td class="px-4 py-3" data-label="Aspect">{track.aspect_ratio ?? ''}</td>
 										<td class="px-4 py-3" data-label="FPS">{track.fps ?? ''}</td>
 										<td class="pl-1 pr-4 py-3" data-label="Rip">
-											{#if tooShort}
-												<span class="ml-4 text-[10px] text-gray-400 dark:text-gray-500" title="Too short to rip (below {minlength}s minimum)">skip</span>
+											{#if filtered}
+												<span class="ml-4 text-[10px] text-gray-400 dark:text-gray-500" title={skipTooltip(track)}>skip</span>
 											{:else}
 												<input
 													type="checkbox"
@@ -825,7 +837,7 @@
 										</td>
 									{/if}
 									<td class="px-4 py-3" data-label="Ripped">
-										{#if track.enabled && !tooShort}
+										{#if track.enabled && !filtered}
 											<span class="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold {track.ripped
 												? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
 												: 'bg-gray-100 text-gray-400 dark:bg-gray-700/50 dark:text-gray-500'}"
@@ -834,7 +846,7 @@
 											</span>
 										{/if}
 									</td>
-									<td class="px-4 py-3" data-label="Status"><StatusBadge status={!track.enabled || tooShort ? 'skipped' : track.status} /></td>
+									<td class="px-4 py-3" data-label="Status"><StatusBadge status={!track.enabled || filtered ? 'skipped' : track.status} /></td>
 									</tr>
 								{#if editingTrackId === track.track_id}
 									<tr>


### PR DESCRIPTION
## Summary

Pairs with uprightbass360/automatic-ripping-machine-neu#306. The backend now records WHY a track is filtered (too short, too long, MakeMKV-skipped, user-disabled) and exposes `track.process` + `track.skip_reason` on the wire. This PR makes the frontend disc-review honest about that.

**Before:** the disc-review widget did its own client-side `track.length < MINLENGTH` check. Result: a track filtered for any other reason (too long, MakeMKV-rejected for some other quirk, etc.) still showed an enabled checkbox the user could uselessly tick.

**After:** filter state comes from `track.process === false`. The "skip" pill tooltip is keyed off `skip_reason` so the user sees specifically why each track is excluded:
- "Skipped: shorter than minimum length (Ns)"
- "Skipped: longer than maximum length (Ns)"
- "Skipped by MakeMKV (likely below Ns)"
- "Skipped: deselected"
- "Skipped: below the main feature"

Both the `/jobs/[id]/+page.svelte` route view and the `DiscReviewWidget` component get the same plumbing so they don't drift.

## Contract bump

`components/contracts` submodule moves to the tip of contracts main (carrying the new `Track.process` / `Track.skip_reason` / `ExpectedTitle` shapes from contracts 0.6.0). The pin will become v0.6.0 once the release-please PR there merges.

`backend/models/schemas.py` re-exports `Track as TrackSchema` from `arm_contracts`, so the new fields flow through the BFF automatically; no schema-mirror edits needed.

## Frontend type changes

- `frontend/src/lib/types/arm.ts`: `Track` interface gains optional `process?: boolean` and `skip_reason?: '...' | null`.
- Two Svelte files updated to use `isFiltered(track)` and `skipTooltip(track)` helpers.

## Test plan

- [ ] `pytest tests/` passes (643 tests, no regression)
- [ ] `cd frontend && npm run check` reports 0 type errors
- [ ] `cd frontend && npm test -- --run` passes (873 tests)
- [ ] On a real disc with mixed track lengths, the disc-review widget dims rows backend marks `process=false` and the tooltip text matches the skip_reason
- [ ] Manually deselecting a track shows "Skipped: deselected" tooltip after refresh; re-enabling clears it