### PR TITLE
feat: adopt arm_contracts v2.0.0 JobState disambiguation

### DIFF
--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -15,20 +15,26 @@ describe('formatBytes', () => {
 
 describe('statusColor', () => {
 	it.each<[string | null, string]>([
-		// JobState (arm-neu Job.status)
+		// JobState (arm-neu Job.status) - v2.0.0 disambiguated members
 		['success', 'status-success'],
 		['fail', 'status-error'],
 		['copying', 'status-warning'],
 		['ejecting', 'status-warning'],
-		['waiting', 'status-warning'],
+		['manual_paused', 'status-warning'],
+		['makemkv_throttled', 'status-warning'],
 		['waiting_transcode', 'status-warning'],
 		['identifying', 'status-scanning'],
 		['ready', 'status-active'],
-		['ripping', 'status-active'],
+		['video_ripping', 'status-active'],
+		['audio_ripping', 'status-active'],
 		['transcoding', 'status-processing'],
+		// JobState legacy pre-v2.0.0 wire strings (kept as defensive fallbacks
+		// for in-flight jobs observed mid-deploy)
+		['ripping', 'status-active'],
+		['waiting', 'status-warning'],
 		// JobStatus (transcoder TranscodeJob.status)
 		['completed', 'status-success'],
-		['failed', 'status-error'],
+		['failed', 'status-error'],   // also TrackStatus.failed (v2.0.0+)
 		['pending', 'status-warning'],
 		['processing', 'status-processing'],
 		// TrackStatus (Track.status)
@@ -51,10 +57,16 @@ describe('statusColor', () => {
 describe('statusLabel', () => {
 	it.each<[string | null, string]>([
 		['identifying', 'Scanning'],
+		// v2.0.0 disambiguated JobState members
+		['video_ripping', 'Ripping'],
+		['audio_ripping', 'Ripping'],
+		['manual_paused', 'Paused'],
+		['makemkv_throttled', 'Throttled'],
+		// Legacy pre-v2.0.0 fallbacks (in-flight jobs mid-deploy)
 		['ripping', 'Ripping'],
+		['waiting', 'Waiting'],
 		['success', 'Success'],
 		['fail', 'Failed'],
-		['waiting', 'Waiting'],
 		['transcoding', 'Transcoding'],
 		['info', 'Scanning'],
 		[null, 'Unknown'],

--- a/frontend/src/lib/__tests__/job-type.test.ts
+++ b/frontend/src/lib/__tests__/job-type.test.ts
@@ -54,15 +54,24 @@ describe('isJobActive', () => {
 		expect(isJobActive(null)).toBe(false);
 	});
 
-	it('returns true for JobState non-terminal members', () => {
+	it('returns true for JobState non-terminal members (v2.0.0 disambiguated)', () => {
 		expect(isJobActive('identifying')).toBe(true);
 		expect(isJobActive('ready')).toBe(true);
-		expect(isJobActive('ripping')).toBe(true);
+		expect(isJobActive('video_ripping')).toBe(true);
+		expect(isJobActive('audio_ripping')).toBe(true);
 		expect(isJobActive('copying')).toBe(true);
 		expect(isJobActive('ejecting')).toBe(true);
 		expect(isJobActive('transcoding')).toBe(true);
-		expect(isJobActive('waiting')).toBe(true);
+		expect(isJobActive('manual_paused')).toBe(true);
+		expect(isJobActive('makemkv_throttled')).toBe(true);
 		expect(isJobActive('waiting_transcode')).toBe(true);
+	});
+
+	it('returns true for legacy pre-v2.0.0 wire strings (defensive fallback)', () => {
+		// Kept so in-flight jobs observed during a mid-deploy window still
+		// register as active rather than silently flipping to terminal.
+		expect(isJobActive('ripping')).toBe(true);
+		expect(isJobActive('waiting')).toBe(true);
 	});
 
 	it('is case-insensitive', () => {

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -69,7 +69,7 @@
 
 		<!-- Status badge -->
 		<div class="shrink-0">
-			<StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} />
+			<StatusBadge status={isFolderImport && (job.status === 'video_ripping' || job.status === 'ripping') ? 'importing' : job.status} />
 		</div>
 
 		<!-- Type + disc badges -->
@@ -175,7 +175,7 @@
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Job ID</td>
 								<td class="py-1 text-gray-900 dark:text-white">{job.job_id}</td>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap pl-6">Status</td>
-								<td class="py-1"><StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} /></td>
+								<td class="py-1"><StatusBadge status={isFolderImport && (job.status === 'video_ripping' || job.status === 'ripping') ? 'importing' : job.status} /></td>
 							</tr>
 							<tr>
 								<td class="py-1 pr-4 text-gray-500 dark:text-gray-400 whitespace-nowrap">Type</td>

--- a/frontend/src/lib/components/JobCard.svelte
+++ b/frontend/src/lib/components/JobCard.svelte
@@ -43,7 +43,7 @@
 				<h3 class="truncate font-semibold text-gray-900 dark:text-white">
 					{job.title || job.label || 'Untitled'}
 				</h3>
-				<StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} />
+				<StatusBadge status={isFolderImport && (job.status === 'video_ripping' || job.status === 'ripping') ? 'importing' : job.status} />
 			</div>
 
 			<!-- Row 2: Year, IMDB, disc label -->

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -45,10 +45,15 @@ export function elapsedTime(startTime: string | null): string {
  * Map a status string to a CSS class. Receives values from three different
  * enums depending on caller:
  *   - arm_contracts.JobState (arm-neu Job.status) - StatusBadge in JobRow,
- *     JobCard, ActiveJobRow, DriveCard, jobs/[id]
+ *     JobCard, ActiveJobRow, DriveCard, jobs/[id]. Disambiguated in v2.0.0:
+ *     'ripping' -> 'video_ripping'/'audio_ripping', 'waiting' ->
+ *     'manual_paused'/'makemkv_throttled'. Old strings kept as defensive
+ *     fallbacks for in-flight jobs observed mid-deploy.
  *   - arm_contracts.JobStatus (transcoder TranscodeJob.status) - StatusBadge
  *     in TranscodeCard, transcoder/+page.svelte
- *   - arm_contracts.TrackStatus (Track.status) - StatusBadge at jobs/[id]:849
+ *   - arm_contracts.TrackStatus (Track.status) - StatusBadge at jobs/[id]:849.
+ *     'failed' is a real TrackStatus member as of v2.0.0 (was previously
+ *     only handled defensively for transcoder JobStatus).
  * Plus two locally-generated literals: 'importing' (folder-import override
  * for status='ripping') and 'skipped' (UI-only marker for filtered/disabled
  * tracks). Both are produced inline at the StatusBadge call site, not by any
@@ -59,7 +64,9 @@ export function statusColor(status: string | null): string {
 		case 'identifying':
 			return 'status-scanning';
 		case 'ready':
-		case 'ripping':
+		case 'ripping':         // legacy pre-v2.0.0; in-flight jobs mid-deploy
+		case 'video_ripping':
+		case 'audio_ripping':
 		case 'importing': // locally generated when isFolderImport && status='ripping'
 			return 'status-active';
 		case 'copying':
@@ -73,9 +80,11 @@ export function statusColor(status: string | null): string {
 		case 'transcoded': // TrackStatus terminal (transcode-phase)
 			return 'status-success';
 		case 'fail':
-		case 'failed': // JobStatus (transcoder) terminal
+		case 'failed': // JobStatus (transcoder) terminal AND TrackStatus.failed (v2.0.0+)
 			return 'status-error';
-		case 'waiting':
+		case 'waiting':         // legacy pre-v2.0.0; in-flight jobs mid-deploy
+		case 'manual_paused':
+		case 'makemkv_throttled':
 		case 'waiting_transcode':
 		case 'pending': // JobStatus (transcoder) + TrackStatus member
 			return 'status-warning';
@@ -90,7 +99,9 @@ const STATUS_LABELS: Record<string, string> = {
 	identifying: 'Scanning',
 	ready: 'Ready',
 	active: 'Active',
-	ripping: 'Ripping',
+	ripping: 'Ripping',           // legacy pre-v2.0.0; in-flight jobs mid-deploy
+	video_ripping: 'Ripping',
+	audio_ripping: 'Ripping',
 	importing: 'Processing',
 	copying: 'Copying',
 	ejecting: 'Ejecting',
@@ -102,7 +113,9 @@ const STATUS_LABELS: Record<string, string> = {
 	fail: 'Failed',
 	failed: 'Failed',
 	error: 'Error',
-	waiting: 'Waiting',
+	waiting: 'Waiting',           // legacy pre-v2.0.0; in-flight jobs mid-deploy
+	manual_paused: 'Paused',
+	makemkv_throttled: 'Throttled',
 	waiting_transcode: 'Waiting to Transcode',
 	pending: 'Pending',
 	skipped: 'Skipped',

--- a/frontend/src/lib/utils/job-type.ts
+++ b/frontend/src/lib/utils/job-type.ts
@@ -71,14 +71,22 @@ export function getVideoTypeConfig(videoType: string | null): VideoTypeConfig {
 // nothing else. Transcoder-side JobStatus ('processing', 'pending') and
 // TrackStatus ('pending') are intentionally absent - they never reach
 // isJobActive in current code paths.
+//
+// v2.0.0 disambiguation: 'ripping' split into 'video_ripping'/'audio_ripping',
+// 'waiting' split into 'manual_paused'/'makemkv_throttled'. Old strings kept
+// as defensive fallbacks for in-flight jobs observed mid-deploy.
 const ACTIVE_STATUSES = new Set([
 	'identifying',
 	'ready',
-	'ripping',
+	'ripping',                  // legacy pre-v2.0.0
+	'video_ripping',
+	'audio_ripping',
 	'copying',
 	'ejecting',
 	'transcoding',
-	'waiting',
+	'waiting',                  // legacy pre-v2.0.0
+	'manual_paused',
+	'makemkv_throttled',
 	'waiting_transcode',
 ]);
 

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -339,13 +339,15 @@
 	async function refreshProgress() {
 		if (!job) return;
 		const s = job.status?.toLowerCase();
-		if (s === 'ripping') {
+		// 'ripping' kept as legacy fallback for in-flight jobs mid-deploy (pre-v2.0.0).
+		const isRipping = s === 'video_ripping' || s === 'audio_ripping' || s === 'ripping';
+		if (isRipping) {
 			try {
 				ripProgress = await fetchJobProgress(job.job_id);
 			} catch {
 				ripProgress = null;
 			}
-		} else if (ripProgress && s !== 'ripping') {
+		} else if (ripProgress) {
 			// Clear stale rip progress once the phase changes so 100% doesn't linger
 			ripProgress = null;
 		}
@@ -426,7 +428,7 @@
 				{#if job.year && job.year !== '0000'}
 					<span class="text-base text-gray-400 dark:text-gray-500">({job.year})</span>
 				{/if}
-				<StatusBadge status={isFolderImport && job.status === 'ripping' ? 'importing' : job.status} />
+				<StatusBadge status={isFolderImport && (job.status === 'video_ripping' || job.status === 'ripping') ? 'importing' : job.status} />
 				{#if job.multi_title}
 					<span class="rounded-full bg-purple-100 px-2.5 py-0.5 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">Multi-Title</span>
 				{/if}
@@ -574,7 +576,8 @@
 		</div>
 
 		<!-- Progress widget: ripping, copying, waiting_transcode, transcoding -->
-		{#if job.status === 'ripping'}
+		<!-- 'ripping' kept as legacy fallback for in-flight jobs mid-deploy (pre-v2.0.0). -->
+		{#if job.status === 'video_ripping' || job.status === 'audio_ripping' || job.status === 'ripping'}
 			<div class="rounded-lg border border-primary/20 bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 				<div class="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
 					<span>Ripping</span>


### PR DESCRIPTION
## Summary

- Bumps contracts submodule to v2.0.0 (362c500)
- Extends statusColor switch + STATUS_LABELS map for new wire strings: `video_ripping`, `audio_ripping`, `manual_paused`, `makemkv_throttled`
- TrackStatus.failed handled by existing `'failed'` case (was defensive for transcoder JobStatus; now also a real TrackStatus value - comment updated)
- ACTIVE_STATUSES Set extended for new wire strings
- Legacy `'ripping'` and `'waiting'` cases retained as defensive fallbacks for in-flight jobs mid-deploy
- Folder-import override (`StatusBadge` in ActiveJobRow / JobCard / jobs/[id]) and rip-progress widget gated on `job.status === 'ripping'` updated to also accept `'video_ripping'` (and `'audio_ripping'` for the rip-progress branch); without this the "Processing" badge and rip progress bar would silently disappear once arm-neu emits the disambiguated wire strings

Companion to contracts PR #18 (merged), arm-neu PR #314 (merged), transcoder PR (in flight). Supersedes auto-bump PR #280.

## Test plan

- [x] Python suite green (643 passed)
- [x] Frontend vitest suite green (886 passed)