### PR TITLE
fix(dashboard): bucket disambiguated wire strings in waiting/ripping filters

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -49,12 +49,19 @@
 			return s === 'identifying' || s === 'ready';
 		})
 	);
+	// 'waiting' is the legacy pre-v2.0.0 wire string; arm-neu now emits
+	// 'manual_paused' (user-pause / disc-review state). Keep both so an
+	// in-flight job observed mid-deploy still surfaces in the review panel.
 	let waitingJobs = $derived(
-		dash.active_jobs.filter(j => j.status?.toLowerCase() === 'waiting' && !dismissedJobIds.has(j.job_id))
+		dash.active_jobs.filter(j => {
+			const s = j.status?.toLowerCase();
+			return (s === 'manual_paused' || s === 'waiting') && !dismissedJobIds.has(j.job_id);
+		})
 	);
 	let nonWaitingActiveJobs = $derived(dash.active_jobs.filter(j => {
 		const s = j.status?.toLowerCase();
-		return s !== 'waiting' && s !== 'transcoding' && s !== 'waiting_transcode'
+		return s !== 'waiting' && s !== 'manual_paused' && s !== 'makemkv_throttled'
+			&& s !== 'transcoding' && s !== 'waiting_transcode'
 			&& s !== 'identifying' && s !== 'ready'
 			&& s !== 'copying' && s !== 'ejecting';
 	}));
@@ -95,7 +102,14 @@
 	}
 
 	async function pollProgress() {
-		const rippingJobs = dash.active_jobs.filter(j => j.status?.toLowerCase() === 'ripping');
+		// 'ripping' is the legacy pre-v2.0.0 wire string; arm-neu now emits
+		// 'video_ripping' (DVD/Blu-ray) and 'audio_ripping' (music). Match all
+		// three so progress polling stays accurate during the deploy and
+		// continues working post-deploy.
+		const rippingJobs = dash.active_jobs.filter(j => {
+			const s = j.status?.toLowerCase();
+			return s === 'video_ripping' || s === 'audio_ripping' || s === 'ripping';
+		});
 		if (rippingJobs.length === 0) {
 			progressMap = {};
 			return;


### PR DESCRIPTION
## Summary

Production bug observed on hifi after deploying contracts v2.0.0 + arm-neu PR #314 (JobState disambiguation): jobs no longer appear in the 'Waiting for Review' section, and discs go straight to ripping. Pausing displays 'ripping' instead of 'waiting/paused'.

Root cause: PR #281 (the v2.0.0 arm-ui adoption) updated the statusColor/statusAccentVar utility helpers and a handful of Svelte component status checks but missed three job-bucket filters in \`routes/+page.svelte\`:

1. \`waitingJobs\` (line 53) filtered on \`'waiting'\` only -> needs \`'manual_paused'\`
2. \`nonWaitingActiveJobs\` (lines 57-59) excluded \`'waiting'\` but not the new \`'manual_paused'\`/\`'makemkv_throttled'\` -> paused/throttled jobs leaked into the wrong bucket
3. \`rippingJobs\` (pollProgress, line 98) filtered on \`'ripping'\` only -> needs \`'video_ripping'\` AND \`'audio_ripping'\`

Legacy \`'waiting'\` and \`'ripping'\` kept as fallbacks for in-flight jobs observed mid-deploy.

## Hotfix priority

This blocks the disc-review workflow on production hifi. Merging ASAP.

## Test plan

- [x] All 910 frontend tests pass
- [ ] Smoke: deploy to hifi, insert a real disc, verify it appears in 'Waiting for Review' section