### PR TITLE
feat(home): replace Elapsed cell with computed ETA on active cards

### DIFF
--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { formatBytes, statusColor, statusLabel, timeAgo, elapsedTime, formatDateTime } from '../utils/format';
+import { formatBytes, statusColor, statusLabel, timeAgo, elapsedTime, etaTime, formatDateTime } from '../utils/format';
 
 describe('formatBytes', () => {
 	it.each([
@@ -107,6 +107,59 @@ describe('elapsedTime', () => {
 		['2025-06-15T09:45:00Z', '2h 15m']
 	])('elapsedTime(%s) = %s', (input, expected) => {
 		expect(elapsedTime(input)).toBe(expected);
+	});
+});
+
+describe('etaTime', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+	});
+	afterEach(() => vi.useRealTimers());
+
+	it('returns null when start time missing', () => {
+		expect(etaTime(null, 50)).toBeNull();
+	});
+
+	it('returns null when progress is null/undefined', () => {
+		expect(etaTime('2025-06-15T11:59:00Z', null)).toBeNull();
+		expect(etaTime('2025-06-15T11:59:00Z', undefined)).toBeNull();
+	});
+
+	it('returns null when progress is 0 or negative', () => {
+		expect(etaTime('2025-06-15T11:59:00Z', 0)).toBeNull();
+		expect(etaTime('2025-06-15T11:59:00Z', -5)).toBeNull();
+	});
+
+	it('returns null when progress is 100 or over', () => {
+		expect(etaTime('2025-06-15T11:59:00Z', 100)).toBeNull();
+		expect(etaTime('2025-06-15T11:59:00Z', 105)).toBeNull();
+	});
+
+	it('returns null below the 30s elapsed threshold', () => {
+		// 25s elapsed at 10% — formula would give 3m45s, but we suppress
+		// to avoid wild estimates from MakeMKV warm-up jitter.
+		expect(etaTime('2025-06-15T11:59:35Z', 10)).toBeNull();
+	});
+
+	it('formats seconds-only ETA', () => {
+		// 60s elapsed at 80% → 15s remaining
+		expect(etaTime('2025-06-15T11:59:00Z', 80)).toBe('15s');
+	});
+
+	it('formats minutes ETA', () => {
+		// 2m elapsed at 25% → 6m remaining
+		expect(etaTime('2025-06-15T11:58:00Z', 25)).toBe('6m 0s');
+	});
+
+	it('formats hours ETA', () => {
+		// 30m elapsed at 10% → 4h 30m remaining
+		expect(etaTime('2025-06-15T11:30:00Z', 10)).toBe('4h 30m');
+	});
+
+	it('caps absurdly long estimates at 24h+', () => {
+		// 5m elapsed at 0.1% → ~83h. Cap.
+		expect(etaTime('2025-06-15T11:55:00Z', 0.1)).toBe('24h+');
 	});
 });
 

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -2,7 +2,7 @@
 	import type { Job } from '$lib/types/arm';
 	import StatusBadge from './StatusBadge.svelte';
 	import ProgressBar from './ProgressBar.svelte';
-	import { elapsedTime } from '$lib/utils/format';
+	import { elapsedTime, etaTime } from '$lib/utils/format';
 	import { getVideoTypeConfig, isJobActive, discTypeLabel } from '$lib/utils/job-type';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
@@ -231,10 +231,12 @@
 										—
 									{/if}
 								</td>
