### PR TITLE
feat(home): redesign active rip + transcode cards

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -18,6 +18,17 @@
 	--color-surface: rgb(241, 247, 255);
 	--color-surface-dark: rgb(22, 28, 45);
 
+	/* Status semantic colors — overrideable per theme via colorScheme tokens.
+	   Cards and badges read these via var() so themes can re-tone them
+	   independently of the primary brand color. */
+	--color-status-ripping: rgb(59, 130, 246);
+	--color-status-transcoding: rgb(139, 92, 246);
+	--color-status-finishing: rgb(245, 158, 11);
+	--color-status-waiting: rgb(234, 179, 8);
+	--color-status-scanning: rgb(6, 182, 212);
+	--color-status-success: rgb(34, 197, 94);
+	--color-status-error: rgb(239, 68, 68);
+
 	--radius-sm: calc(var(--radius) * 0.25);
 	--radius-md: calc(var(--radius) * 0.75);
 	--radius-lg: var(--radius);
@@ -110,13 +121,16 @@
 		border-right: 2px solid color-mix(in srgb, var(--_accent) 30%, transparent);
 	}
 
-	/* Status badge semantic colors */
-	.status-scanning   { @apply bg-cyan-500; }
-	.status-active     { @apply bg-blue-500; }
-	.status-warning    { @apply bg-yellow-500; }
-	.status-processing { @apply bg-indigo-500; }
-	.status-success    { @apply bg-green-500; }
-	.status-error      { @apply bg-red-500; }
+	/* Status badge semantic colors — back the .status-* classes used by
+	   StatusBadge with the themeable --color-status-* tokens. The unknown
+	   bucket stays neutral gray (not theme-tinted on purpose). */
+	.status-scanning   { background: var(--color-status-scanning); }
+	.status-active     { background: var(--color-status-ripping); }
+	.status-finishing  { background: var(--color-status-finishing); }
+	.status-warning    { background: var(--color-status-waiting); }
+	.status-processing { background: var(--color-status-transcoding); }
+	.status-success    { background: var(--color-status-success); }
+	.status-error      { background: var(--color-status-error); }
 	.status-unknown    { @apply bg-gray-500; }
 
 	/* File icon category colors */

