### PR TITLE
chore(ui): clarify non-JobState status values in utility helpers

### DIFF
--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -15,25 +15,34 @@ describe('formatBytes', () => {
 
 describe('statusColor', () => {
 	it.each<[string | null, string]>([
+		// JobState (arm-neu Job.status)
 		['success', 'status-success'],
-		['completed', 'status-success'],
-		['complete', 'status-success'],
 		['fail', 'status-error'],
-		['failed', 'status-error'],
-		['error', 'status-error'],
 		['copying', 'status-warning'],
 		['ejecting', 'status-warning'],
 		['waiting', 'status-warning'],
 		['waiting_transcode', 'status-warning'],
-		['pending', 'status-warning'],
 		['identifying', 'status-scanning'],
 		['ready', 'status-active'],
-		['active', 'status-active'],
 		['ripping', 'status-active'],
 		['transcoding', 'status-processing'],
+		// JobStatus (transcoder TranscodeJob.status)
+		['completed', 'status-success'],
+		['failed', 'status-error'],
+		['pending', 'status-warning'],
 		['processing', 'status-processing'],
+		// TrackStatus (Track.status)
+		['transcoded', 'status-success'],
+		// Locally-generated literals
+		['importing', 'status-active'],
+		['skipped', 'status-unknown'],
+		// Fallthrough
 		['unknown', 'status-unknown'],
-		[null, 'status-unknown']
+		[null, 'status-unknown'],
+		// Removed legacy synonyms - now fall through to status-unknown
+		['active', 'status-unknown'],
+		['complete', 'status-unknown'],
+		['error', 'status-unknown']
 	])('statusColor(%s) = %s', (input, expected) => {
 		expect(statusColor(input)).toBe(expected);
 	});

--- a/frontend/src/lib/__tests__/job-type.test.ts
+++ b/frontend/src/lib/__tests__/job-type.test.ts
@@ -54,16 +54,13 @@ describe('isJobActive', () => {
 		expect(isJobActive(null)).toBe(false);
 	});
 
-	it('returns true for active statuses', () => {
+	it('returns true for JobState non-terminal members', () => {
 		expect(isJobActive('identifying')).toBe(true);
 		expect(isJobActive('ready')).toBe(true);
-		expect(isJobActive('active')).toBe(true);
 		expect(isJobActive('ripping')).toBe(true);
 		expect(isJobActive('copying')).toBe(true);
 		expect(isJobActive('ejecting')).toBe(true);
-		expect(isJobActive('processing')).toBe(true);
 		expect(isJobActive('transcoding')).toBe(true);
-		expect(isJobActive('pending')).toBe(true);
 		expect(isJobActive('waiting')).toBe(true);
 		expect(isJobActive('waiting_transcode')).toBe(true);
 	});
@@ -73,9 +70,17 @@ describe('isJobActive', () => {
 		expect(isJobActive('RIPPING')).toBe(true);
 	});
 
-	it('returns false for terminal statuses', () => {
+	it('returns false for terminal JobState members', () => {
 		expect(isJobActive('success')).toBe(false);
 		expect(isJobActive('fail')).toBe(false);
+	});
+
+	it('returns false for non-JobState values (transcoder JobStatus, TrackStatus, legacy)', () => {
+		// Defensive check: isJobActive is only called on arm-neu Job.status.
+		// Transcoder JobStatus values and legacy synonyms should not slip in.
+		expect(isJobActive('active')).toBe(false);
+		expect(isJobActive('processing')).toBe(false);
+		expect(isJobActive('pending')).toBe(false);
 		expect(isJobActive('completed')).toBe(false);
 		expect(isJobActive('error')).toBe(false);
 	});

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -41,35 +41,45 @@ export function elapsedTime(startTime: string | null): string {
 	return `${seconds}s`;
 }
 
+/**
+ * Map a status string to a CSS class. Receives values from three different
+ * enums depending on caller:
+ *   - arm_contracts.JobState (arm-neu Job.status) - StatusBadge in JobRow,
+ *     JobCard, ActiveJobRow, DriveCard, jobs/[id]
+ *   - arm_contracts.JobStatus (transcoder TranscodeJob.status) - StatusBadge
+ *     in TranscodeCard, transcoder/+page.svelte
+ *   - arm_contracts.TrackStatus (Track.status) - StatusBadge at jobs/[id]:849
+ * Plus two locally-generated literals: 'importing' (folder-import override
+ * for status='ripping') and 'skipped' (UI-only marker for filtered/disabled
+ * tracks). Both are produced inline at the StatusBadge call site, not by any
+ * backend.
+ */
 export function statusColor(status: string | null): string {
 	switch (status?.toLowerCase()) {
 		case 'identifying':
 			return 'status-scanning';
 		case 'ready':
-		case 'active':
 		case 'ripping':
-		case 'importing':
+		case 'importing': // locally generated when isFolderImport && status='ripping'
 			return 'status-active';
 		case 'copying':
 		case 'ejecting':
 			return 'status-warning';
 		case 'transcoding':
-		case 'processing':
+		case 'processing': // JobStatus (transcoder) - TranscodeCard / transcoder page
 			return 'status-processing';
 		case 'success':
-		case 'completed':
-		case 'complete':
-		case 'transcoded':
+		case 'completed': // JobStatus (transcoder) terminal
+		case 'transcoded': // TrackStatus terminal (transcode-phase)
 			return 'status-success';
 		case 'fail':
-		case 'failed':
-		case 'error':
+		case 'failed': // JobStatus (transcoder) terminal
 			return 'status-error';
 		case 'waiting':
 		case 'waiting_transcode':
-		case 'pending':
+		case 'pending': // JobStatus (transcoder) + TrackStatus member
 			return 'status-warning';
-		case 'skipped':
+		case 'skipped': // locally generated for !track.enabled || filtered (jobs/[id]:849)
 			return 'status-unknown';
 		default:
 			return 'status-unknown';

--- a/frontend/src/lib/utils/job-type.ts
+++ b/frontend/src/lib/utils/job-type.ts
@@ -64,16 +64,20 @@ export function getVideoTypeConfig(videoType: string | null): VideoTypeConfig {
 	return TYPE_MAP[videoType.toLowerCase()] ?? FALLBACK_CONFIG;
 }
 
+// Source of truth: arm_contracts.JobState (see components/contracts).
+// isJobActive() is only ever called with arm-neu Job.status values
+// (ActiveJobRow / JobCard / JobRow / JobActions / job-fields / jobs/[id]),
+// so this set deliberately tracks JobState's non-terminal members and
+// nothing else. Transcoder-side JobStatus ('processing', 'pending') and
+// TrackStatus ('pending') are intentionally absent - they never reach
+// isJobActive in current code paths.
 const ACTIVE_STATUSES = new Set([
 	'identifying',
 	'ready',
-	'active',
 	'ripping',
 	'copying',
 	'ejecting',
-	'processing',
 	'transcoding',
-	'pending',
 	'waiting',
 	'waiting_transcode',
 ]);


### PR DESCRIPTION
## Summary

Followup from the recent enum-extraction batch. The two utility files (\`job-type.ts\`, \`format.ts\`) carried status strings that don't exist in JobState. Audited each one to determine source against \`arm_contracts\` (JobState / JobStatus / TrackStatus) and current arm-neu emitters:

- Real source (TrackStatus, JobStatus, locally-generated): kept + annotated inline
- Dead defensive code (legacy upstream-ARM synonyms with no current emitter): removed

### Per-value verdicts

\`ACTIVE_STATUSES\` (only ever called on arm-neu \`Job.status\`):

| value | verdict | reason |
|-------|---------|--------|
| \`active\`     | removed | no emitter; UI 'active' is a filter category, not a status |
| \`processing\` | removed | JobStatus value, but \`isJobActive\` is only called on arm-neu Job.status (never on transcoder jobs) |
| \`pending\`    | removed | TrackStatus / JobStatus value, but never reaches \`isJobActive\` |

\`statusColor\` (called on JobState, JobStatus, TrackStatus, and two locally-generated literals):

| value | verdict | reason |
|-------|---------|--------|
| \`active\`     | removed | no emitter |
| \`complete\`   | removed | legacy upstream-ARM; not in any current enum |
| \`error\`      | removed | no emitter; UI 'error' is feedback-toast / log-level only |
| \`completed\`  | kept    | \`JobStatus.completed\` terminal (TranscodeCard / transcoder page) |
| \`failed\`     | kept    | \`JobStatus.failed\` terminal |
| \`pending\`    | kept    | \`JobStatus.pending\` + \`TrackStatus.pending\` |
| \`processing\` | kept    | \`JobStatus.processing\` |
| \`transcoded\` | kept    | \`TrackStatus.transcoded\` terminal |
| \`importing\`  | kept    | locally generated when \`isFolderImport && status==='ripping'\` |
| \`skipped\`    | kept    | locally generated for filtered/disabled tracks at jobs/[id]:849 |

A docblock on \`statusColor\` and a header comment on \`ACTIVE_STATUSES\` now name the source enums + call sites so the next reader doesn't have to re-derive.

No behavioral change for any currently-emitted status string. Removed values now fall through to the \`status-unknown\` default; \`statusColor\` tests assert this fallback explicitly to lock in the regression.

## Test plan

- [x] Python suite green (643 passed)
- [x] Frontend vitest suite green (877 passed)