-								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">Elapsed</td>
+								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">
+									{#if !active && job.job_length}Total{:else}ETA{/if}
+								</td>
 								<td class="py-1 text-gray-900 dark:text-white">
 									{#if active && job.start_time}
-										{elapsedTime(job.start_time)}
+										{etaTime(job.start_time, progress) ?? '—'}
 									{:else if !active && job.job_length}
 										{job.job_length}
 									{:else}

--- a/frontend/src/lib/components/TranscodeCard.svelte
+++ b/frontend/src/lib/components/TranscodeCard.svelte
@@ -2,7 +2,7 @@
 	import type { TranscoderJob } from '$lib/types/transcoder';
 	import StatusBadge from './StatusBadge.svelte';
 	import ProgressBar from './ProgressBar.svelte';
-	import { elapsedTime } from '$lib/utils/format';
+	import { elapsedTime, etaTime } from '$lib/utils/format';
 	import { discTypeLabel } from '$lib/utils/job-type';
 	import PosterImage from './PosterImage.svelte';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
@@ -169,13 +169,13 @@
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Started</td>
 								<td class="py-1 text-gray-900 dark:text-white">{#if job.started_at}<TimeAgo date={job.started_at} />{:else}—{/if}</td>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">
-									{#if job.completed_at}Completed{:else}Elapsed{/if}
+									{#if job.completed_at}Completed{:else}ETA{/if}
 								</td>
 								<td class="py-1 text-gray-900 dark:text-white">
 									{#if job.completed_at}
 										<TimeAgo date={job.completed_at} />
-									{:else if job.started_at}
-										{elapsedTime(job.started_at)}
+									{:else if isActive}
+										{etaTime(job.started_at, job.progress) ?? '—'}
 									{:else}
 										—
 									{/if}
@@ -183,14 +183,12 @@
 							</tr>
 							<tr>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Progress</td>
-								<td class="py-1 text-gray-900 dark:text-white">
+								<td class="py-1 text-gray-900 dark:text-white" colspan="3">
 									{typeof job.progress === 'number' ? `${job.progress}%` : '—'}
 									{#if isActive && typeof job.current_fps === 'number' && job.current_fps > 0}
 										<span class="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400">{job.current_fps.toFixed(1)} fps</span>
 									{/if}
 								</td>
-								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">Created</td>
-								<td class="py-1 text-gray-900 dark:text-white">{#if job.created_at}<TimeAgo date={job.created_at} />{:else}—{/if}</td>
 							</tr>
 						</tbody>
 					</table>

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -42,6 +42,35 @@ export function elapsedTime(startTime: string | null): string {
 }
 
 /**
+ * Estimate time remaining for an in-flight job.
+ * Returns null when an ETA can't be reasonably computed (just started,
+ * already done, no progress signal); the caller renders an em-dash.
+ *
+ * The 30s elapsed threshold smooths the noisy first-percent jitter
+ * that MakeMKV/abcde produce during drive-spin and warm-up.
+ * Capped at 24h+ to avoid printing absurd estimates from sub-1%
+ * progress values that haven't yet stabilised.
+ */
+export function etaTime(
+	startTime: string | null,
+	progressPct: number | null | undefined
+): string | null {
+	if (!startTime || progressPct == null) return null;
+	if (progressPct <= 0 || progressPct >= 100) return null;
+	const start = new Date(startTime);
+	const elapsedSec = (Date.now() - start.getTime()) / 1000;
+	if (elapsedSec < 30) return null;
+	const remainingSec = (elapsedSec * (100 - progressPct)) / progressPct;
+	if (remainingSec >= 24 * 3600) return '24h+';
+	const h = Math.floor(remainingSec / 3600);
+	const m = Math.floor((remainingSec % 3600) / 60);
+	const s = Math.floor(remainingSec % 60);
+	if (h > 0) return `${h}h ${m}m`;
+	if (m > 0) return `${m}m ${s}s`;
+	return `${s}s`;
+}
+
+/**
  * Map a status string to a CSS class. Receives values from three different
  * enums depending on caller:
  *   - arm_contracts.JobState (arm-neu Job.status) - StatusBadge in JobRow,


### PR DESCRIPTION
## Summary

- Home-page active-job cards previously showed elapsed time twice for in-flight jobs — once as a chip on the collapsed row and again as the **Elapsed** cell in the expanded table. The expanded cell adds no information.
- Replaces the Elapsed cell with a computed **ETA** when the job is active. Label flips to **Total** (ARM, uses `job_length`) or **Completed** (transcoder, uses `TimeAgo` of `completed_at`) when finished.
- Drops the **Created** cell from TranscodeCard since `created_at` was typically within seconds of `started_at`, making it visually identical to the **Started** cell.

## Helper behavior

`etaTime(startTime, progressPct)` in `src/lib/utils/format.ts`:
- returns `null` below 30s elapsed (suppresses MakeMKV/abcde warm-up jitter)
- returns `null` at progress = 0 or >= 100
- caps display at `24h+` to avoid absurd estimates from sub-1% progress
- format follows `elapsedTime` conventions (`Xh Ym`, `Xm Ys`, `Xs`)

Works mode-agnostic — the BFF's `/api/jobs/{id}/progress` already distinguishes music vs video and pipes the right percentage through the shared `progress` field, so the helper sees one number either way.

## Test plan

- [x] 9 new unit tests cover the threshold, cap, null/edge cases, and three magnitude tiers (s/m/h)
- [x] Full vitest run: 882/882 passing
- [ ] Reviewer: pull locally, run a real rip + transcode, confirm ETA appears on both cards and ticks down sensibly