--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { formatBytes, statusColor, statusLabel, timeAgo, elapsedTime, etaTime, formatDateTime } from '../utils/format';
+import { formatBytes, statusColor, statusLabel, statusAccentVar, timeAgo, elapsedTime, etaTime, formatDateTime } from '../utils/format';
 
 describe('formatBytes', () => {
 	it.each([
@@ -18,8 +18,11 @@ describe('statusColor', () => {
 		// JobState (arm-neu Job.status) - v2.0.0 disambiguated members
 		['success', 'status-success'],
 		['fail', 'status-error'],
-		['copying', 'status-warning'],
-		['ejecting', 'status-warning'],
+		// status-finishing is a distinct theme token (introduced alongside
+		// statusAccentVar) to highlight the copying/ejecting wind-down phase
+		// separately from the warning-tinted waiting bucket.
+		['copying', 'status-finishing'],
+		['ejecting', 'status-finishing'],
 		['manual_paused', 'status-warning'],
 		['makemkv_throttled', 'status-warning'],
 		['waiting_transcode', 'status-warning'],
@@ -107,6 +110,28 @@ describe('elapsedTime', () => {
 		['2025-06-15T09:45:00Z', '2h 15m']
 	])('elapsedTime(%s) = %s', (input, expected) => {
 		expect(elapsedTime(input)).toBe(expected);
+	});
+});
+
+describe('statusAccentVar', () => {
+	it.each<[string | null | undefined, string]>([
+		['ripping', 'var(--color-status-ripping)'],
+		['identifying', 'var(--color-status-scanning)'],
+		['transcoding', 'var(--color-status-transcoding)'],
+		['processing', 'var(--color-status-transcoding)'],
+		['copying', 'var(--color-status-finishing)'],
+		['ejecting', 'var(--color-status-finishing)'],
+		['waiting', 'var(--color-status-waiting)'],
+		['waiting_transcode', 'var(--color-status-waiting)'],
+		['success', 'var(--color-status-success)'],
+		['transcoded', 'var(--color-status-success)'],
+		['fail', 'var(--color-status-error)'],
+		['failed', 'var(--color-status-error)'],
+		[null, 'var(--color-primary)'],
+		[undefined, 'var(--color-primary)'],
+		['something-new', 'var(--color-primary)']
+	])('statusAccentVar(%s) = %s', (input, expected) => {
+		expect(statusAccentVar(input)).toBe(expected);
 	});
 });
 

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -2,12 +2,13 @@
 	import type { Job } from '$lib/types/arm';
 	import StatusBadge from './StatusBadge.svelte';
 	import ProgressBar from './ProgressBar.svelte';
-	import { elapsedTime, etaTime } from '$lib/utils/format';
+	import { elapsedTime, etaTime, statusAccentVar } from '$lib/utils/format';
 	import { getVideoTypeConfig, isJobActive, discTypeLabel } from '$lib/utils/job-type';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import TimeAgo from './TimeAgo.svelte';
 	import PosterImage from './PosterImage.svelte';
 	import SkeletonCard from './SkeletonCard.svelte';
+	import { abandonJob } from '$lib/api/jobs';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -31,6 +32,12 @@
 	let active = $derived(isJobActive(job?.status ?? null));
 	let hasErrors = $derived(!!job?.errors && job.errors.trim().length > 0);
 	let isFolderImport = $derived(job?.source_type === 'folder');
+	let accentVar = $derived(
+		statusAccentVar(isFolderImport && job?.status === 'ripping' ? 'importing' : job?.status)
+	);
+	let etaDisplay = $derived(
+		active && job?.start_time ? etaTime(job.start_time, progress) : null
+	);
 	let discLabelDiffers = $derived(
 		!!job?.label && !!job?.title && job.label.toLowerCase() !== job.title.toLowerCase()
 	);
@@ -39,6 +46,23 @@
 		// Don't toggle when clicking links/buttons inside
 		if ((e.target as HTMLElement).closest('a, button:not(.row-toggle)')) return;
 		expanded = !expanded;
+	}
+
+	let abandoning = $state(false);
+	let abandonError = $state<string | null>(null);
+
+	async function handleAbandon() {
+		if (!job) return;
+		if (!confirm(`Abandon job "${job.title || job.label || job.job_id}"?`)) return;
+		abandoning = true;
+		abandonError = null;
+		try {
+			await abandonJob(job.job_id);
+		} catch (e) {
+			abandonError = e instanceof Error ? e.message : 'Failed to abandon';
+		} finally {
+			abandoning = false;
+		}
 	}
 </script>
 
@@ -53,95 +77,99 @@
 	tabindex="0"
 >
 	<!-- Collapsed row -->
-	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
-		<!-- Poster thumbnail -->
-		<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
+	<div class="cursor-pointer px-4 pt-2.5" class:pb-2.5={!active}>
+		<div class="flex items-center gap-3">
+			<!-- Poster thumbnail -->
+			<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
 
-		<!-- Title -->
-		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
-			{job.title || job.label || 'Untitled'}
-		</h3>
+			<!-- Title -->
+			<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
+				{job.title || job.label || 'Untitled'}
+			</h3>
 
-		<!-- Year -->
-		{#if job.year}
-			<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{job.year}</span>
-		{/if}
-
-		<!-- Status badge -->
-		<div class="shrink-0">
-			<StatusBadge status={isFolderImport && (job.status === 'video_ripping' || job.status === 'ripping') ? 'importing' : job.status} />
-		</div>
-
-		<!-- Type + disc badges -->
-		<div class="hidden sm:flex shrink-0 items-center gap-1.5">
-			<span class="rounded-sm px-1.5 py-0.5 text-xs font-medium {typeConfig.badgeClasses}">{typeConfig.label}</span>
-			{#if job.disctype}
-				<span class="inline-flex items-center gap-0.5 rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs dark:bg-primary/15">
-					<DiscTypeIcon disctype={job.disctype} size="h-3 w-3" />
-					{discTypeLabel(job.disctype)}
-				</span>
+			<!-- Year -->
+			{#if job.year}
+				<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{job.year}</span>
 			{/if}
-		</div>
 
-		<!-- Drive / source -->
-		<span class="hidden md:inline shrink-0 text-xs text-gray-500 dark:text-gray-400">
-			{#if job.devpath}
-				{driveName ?? job.devpath}
-			{:else if job.source_path}
-				{job.source_path.split('/').slice(-1)[0]}
-			{/if}
-		</span>
+			<!-- Status badge: folder-import jobs in the rip phase render as
+			     'importing' regardless of which JobState rip variant arm-neu
+			     emits. Both v2.0.0 'video_ripping' and the legacy 'ripping'
+			     are matched so in-flight jobs mid-deploy still show the
+			     correct badge. -->
+			<div class="shrink-0">
+				<StatusBadge status={isFolderImport && (job.status === 'video_ripping' || job.status === 'ripping') ? 'importing' : job.status} />
+			</div>
 
-		<!-- Progress bar (inline) -->
-		{#if active}
-			<div class="hidden lg:block flex-1 min-w-24">
-				{#if progress != null && progress > 0}
-					<ProgressBar value={progress} color="bg-primary" />
-				{:else}
-					<div class="h-2 overflow-hidden rounded-full bg-primary/15">
-						<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
-					</div>
+			<!-- Type + disc badges -->
+			<div class="hidden sm:flex shrink-0 items-center gap-1.5">
+				<span class="rounded-sm px-1.5 py-0.5 text-xs font-medium {typeConfig.badgeClasses}">{typeConfig.label}</span>
+				{#if job.disctype}
+					<span class="inline-flex items-center gap-0.5 rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs dark:bg-primary/15">
+						<DiscTypeIcon disctype={job.disctype} size="h-3 w-3" />
+						{discTypeLabel(job.disctype)}
+					</span>
 				{/if}
 			</div>
-		{/if}
 
-		<!-- Track counts -->
-		{#if active && displayTotal > 0 && !isFolderImport}
-			<span class="hidden lg:inline shrink-0 text-xs text-gray-500 dark:text-gray-400">
-				{displayRipped}/{displayTotal}
+			<!-- Drive / source -->
+			<span class="hidden md:inline shrink-0 text-xs text-gray-500 dark:text-gray-400">
+				{#if job.devpath}
+					{driveName ?? job.devpath}
+				{:else if job.source_path}
+					{job.source_path.split('/').slice(-1)[0]}
+				{/if}
 			</span>
-		{/if}
 
-		<!-- Elapsed -->
-		{#if active && job.start_time}
-			<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{elapsedTime(job.start_time)}</span>
-		{/if}
+			<!-- Spacer -->
+			<span class="flex-1"></span>
 
-		<!-- Errors indicator -->
-		{#if hasErrors}
-			<span class="shrink-0 text-red-500 dark:text-red-400" title={job.errors ?? ''}>
-				<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
-					<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+			<!-- Track counts -->
+			{#if active && displayTotal > 0 && !isFolderImport}
+				<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+					{displayRipped}/{displayTotal}
+				</span>
+			{/if}
+
+			<!-- ETA (active) or Elapsed (inactive but recent) -->
+			{#if active}
+				<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400" title="Estimated time remaining">
+					{etaDisplay ? `~${etaDisplay}` : elapsedTime(job.start_time)}
+				</span>
+			{/if}
+
+			<!-- Errors indicator -->
+			{#if hasErrors}
+				<span class="shrink-0 text-red-500 dark:text-red-400" title={job.errors ?? ''}>
+					<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+						<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+					</svg>
+				</span>
+			{/if}
+
+			<!-- Expand chevron -->
+			<button class="row-toggle shrink-0 p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-transform" class:rotate-180={expanded} title={expanded ? 'Collapse' : 'Expand'}>
+				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
 				</svg>
-			</span>
-		{/if}
-
-		<!-- Expand chevron -->
-		<button class="row-toggle shrink-0 p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-transform" class:rotate-180={expanded} title={expanded ? 'Collapse' : 'Expand'}>
-			<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-			</svg>
-		</button>
+			</button>
+		</div>
 	</div>
 
-	<!-- Mobile progress (below collapsed row) -->
-	{#if active && !expanded}
-		<div class="lg:hidden px-4 pb-2.5">
+	<!-- Progress row: own line below a divider, indented under content -->
+	{#if active}
+		<div class="mt-2 border-t border-primary/10 dark:border-primary/15 px-4 pl-[64px] pr-4 py-2.5">
 			{#if progress != null && progress > 0}
-				<ProgressBar value={progress} color="bg-primary" />
+				<ProgressBar value={progress} colorVar={accentVar} />
 			{:else}
-				<div class="h-2 overflow-hidden rounded-full bg-primary/15">
-					<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
+				<div class="flex items-center gap-2">
+					<div class="h-2.5 flex-1 overflow-hidden rounded-full bg-primary/15">
+						<div
+							class="h-full w-1/3 animate-indeterminate rounded-full"
+							style="background: {accentVar}; opacity: 0.6"
+						></div>
+					</div>
+					<span class="min-w-[3ch] text-right text-xs text-gray-500 dark:text-gray-400">…</span>
 				</div>
 			{/if}
 		</div>
@@ -155,18 +183,25 @@
 				<PosterImage url={job.poster_url} alt={job.title ?? 'Poster'} class="h-32 w-22 shrink-0 rounded-sm object-cover" />
 
 				<div class="min-w-0 flex-1">
-					<!-- Title + links -->
+					<!-- Title + links + abandon -->
 					<div class="mb-2 flex items-start justify-between gap-2">
 						<a href="/jobs/{job.job_id}" class="text-sm font-semibold text-primary hover:underline">{job.title || job.label || 'Untitled'}</a>
 						<div class="flex items-center gap-2">
 							{#if job.imdb_id}
 								<a href="https://www.imdb.com/title/{job.imdb_id}/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-sm bg-yellow-400 px-1.5 py-0.5 text-xs font-bold text-black hover:bg-yellow-300">IMDb</a>
 							{/if}
-							{#if job.logfile}
-								<a href="/logs/{job.logfile}" class="text-xs text-primary hover:underline">Log</a>
+							{#if active}
+								<button
+									onclick={handleAbandon}
+									disabled={abandoning}
+									class="text-xs font-medium text-red-500 hover:underline disabled:opacity-50 dark:text-red-400"
+								>{abandoning ? 'Abandoning…' : 'Abandon'}</button>
 							{/if}
 						</div>
 					</div>
+					{#if abandonError}
+						<div class="mb-2 text-xs text-red-500 dark:text-red-400">{abandonError}</div>
+					{/if}
 
 					<!-- Data table -->
 					<table class="w-full text-xs">
@@ -289,9 +324,18 @@
 						</div>
 					{/if}
 
-					<!-- View detail link -->
-					<div class="mt-2">
-						<a href="/jobs/{job.job_id}" class="inline-block text-xs text-primary hover:underline">View full details</a>
+					<!-- Actions -->
+					<div class="mt-3 flex items-center gap-2">
+						<a
+							href="/jobs/{job.job_id}"
+							class="rounded-md border border-primary/30 bg-primary/15 px-3 py-1 text-xs font-medium text-primary hover:bg-primary/25"
+						>Open details</a>
+						{#if job.logfile}
+							<a
+								href="/logs/{job.logfile}"
+								class="rounded-md border border-primary/25 bg-transparent px-3 py-1 text-xs font-medium text-gray-600 hover:bg-primary/10 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+							>View log</a>
+						{/if}
 					</div>
 				</div>
 			</div>

--- a/frontend/src/lib/components/ProgressBar.svelte
+++ b/frontend/src/lib/components/ProgressBar.svelte
@@ -3,20 +3,29 @@
 		value: number;
 		max?: number;
 		color?: string;
+		colorVar?: string | null;
 		showLabel?: boolean;
 	}
 
-	let { value, max = 100, color = 'bg-primary', showLabel = true }: Props = $props();
+	let {
+		value,
+		max = 100,
+		color = 'bg-primary',
+		colorVar = null,
+		showLabel = true
+	}: Props = $props();
 	let pct = $derived(Math.min(100, Math.max(0, (value / max) * 100)));
+	let fillStyle = $derived(
+		colorVar ? `width: ${pct}%; background: ${colorVar}` : `width: ${pct}%`
+	);
+	let fillClasses = $derived(
+		colorVar ? 'h-2.5 rounded-full transition-all duration-500' : `h-2.5 rounded-full transition-all duration-500 ${color}`
+	);
 </script>
 
 <div class="flex items-center gap-2">
 	<div data-progress-track class="h-2.5 flex-1 rounded-full bg-primary/15 dark:bg-primary/15">
-		<div
-			data-progress-fill
-			class="h-2.5 rounded-full transition-all duration-500 {color}"
-			style="width: {pct}%"
-		></div>
+		<div data-progress-fill class={fillClasses} style={fillStyle}></div>
 	</div>
 	{#if showLabel}
 		<span class="min-w-[3ch] text-right text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/lib/components/StatusBadge.test.ts
+++ b/frontend/src/lib/components/StatusBadge.test.ts
@@ -8,7 +8,7 @@ describe('StatusBadge', () => {
 	it.each([
 		['ripping', 'Ripping', 'status-active'],
 		['SUCCESS', 'Success', 'status-success'],
-		['copying', 'Copying', 'status-warning'],
+		['copying', 'Copying', 'status-finishing'],
 		['something_new', 'something_new', 'status-unknown']
 	])('renders status=%s as "%s" with class %s', (status, expectedText, expectedClass) => {
 		renderComponent(StatusBadge, { props: { status } });

--- a/frontend/src/lib/components/TranscodeCard.svelte
+++ b/frontend/src/lib/components/TranscodeCard.svelte
@@ -2,7 +2,7 @@
 	import type { TranscoderJob } from '$lib/types/transcoder';
 	import StatusBadge from './StatusBadge.svelte';
 	import ProgressBar from './ProgressBar.svelte';
-	import { elapsedTime, etaTime } from '$lib/utils/format';
+	import { elapsedTime, etaTime, statusAccentVar } from '$lib/utils/format';
 	import { discTypeLabel } from '$lib/utils/job-type';
 	import PosterImage from './PosterImage.svelte';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
@@ -23,6 +23,10 @@
 	let sourceFile = $derived(job?.source_path?.split('/').pop() ?? null);
 	let hasError = $derived(!!job?.error);
 	let isActive = $derived(job?.status === 'processing' || job?.status === 'transcoding');
+	let accentVar = $derived(statusAccentVar(job?.status));
+	let etaDisplay = $derived(
+		isActive && job?.started_at ? etaTime(job.started_at, job.progress) : null
+	);
 
 	function toggle(e: MouseEvent) {
 		if ((e.target as HTMLElement).closest('a, button:not(.row-toggle)')) return;
@@ -41,88 +45,90 @@
 	tabindex="0"
 >
 	<!-- Collapsed row -->
-	<div class="flex items-center gap-3 px-4 py-2.5 cursor-pointer">
-		<!-- Poster thumbnail -->
-		<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
+	<div class="cursor-pointer px-4 pt-2.5" class:pb-2.5={!isActive}>
+		<div class="flex items-center gap-3">
+			<!-- Poster thumbnail -->
+			<PosterImage url={job.poster_url} alt="" class="h-10 w-7 shrink-0 rounded-sm object-cover" />
 
-		<!-- Title -->
-		<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
-			{displayTitle}
-		</h3>
+			<!-- Title -->
+			<h3 class="min-w-0 flex-shrink truncate font-semibold text-sm text-gray-900 dark:text-white">
+				{displayTitle}
+			</h3>
 
-		<!-- Year -->
-		{#if job.year}
-			<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{job.year}</span>
-		{/if}
-
-		<!-- Status badge -->
-		<div class="shrink-0">
-			<StatusBadge status={job.status} />
-		</div>
-
-		<!-- Type + disc badges -->
-		<div class="hidden sm:flex shrink-0 items-center gap-1.5">
-			{#if job.video_type && job.video_type !== 'unknown'}
-				<span class="rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs font-medium dark:bg-primary/15">{job.video_type}</span>
+			<!-- Year -->
+			{#if job.year}
+				<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{job.year}</span>
 			{/if}
-			{#if job.disctype}
-				<span class="inline-flex items-center gap-0.5 rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs dark:bg-primary/15">
-					<DiscTypeIcon disctype={job.disctype} size="h-3 w-3" />
-					{discTypeLabel(job.disctype)}
+
+			<!-- Status badge -->
+			<div class="shrink-0">
+				<StatusBadge status={job.status} />
+			</div>
+
+			<!-- Type + disc badges -->
+			<div class="hidden sm:flex shrink-0 items-center gap-1.5">
+				{#if job.video_type && job.video_type !== 'unknown'}
+					<span class="rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs font-medium dark:bg-primary/15">{job.video_type}</span>
+				{/if}
+				{#if job.disctype}
+					<span class="inline-flex items-center gap-0.5 rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs dark:bg-primary/15">
+						<DiscTypeIcon disctype={job.disctype} size="h-3 w-3" />
+						{discTypeLabel(job.disctype)}
+					</span>
+				{/if}
+			</div>
+
+			<!-- Spacer -->
+			<span class="flex-1"></span>
+
+			<!-- FPS (when actively encoding) -->
+			{#if isActive && typeof job.current_fps === 'number' && job.current_fps > 0}
+				<span class="shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400" title="Encoder frames per second">
+					{job.current_fps.toFixed(1)} fps
 				</span>
 			{/if}
-		</div>
 
-		<!-- Progress bar (inline) -->
-		{#if typeof job.progress === 'number' && job.progress > 0}
-			<div class="hidden lg:block flex-1 min-w-24">
-				<ProgressBar value={job.progress} color="bg-primary" />
-			</div>
-		{:else if isActive}
-			<div class="hidden lg:block flex-1 min-w-24">
-				<div class="h-2 overflow-hidden rounded-full bg-primary/15">
-					<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
-				</div>
-			</div>
-		{/if}
+			<!-- ETA (active) or Elapsed (otherwise) -->
+			{#if isActive}
+				<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400" title="Estimated time remaining">
+					{etaDisplay ? `~${etaDisplay}` : (job.started_at ? elapsedTime(job.started_at) : '—')}
+				</span>
+			{:else if job.started_at}
+				<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{elapsedTime(job.started_at)}</span>
+			{/if}
 
-		<!-- FPS (when actively encoding) -->
-		{#if isActive && typeof job.current_fps === 'number' && job.current_fps > 0}
-			<span class="shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400" title="Encoder frames per second">
-				{job.current_fps.toFixed(1)} fps
-			</span>
-		{/if}
+			<!-- Error indicator -->
+			{#if hasError}
+				<span class="shrink-0 text-red-500 dark:text-red-400" title={job.error ?? ''}>
+					<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+						<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+					</svg>
+				</span>
+			{/if}
 
-		<!-- Elapsed -->
-		{#if job.started_at}
-			<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">{elapsedTime(job.started_at)}</span>
-		{/if}
-
-		<!-- Error indicator -->
-		{#if hasError}
-			<span class="shrink-0 text-red-500 dark:text-red-400" title={job.error ?? ''}>
-				<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
-					<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+			<!-- Expand chevron -->
+			<button class="row-toggle shrink-0 p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-transform" class:rotate-180={expanded} title={expanded ? 'Collapse' : 'Expand'}>
+				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
 				</svg>
-			</span>
-		{/if}
-
-		<!-- Expand chevron -->
-		<button class="row-toggle shrink-0 p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-transform" class:rotate-180={expanded} title={expanded ? 'Collapse' : 'Expand'}>
-			<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-			</svg>
-		</button>
+			</button>
+		</div>
 	</div>
 
-	<!-- Mobile progress -->
-	{#if isActive && !expanded}
-		<div class="lg:hidden px-4 pb-2.5">
+	<!-- Progress row: own line below a divider, indented under content -->
+	{#if isActive}
+		<div class="mt-2 border-t border-primary/10 dark:border-primary/15 px-4 pl-[64px] pr-4 py-2.5">
 			{#if typeof job.progress === 'number' && job.progress > 0}
-				<ProgressBar value={job.progress} color="bg-primary" />
+				<ProgressBar value={job.progress} colorVar={accentVar} />
 			{:else}
-				<div class="h-2 overflow-hidden rounded-full bg-primary/15">
-					<div class="h-full w-1/3 animate-indeterminate rounded-full bg-primary/60"></div>
+				<div class="flex items-center gap-2">
+					<div class="h-2.5 flex-1 overflow-hidden rounded-full bg-primary/15">
+						<div
+							class="h-full w-1/3 animate-indeterminate rounded-full"
+							style="background: {accentVar}; opacity: 0.6"
+						></div>
+					</div>
+					<span class="min-w-[3ch] text-right text-xs text-gray-500 dark:text-gray-400">…</span>
 				</div>
 			{/if}
 		</div>
@@ -143,7 +149,9 @@
 						<tbody class="divide-y divide-primary/5 dark:divide-primary/10">
 							<tr>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Job ID</td>
-								<td class="py-1 text-gray-900 dark:text-white">{job.id}{#if job.arm_job_id} <span class="text-gray-400">(ARM #{job.arm_job_id})</span>{/if}</td>
+								<td class="py-1">
+									<a href="/jobs/{job.id}" class="text-primary hover:underline">#{job.id}</a>
+								</td>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">Status</td>
 								<td class="py-1"><StatusBadge status={job.status} /></td>
 							</tr>
@@ -202,11 +210,25 @@
 						</div>
 					{/if}
 
-					{#if job.arm_job_id}
-						<div class="mt-2">
-							<a href="/jobs/{job.arm_job_id}" class="inline-block text-xs text-primary hover:underline">View full details</a>
-						</div>
-					{/if}
+					<!-- Actions: per the unified-ID schema, transcoder.id == arm.job_id
+					 for webhook-originated jobs (see transcoder.py "Create new job
+					 with ARM job ID as PK"). -->
+					<div class="mt-3 flex flex-wrap items-center gap-2">
+						<a
+							href="/jobs/{job.id}"
+							class="rounded-md border border-primary/30 bg-primary/15 px-3 py-1 text-xs font-medium text-primary hover:bg-primary/25"
+						>Open job</a>
+						<a
+							href="/transcoder#job-{job.id}"
+							class="rounded-md border border-primary/25 bg-transparent px-3 py-1 text-xs font-medium text-gray-600 hover:bg-primary/10 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+						>Open transcoder</a>
+						{#if job.logfile}
+							<a
+								href="/logs/{job.logfile}"
+								class="rounded-md border border-primary/25 bg-transparent px-3 py-1 text-xs font-medium text-gray-600 hover:bg-primary/10 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+							>View log</a>
+						{/if}
+					</div>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/lib/components/TranscodeCard.test.ts
+++ b/frontend/src/lib/components/TranscodeCard.test.ts
@@ -16,7 +16,6 @@ function createTranscodeJob(overrides: Partial<TranscoderJob> = {}): TranscoderJ
 		video_type: 'movie',
 		year: '2024',
 		disctype: 'bluray',
-		arm_job_id: null,
 		output_path: null,
 		total_tracks: null,
 		poster_url: null,
@@ -70,8 +69,16 @@ describe('TranscodeCard', () => {
 			expect(matches.length).toBeGreaterThanOrEqual(1);
 		});
 
-		it('shows elapsed time', () => {
+		it('shows ETA when actively transcoding', () => {
+			// elapsed 1h 55m at 45% progress -> ~2h22m remaining, prefixed with ~
 			renderComponent(TranscodeCard, { props: { job: createTranscodeJob() } });
+			expect(screen.getByText(/^~/)).toBeInTheDocument();
+		});
+
+		it('shows elapsed time when not actively transcoding', () => {
+			renderComponent(TranscodeCard, {
+				props: { job: createTranscodeJob({ status: 'completed', completed_at: '2025-06-15T11:55:00Z' }) }
+			});
 			expect(screen.getByText('1h 55m')).toBeInTheDocument();
 		});
 
@@ -84,7 +91,8 @@ describe('TranscodeCard', () => {
 
 		it('does not show expanded detail by default', () => {
 			renderComponent(TranscodeCard, { props: { job: createTranscodeJob() } });
-			expect(screen.queryByText('View full details')).not.toBeInTheDocument();
+			expect(screen.queryByText('Open job')).not.toBeInTheDocument();
+			expect(screen.queryByText('Open transcoder')).not.toBeInTheDocument();
 		});
 	});
 
@@ -101,19 +109,16 @@ describe('TranscodeCard', () => {
 			});
 		});
 
-		it('shows view full details link when arm_job_id is set', async () => {
-			renderComponent(TranscodeCard, { props: { job: createTranscodeJob({ arm_job_id: '42' }) } });
-			await fireEvent.click(screen.getByText('My Movie'));
-			await waitFor(() => {
-				expect(screen.getByText('View full details')).toBeInTheDocument();
-			});
-		});
-
-		it('hides view full details link when arm_job_id is null', async () => {
+		it('shows Open job + Open transcoder buttons when expanded', async () => {
+			// Unified-ID schema: transcoder.id == arm.job_id, so Open job
+			// always renders and points to /jobs/{id}.
 			renderComponent(TranscodeCard, { props: { job: createTranscodeJob() } });
 			await fireEvent.click(screen.getByText('My Movie'));
 			await waitFor(() => {
-				expect(screen.queryByText('View full details')).not.toBeInTheDocument();
+				const openJob = screen.getByText('Open job');
+				expect(openJob).toBeInTheDocument();
+				expect(openJob.getAttribute('href')).toBe('/jobs/1');
+				expect(screen.getByText('Open transcoder')).toBeInTheDocument();
 			});
 		});
 
@@ -144,13 +149,13 @@ describe('TranscodeCard', () => {
 			});
 		});
 
-		it('shows ARM job ID when present', async () => {
-			renderComponent(TranscodeCard, {
-				props: { job: createTranscodeJob({ arm_job_id: '42' }) }
-			});
+		it('renders Job ID as a link to the unified job page', async () => {
+			renderComponent(TranscodeCard, { props: { job: createTranscodeJob() } });
 			await fireEvent.click(screen.getByText('My Movie'));
 			await waitFor(() => {
-				expect(screen.getByText('(ARM #42)')).toBeInTheDocument();
+				const idLink = screen.getByText('#1');
+				expect(idLink).toBeInTheDocument();
+				expect(idLink.getAttribute('href')).toBe('/jobs/1');
 			});
 		});
 	});

--- a/frontend/src/lib/components/__tests__/ActiveJobRow.test.ts
+++ b/frontend/src/lib/components/__tests__/ActiveJobRow.test.ts
@@ -68,7 +68,7 @@ describe('ActiveJobRow', () => {
 
 		it('does not show expanded detail by default', () => {
 			renderComponent(ActiveJobRow, { props: { job: createJob() } });
-			expect(screen.queryByText('View full details')).not.toBeInTheDocument();
+			expect(screen.queryByText('Open details')).not.toBeInTheDocument();
 		});
 	});
 
@@ -80,7 +80,7 @@ describe('ActiveJobRow', () => {
 			// Click the row to expand
 			await fireEvent.click(screen.getByText('Test Movie'));
 			await waitFor(() => {
-				expect(screen.getByText('View full details')).toBeInTheDocument();
+				expect(screen.getByText('Open details')).toBeInTheDocument();
 			});
 		});
 
@@ -130,7 +130,7 @@ describe('ActiveJobRow', () => {
 			});
 			await fireEvent.click(screen.getByText('Test Movie'));
 			await waitFor(() => {
-				expect(screen.getByText('View full details')).toBeInTheDocument();
+				expect(screen.getByText('Open details')).toBeInTheDocument();
 			});
 		});
 	});

--- a/frontend/src/lib/types/transcoder.ts
+++ b/frontend/src/lib/types/transcoder.ts
@@ -10,7 +10,6 @@ export interface TranscoderJob {
 	video_type: string | null;
 	year: string | null;
 	disctype: string | null;
-	arm_job_id: string | null;
 	output_path: string | null;
 	total_tracks: number | null;
 	poster_url: string | null;

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -71,6 +71,55 @@ export function etaTime(
 }
 
 /**
+ * Map a job status to a themeable CSS variable reference suitable for
+ * inline `style="background: ${statusAccentVar(status)}"` use. Falls back
+ * to the primary brand color so unrecognized statuses still pick up
+ * theme tinting.
+ *
+ * Accepts JobState (arm-neu Job.status), JobStatus (transcoder), or
+ * TrackStatus values. v2.0.0 disambiguated 'ripping' into
+ * 'video_ripping'/'audio_ripping' and 'waiting' into
+ * 'manual_paused'/'makemkv_throttled'; both new and legacy strings are
+ * mapped here so in-flight jobs observed mid-deploy still tint correctly.
+ */
+export function statusAccentVar(status: string | null | undefined): string {
+	switch (status?.toLowerCase()) {
+		case 'identifying':
+			return 'var(--color-status-scanning)';
+		case 'ready':
+		case 'active':
+		case 'ripping':         // legacy pre-v2.0.0
+		case 'video_ripping':
+		case 'audio_ripping':
+		case 'importing':
+			return 'var(--color-status-ripping)';
+		case 'copying':
+		case 'ejecting':
+			return 'var(--color-status-finishing)';
+		case 'transcoding':
+		case 'processing':
+			return 'var(--color-status-transcoding)';
+		case 'success':
+		case 'completed':
+		case 'complete':
+		case 'transcoded':
+			return 'var(--color-status-success)';
+		case 'fail':
+		case 'failed':
+		case 'error':
+			return 'var(--color-status-error)';
+		case 'waiting':         // legacy pre-v2.0.0
+		case 'manual_paused':
+		case 'makemkv_throttled':
+		case 'waiting_transcode':
+		case 'pending':
+			return 'var(--color-status-waiting)';
+		default:
+			return 'var(--color-primary)';
+	}
+}
+
+/**
  * Map a status string to a CSS class. Receives values from three different
  * enums depending on caller:
  *   - arm_contracts.JobState (arm-neu Job.status) - StatusBadge in JobRow,
@@ -100,7 +149,7 @@ export function statusColor(status: string | null): string {
 			return 'status-active';
 		case 'copying':
 		case 'ejecting':
-			return 'status-warning';
+			return 'status-finishing';
 		case 'transcoding':
 		case 'processing': // JobStatus (transcoder) - TranscodeCard / transcoder page
 			return 'status-processing';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -424,13 +424,7 @@
 				<div class="space-y-2">
 					{#each dash.active_transcodes as tc (tc.id)}
 						<div in:fade|local={fadeIn} out:fade|local={fadeOut}>
-							{#if tc.arm_job_id}
-								<a href="/jobs/{tc.arm_job_id}" class="block transition-opacity hover:opacity-80">
-									<TranscodeCard job={tc} />
-								</a>
-							{:else}
-								<TranscodeCard job={tc} />
-							{/if}
+							<TranscodeCard job={tc} />
 						</div>
 					{/each}
 				</div>

--- a/frontend/src/routes/transcoder/+page.svelte
+++ b/frontend/src/routes/transcoder/+page.svelte
@@ -390,12 +390,10 @@
 									{#if job.year}
 										<span>{job.year}</span>
 									{/if}
-									{#if job.arm_job_id}
-										<a
-											href="/jobs/{job.arm_job_id}"
-											class="inline-flex items-center rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary-text hover:bg-primary/20 dark:bg-primary/15 dark:text-primary-text-dark dark:hover:bg-primary/25"
-										>ARM #{job.arm_job_id}</a>
-									{/if}
+									<a
+										href="/jobs/{job.id}"
+										class="inline-flex items-center rounded-sm bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary-text hover:bg-primary/20 dark:bg-primary/15 dark:text-primary-text-dark dark:hover:bg-primary/25"
+									>Job #{job.id}</a>
 									{#if job.source_path}
 										<span class="truncate font-mono text-xs text-gray-400 dark:text-gray-500" title={job.source_path}>{sourceBasename(job.source_path)}</span>
 									{/if}

--- a/frontend/src/routes/transcoder/__tests__/transcoder-page.test.ts
+++ b/frontend/src/routes/transcoder/__tests__/transcoder-page.test.ts
@@ -9,7 +9,7 @@ vi.mock('$lib/api/transcoder', () => ({
 	})),
 	fetchTranscoderJobs: vi.fn(() => Promise.resolve({
 		jobs: [
-			{ id: 1, title: 'Movie 1', source_path: '/raw/movie1.mkv', status: 'processing', progress: 50, error: null, logfile: 'tc_1.log', video_type: 'movie', year: '2024', disctype: 'bluray', arm_job_id: null, output_path: null, total_tracks: null, poster_url: null, config_overrides: null, created_at: '2025-06-15T10:00:00Z', started_at: '2025-06-15T10:05:00Z', completed_at: null }
+			{ id: 1, title: 'Movie 1', source_path: '/raw/movie1.mkv', status: 'processing', progress: 50, error: null, logfile: 'tc_1.log', video_type: 'movie', year: '2024', disctype: 'bluray', output_path: null, total_tracks: null, poster_url: null, config_overrides: null, created_at: '2025-06-15T10:00:00Z', started_at: '2025-06-15T10:05:00Z', completed_at: null }
 		],
 		total: 1
 	})),


### PR DESCRIPTION
## Summary
Stacks on #274 (ETA replacement). Polishes the active rip + active transcode cards on the home dashboard:

- **Themeable status colors** - 7 new `--color-status-*` CSS variables under `@theme`. The `.status-*` classes consume them, plus a new `statusAccentVar()` helper for inline use. `copying`/`ejecting` move from `status-warning` to a dedicated `status-finishing` so they read as "wrapping up" rather than "something might be wrong".
- **Layout port** from a standalone design app (`~/src/active-job-row`):
  - Progress bar moves to its own row below a divider, indented under the content
  - Bar fill takes a status-accent CSS variable (blue=ripping, violet=transcoding, amber=finishing) so different stages distinguish at a glance
  - Collapsed row shows ETA when active (with `~` prefix); falls back to elapsed for the first 30s
  - Expanded body gets a real action area: small `Abandon` link top-right (active jobs only), then `Open details`/`Open job` + ghost `View log` buttons under the table
- **Drop dead `TranscoderJob.arm_job_id` field.** Per the unified-ID schema, `transcoder.id == arm.job_id` for any webhook-originated job (see `transcoder.py`: "Create new job with ARM job ID as PK"). The separate field was never emitted by the BFF. Surface the unified id directly:
  - Card table cell: Job ID is now a primary-color link to `/jobs/{id}`
  - Card actions: `Open job` + `Open transcoder` buttons (latter linking to `/transcoder#job-{id}`)
  - `/transcoder` list page: `ARM #{arm_job_id}` chip becomes `Job #{id}`
  - Home page: removed redundant card-wrapping anchor (was eating clicks intended for the new in-card buttons)

## Test plan
- [x] `npx vitest run` - 897/897 pass
- [x] `npx svelte-check` - 0 errors
- [x] Local stack on hifi-dev with seeded jobs - blue/violet progress accents, ETA on Blade Runner card, action buttons render correctly
- [ ] CI: tests, gitleaks, codeql, submodule-lockstep
- [ ] Visual smoke on hifi RC after merge