### PR TITLE
refactor(maintenance): mirror arm-neu PR #322 invariant wire shapes

### DIFF
--- a/backend/models/files.py
+++ b/backend/models/files.py
@@ -45,11 +45,15 @@ class OperationResult(BaseModel):
 
     Designed permissively because upstream arm-neu actions return a
     family of envelopes (``{success}``, ``{success, paused}``,
-    ``{success, count}``, ``{success, deleted, ...}``, etc). Common
-    keys are surfaced for type help; ``extra='allow'`` keeps unknown
-    keys (e.g. ``updated``, ``overrides``) flowing through so callers
-    can read upstream-specific fields. Passthrough hardening into
-    dedicated models is tracked separately.
+    ``{success, count}``, etc). Common keys are surfaced for type help;
+    ``extra='allow'`` keeps unknown keys (e.g. ``updated``, ``overrides``)
+    flowing through so callers can read upstream-specific fields.
+    Passthrough hardening into dedicated models is tracked separately.
+
+    Single-target delete (delete-log / delete-folder) and bulk delete
+    (bulk-delete-logs / bulk-delete-folders) now have their own typed
+    shapes (DeleteResult / BulkDeleteResult) - this model no longer
+    needs to fit either of those.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -59,7 +63,3 @@ class OperationResult(BaseModel):
     paused: bool | None = None
     count: int | None = None
     cleared: int | None = None
-    # `deleted` may be either a path string (single-target delete) or
-    # an int count (bulk delete) depending on the upstream endpoint.
-    # Permissive str|int union keeps a single model usable across both.
-    deleted: str | int | None = None

--- a/backend/models/maintenance.py
+++ b/backend/models/maintenance.py
@@ -1,8 +1,11 @@
 """BFF response shapes for the maintenance surface.
 
-These wrap arm-neu's maintenance endpoints; the BFF currently passes
-the dicts through. Per the spec, response_model annotations describe
-the contract but no model_validate wrap is added on the BFF side.
+Mirrors the invariant wire shapes shipped in arm-neu PR #322
+(feat/maintenance-shape-cleanup): success/failure paths emit the same keys,
+delete_* always include `error: str | None`, bulk_delete_* always include
+`success: bool`, clear_raw failure path emits the full success-shape with
+zero defaults plus `error`, and orphan-folders carries `roots: list[str]`
+for symmetry with orphan-logs (`root: str`).
 """
 
 from __future__ import annotations
@@ -20,64 +23,114 @@ class MaintenanceSummary(BaseModel):
     stale_transcoder_jobs: int | None = None
 
 
-class OrphanLogList(BaseModel):
-    """Orphan logs payload from arm-neu.
-
-    Real upstream shape is a generic `{success, count, items?}` envelope
-    rather than a typed list - typed permissively here so the BFF can
-    pass it through, and the frontend reads `count` for the badge.
-    """
+class OrphanLogEntry(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    success: bool = True
-    count: int | None = None
-    logs: list[str] | None = None
+    path: str
+    relative_path: str
+    size_bytes: int
+
+
+class OrphanLogList(BaseModel):
+    """Orphan logs from arm-neu /api/v1/maintenance/orphan-logs."""
+    model_config = ConfigDict(extra="ignore")
+
+    root: str
+    total_size_bytes: int
+    files: list[OrphanLogEntry]
+
+
+class OrphanFolderEntry(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    path: str
+    name: str
+    category: str
+    size_bytes: int
 
 
 class OrphanFolderList(BaseModel):
+    """Orphan folders from arm-neu /api/v1/maintenance/orphan-folders.
+
+    `roots` carries both scanned roots (RAW + COMPLETED) since orphan-folders
+    spans two trees, mirroring the single `root` on orphan-logs.
+    """
     model_config = ConfigDict(extra="ignore")
 
-    success: bool = True
-    count: int | None = None
-    folders: list[str] | None = None
+    roots: list[str]
+    total_size_bytes: int
+    folders: list[OrphanFolderEntry]
 
 
-class BulkOperationResult(BaseModel):
-    """Bulk delete result. Upstream returns `deleted: <int count>`."""
+class MaintenanceDeleteResult(BaseModel):
+    """Single-target delete result (delete-log / delete-folder).
+
+    Wire shape is invariant across success/failure: `error` is always
+    present, `None` on success, `str` on failure. Named with a
+    Maintenance prefix to disambiguate from transcoder.DeleteResult.
+    """
     model_config = ConfigDict(extra="ignore")
 
-    success: bool = True
-    deleted: int | None = None
-    errors: list[str] | None = None
+    success: bool
+    path: str
+    error: str | None
+
+
+class MaintenanceBulkDeleteResult(BaseModel):
+    """Bulk delete result (bulk-delete-logs / bulk-delete-folders).
+
+    `success` is True only when no entries failed; partial-failure surfaces
+    as `success=False` with the failed paths in `errors`. Maintenance
+    prefix mirrors MaintenanceDeleteResult for grep-friendly cohabitation.
+    """
+    model_config = ConfigDict(extra="ignore")
+
+    success: bool
+    removed: list[str]
+    errors: list[str]
 
 
 class ImageCacheStats(BaseModel):
-    """Image cache snapshot. image_cache.stats() returns ``count`` and
-    ``size_bytes``; image_cache.clear() returns ``cleared`` (the count
-    of dropped entries). Both keys are surfaced so a single typed model
-    serves both endpoints."""
+    """Image cache snapshot. ``stats()`` returns count, size_bytes, size_mb,
+    oldest, path. ``clear()`` returns success, cleared, freed_bytes. The
+    superset is modeled with optional fields so a single shape serves both
+    endpoints."""
     model_config = ConfigDict(extra="ignore")
 
     count: int | None = None
     size_bytes: int | None = None
+    size_mb: float | None = None
+    oldest: float | None = None
+    path: str | None = None
+    success: bool | None = None
     cleared: int | None = None
+    freed_bytes: int | None = None
 
 
 class CleanupTranscoderResult(BaseModel):
-    """Cleanup-transcoder counts deleted jobs."""
+    """Cleanup-transcoder counts deleted jobs.
+
+    Handler always emits all three fields, so they are required in the
+    typed shape (no `= ...` defaults that would make codegen mark them
+    optional).
+    """
     model_config = ConfigDict(extra="ignore")
 
-    success: bool = True
-    deleted: int = 0
-    errors: list[str] = []
+    success: bool
+    deleted: int
+    errors: list[str]
 
 
 class ClearRawResult(BaseModel):
-    """Clear-raw cleared count, bytes freed, and any errors."""
+    """Clear-raw cleared count, bytes freed, and any errors.
+
+    Wire shape is invariant across success/failure (arm-neu PR #322).
+    """
     model_config = ConfigDict(extra="ignore")
 
-    success: bool = True
-    cleared: int = 0
-    freed_bytes: int = 0
-    errors: list[str] = []
-    path: str | None = None
+    success: bool
+    cleared: int
+    freed_bytes: int
+    errors: list[str]
+    path: str
+    error: str | None

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -47,11 +47,15 @@ from backend.models.logs import (
     StructuredLogResponse,
 )
 from backend.models.maintenance import (
-    BulkOperationResult,
     CleanupTranscoderResult,
+    ClearRawResult,
     ImageCacheStats,
+    MaintenanceBulkDeleteResult,
+    MaintenanceDeleteResult,
     MaintenanceSummary,
+    OrphanFolderEntry,
     OrphanFolderList,
+    OrphanLogEntry,
     OrphanLogList,
 )
 from backend.models.metadata import (
@@ -108,8 +112,10 @@ from backend.models.transcoder import (
 __all__ = [
     "TRANSCODE_OVERRIDES_ALLOWLIST",
     "AdvancedField",
-    "BulkOperationResult",
     "CleanupTranscoderResult",
+    "ClearRawResult",
+    "MaintenanceBulkDeleteResult",
+    "MaintenanceDeleteResult",
     "DashboardResponse",
     "DirectoryListing",
     "DriveEjectResult",
@@ -147,7 +153,9 @@ __all__ = [
     "NamingPreviewResponse",
     "NotificationSchema",
     "OperationResult",
+    "OrphanFolderEntry",
     "OrphanFolderList",
+    "OrphanLogEntry",
     "OrphanLogList",
     "Overrides",
     "PreflightFixResult",

--- a/backend/routers/maintenance.py
+++ b/backend/routers/maintenance.py
@@ -10,10 +10,11 @@ from pydantic import BaseModel
 
 from backend.models.files import OperationResult
 from backend.models.maintenance import (
-    BulkOperationResult,
     CleanupTranscoderResult,
     ClearRawResult,
     ImageCacheStats,
+    MaintenanceBulkDeleteResult,
+    MaintenanceDeleteResult,
     MaintenanceSummary,
     OrphanFolderList,
     OrphanLogList,
@@ -84,22 +85,22 @@ async def get_orphan_folders():
     return _check_arm(await arm_client.get_orphan_folders())
 
 
-@router.post("/maintenance/delete-log", response_model=OperationResult)
+@router.post("/maintenance/delete-log", response_model=MaintenanceDeleteResult)
 async def delete_log(req: PathRequest):
     return _check_arm(await arm_client.delete_orphan_log(req.path))
 
 
-@router.post("/maintenance/delete-folder", response_model=OperationResult)
+@router.post("/maintenance/delete-folder", response_model=MaintenanceDeleteResult)
 async def delete_folder(req: PathRequest):
     return _check_arm(await arm_client.delete_orphan_folder(req.path))
 
 
-@router.post("/maintenance/bulk-delete-logs", response_model=BulkOperationResult)
+@router.post("/maintenance/bulk-delete-logs", response_model=MaintenanceBulkDeleteResult)
 async def bulk_delete_logs(req: BulkPathRequest):
     return _check_arm(await arm_client.bulk_delete_logs(req.paths))
 
 
-@router.post("/maintenance/bulk-delete-folders", response_model=BulkOperationResult)
+@router.post("/maintenance/bulk-delete-folders", response_model=MaintenanceBulkDeleteResult)
 async def bulk_delete_folders(req: BulkPathRequest):
     return _check_arm(await arm_client.bulk_delete_folders(req.paths))
 

--- a/frontend/src/lib/api/maintenance.ts
+++ b/frontend/src/lib/api/maintenance.ts
@@ -1,67 +1,64 @@
 import { apiFetch } from './client';
+import type {
+	MaintenanceSummary,
+	OrphanLogList,
+	OrphanFolderList,
+	OrphanLogEntry,
+	OrphanFolderEntry,
+	MaintenanceDeleteResult,
+	MaintenanceBulkDeleteResult,
+	ClearRawResult,
+	ImageCacheStats,
+	CleanupTranscoderResult,
+} from '$lib/types/api.gen';
 
-export interface MaintenanceSummary {
-	orphan_logs: number | null;
-	orphan_folders: number | null;
-	unseen_notifications: number | null;
-	cleared_notifications: number | null;
-	stale_transcoder_jobs: number | null;
-}
+export type {
+	MaintenanceSummary,
+	OrphanLogList,
+	OrphanFolderList,
+	OrphanLogEntry,
+	OrphanFolderEntry,
+	ClearRawResult,
+	ImageCacheStats,
+	CleanupTranscoderResult,
+};
 
-export interface OrphanLog {
-	path: string;
-	relative_path: string;
-	size_bytes: number;
-}
-
-export interface OrphanFolder {
-	path: string;
-	name: string;
-	category: 'raw' | 'completed';
-	size_bytes: number;
-}
-
-export interface OrphanLogsResponse {
-	root: string;
-	total_size_bytes: number;
-	files: OrphanLog[];
-}
-
-export interface OrphanFoldersResponse {
-	total_size_bytes: number;
-	folders: OrphanFolder[];
-}
-
-export interface BulkDeleteResult {
-	removed: string[];
-	errors: string[];
-}
+// Legacy aliases - the surrounding pages import these names. The generated
+// equivalents are MaintenanceDeleteResult / MaintenanceBulkDeleteResult /
+// OrphanLogList / OrphanFolderList; these aliases keep the call sites
+// untouched.
+export type OrphanLog = OrphanLogEntry;
+export type OrphanFolder = OrphanFolderEntry;
+export type OrphanLogsResponse = OrphanLogList;
+export type OrphanFoldersResponse = OrphanFolderList;
+export type DeleteResult = MaintenanceDeleteResult;
+export type BulkDeleteResult = MaintenanceBulkDeleteResult;
 
 export function fetchSummary(): Promise<MaintenanceSummary> {
 	return apiFetch('/api/maintenance/summary');
 }
 
-export function fetchOrphanLogs(): Promise<OrphanLogsResponse> {
+export function fetchOrphanLogs(): Promise<OrphanLogList> {
 	return apiFetch('/api/maintenance/orphan-logs');
 }
 
-export function fetchOrphanFolders(): Promise<OrphanFoldersResponse> {
+export function fetchOrphanFolders(): Promise<OrphanFolderList> {
 	return apiFetch('/api/maintenance/orphan-folders');
 }
 
-export function deleteLog(path: string): Promise<{ success: boolean }> {
+export function deleteLog(path: string): Promise<MaintenanceDeleteResult> {
 	return apiFetch('/api/maintenance/delete-log', { method: 'POST', body: JSON.stringify({ path }) });
 }
 
-export function deleteFolder(path: string): Promise<{ success: boolean }> {
+export function deleteFolder(path: string): Promise<MaintenanceDeleteResult> {
 	return apiFetch('/api/maintenance/delete-folder', { method: 'POST', body: JSON.stringify({ path }) });
 }
 
-export function bulkDeleteLogs(paths: string[]): Promise<BulkDeleteResult> {
+export function bulkDeleteLogs(paths: string[]): Promise<MaintenanceBulkDeleteResult> {
 	return apiFetch('/api/maintenance/bulk-delete-logs', { method: 'POST', body: JSON.stringify({ paths }) });
 }
 
-export function bulkDeleteFolders(paths: string[]): Promise<BulkDeleteResult> {
+export function bulkDeleteFolders(paths: string[]): Promise<MaintenanceBulkDeleteResult> {
 	return apiFetch('/api/maintenance/bulk-delete-folders', { method: 'POST', body: JSON.stringify({ paths }) });
 }
 
@@ -73,32 +70,16 @@ export function purgeNotifications(): Promise<{ success: boolean; count: number 
 	return apiFetch('/api/maintenance/purge-notifications', { method: 'POST' });
 }
 
-export function cleanupTranscoder(): Promise<{ success: boolean; deleted: number; errors: string[] }> {
+export function cleanupTranscoder(): Promise<CleanupTranscoderResult> {
 	return apiFetch('/api/maintenance/cleanup-transcoder', { method: 'POST' });
-}
-
-export interface ImageCacheStats {
-	count: number;
-	size_bytes: number;
-	size_mb: number;
-	oldest: number | null;
-	path: string;
 }
 
 export function fetchImageCacheStats(): Promise<ImageCacheStats> {
 	return apiFetch('/api/maintenance/image-cache-stats');
 }
 
-export function clearImageCache(): Promise<{ success: boolean; cleared: number; freed_bytes: number }> {
+export function clearImageCache(): Promise<ImageCacheStats> {
 	return apiFetch('/api/maintenance/clear-image-cache', { method: 'POST' });
-}
-
-export interface ClearRawResult {
-	success: boolean;
-	cleared: number;
-	freed_bytes: number;
-	errors: string[];
-	path: string;
 }
 
 export function clearRaw(): Promise<ClearRawResult> {

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -90,26 +90,6 @@ export type BulkJobRequest = {
 };
 
 /**
- * BulkOperationResult
- *
- * Bulk delete result. Upstream returns `deleted: <int count>`.
- */
-export type BulkOperationResult = {
-    /**
-     * Success
-     */
-    success?: boolean;
-    /**
-     * Deleted
-     */
-    deleted?: number | null;
-    /**
-     * Errors
-     */
-    errors?: Array<string> | null;
-};
-
-/**
  * BulkPathRequest
  */
 export type BulkPathRequest = {
@@ -123,48 +103,58 @@ export type BulkPathRequest = {
  * CleanupTranscoderResult
  *
  * Cleanup-transcoder counts deleted jobs.
+ *
+ * Handler always emits all three fields, so they are required in the
+ * typed shape (no `= ...` defaults that would make codegen mark them
+ * optional).
  */
 export type CleanupTranscoderResult = {
     /**
      * Success
      */
-    success?: boolean;
+    success: boolean;
     /**
      * Deleted
      */
-    deleted?: number;
+    deleted: number;
     /**
      * Errors
      */
-    errors?: Array<string>;
+    errors: Array<string>;
 };
 
 /**
  * ClearRawResult
  *
  * Clear-raw cleared count, bytes freed, and any errors.
+ *
+ * Wire shape is invariant across success/failure (arm-neu PR #322).
  */
 export type ClearRawResult = {
     /**
      * Success
      */
-    success?: boolean;
+    success: boolean;
     /**
      * Cleared
      */
-    cleared?: number;
+    cleared: number;
     /**
      * Freed Bytes
      */
-    freed_bytes?: number;
+    freed_bytes: number;
     /**
      * Errors
      */
-    errors?: Array<string>;
+    errors: Array<string>;
     /**
      * Path
      */
-    path?: string | null;
+    path: string;
+    /**
+     * Error
+     */
+    error: string | null;
 };
 
 /**
@@ -762,10 +752,10 @@ export type HardwareInfoSchema = {
 /**
  * ImageCacheStats
  *
- * Image cache snapshot. image_cache.stats() returns ``count`` and
- * ``size_bytes``; image_cache.clear() returns ``cleared`` (the count
- * of dropped entries). Both keys are surfaced so a single typed model
- * serves both endpoints.
+ * Image cache snapshot. ``stats()`` returns count, size_bytes, size_mb,
+ * oldest, path. ``clear()`` returns success, cleared, freed_bytes. The
+ * superset is modeled with optional fields so a single shape serves both
+ * endpoints.
  */
 export type ImageCacheStats = {
     /**
@@ -777,9 +767,29 @@ export type ImageCacheStats = {
      */
     size_bytes?: number | null;
     /**
+     * Size Mb
+     */
+    size_mb?: number | null;
+    /**
+     * Oldest
+     */
+    oldest?: number | null;
+    /**
+     * Path
+     */
+    path?: string | null;
+    /**
+     * Success
+     */
+    success?: boolean | null;
+    /**
      * Cleared
      */
     cleared?: number | null;
+    /**
+     * Freed Bytes
+     */
+    freed_bytes?: number | null;
 };
 
 /**
@@ -1615,6 +1625,54 @@ export type LogFileSchema = {
 };
 
 /**
+ * MaintenanceBulkDeleteResult
+ *
+ * Bulk delete result (bulk-delete-logs / bulk-delete-folders).
+ *
+ * `success` is True only when no entries failed; partial-failure surfaces
+ * as `success=False` with the failed paths in `errors`. Maintenance
+ * prefix mirrors MaintenanceDeleteResult for grep-friendly cohabitation.
+ */
+export type MaintenanceBulkDeleteResult = {
+    /**
+     * Success
+     */
+    success: boolean;
+    /**
+     * Removed
+     */
+    removed: Array<string>;
+    /**
+     * Errors
+     */
+    errors: Array<string>;
+};
+
+/**
+ * MaintenanceDeleteResult
+ *
+ * Single-target delete result (delete-log / delete-folder).
+ *
+ * Wire shape is invariant across success/failure: `error` is always
+ * present, `None` on success, `str` on failure. Named with a
+ * Maintenance prefix to disambiguate from transcoder.DeleteResult.
+ */
+export type MaintenanceDeleteResult = {
+    /**
+     * Success
+     */
+    success: boolean;
+    /**
+     * Path
+     */
+    path: string;
+    /**
+     * Error
+     */
+    error: string | null;
+};
+
+/**
  * MaintenanceSummary
  */
 export type MaintenanceSummary = {
@@ -1957,11 +2015,15 @@ export type NotificationSchema = {
  *
  * Designed permissively because upstream arm-neu actions return a
  * family of envelopes (``{success}``, ``{success, paused}``,
- * ``{success, count}``, ``{success, deleted, ...}``, etc). Common
- * keys are surfaced for type help; ``extra='allow'`` keeps unknown
- * keys (e.g. ``updated``, ``overrides``) flowing through so callers
- * can read upstream-specific fields. Passthrough hardening into
- * dedicated models is tracked separately.
+ * ``{success, count}``, etc). Common keys are surfaced for type help;
+ * ``extra='allow'`` keeps unknown keys (e.g. ``updated``, ``overrides``)
+ * flowing through so callers can read upstream-specific fields.
+ * Passthrough hardening into dedicated models is tracked separately.
+ *
+ * Single-target delete (delete-log / delete-folder) and bulk delete
+ * (bulk-delete-logs / bulk-delete-folders) now have their own typed
+ * shapes (DeleteResult / BulkDeleteResult) - this model no longer
+ * needs to fit either of those.
  */
 export type OperationResult = {
     /**
@@ -1988,53 +2050,90 @@ export type OperationResult = {
      * Cleared
      */
     cleared?: number | null;
-    /**
-     * Deleted
-     */
-    deleted?: string | number | null;
     [key: string]: unknown;
 };
 
 /**
+ * OrphanFolderEntry
+ */
+export type OrphanFolderEntry = {
+    /**
+     * Path
+     */
+    path: string;
+    /**
+     * Name
+     */
+    name: string;
+    /**
+     * Category
+     */
+    category: string;
+    /**
+     * Size Bytes
+     */
+    size_bytes: number;
+};
+
+/**
  * OrphanFolderList
+ *
+ * Orphan folders from arm-neu /api/v1/maintenance/orphan-folders.
+ *
+ * `roots` carries both scanned roots (RAW + COMPLETED) since orphan-folders
+ * spans two trees, mirroring the single `root` on orphan-logs.
  */
 export type OrphanFolderList = {
     /**
-     * Success
+     * Roots
      */
-    success?: boolean;
+    roots: Array<string>;
     /**
-     * Count
+     * Total Size Bytes
      */
-    count?: number | null;
+    total_size_bytes: number;
     /**
      * Folders
      */
-    folders?: Array<string> | null;
+    folders: Array<OrphanFolderEntry>;
+};
+
+/**
+ * OrphanLogEntry
+ */
+export type OrphanLogEntry = {
+    /**
+     * Path
+     */
+    path: string;
+    /**
+     * Relative Path
+     */
+    relative_path: string;
+    /**
+     * Size Bytes
+     */
+    size_bytes: number;
 };
 
 /**
  * OrphanLogList
  *
- * Orphan logs payload from arm-neu.
- *
- * Real upstream shape is a generic `{success, count, items?}` envelope
- * rather than a typed list - typed permissively here so the BFF can
- * pass it through, and the frontend reads `count` for the badge.
+ * Orphan logs from arm-neu /api/v1/maintenance/orphan-logs.
  */
 export type OrphanLogList = {
     /**
-     * Success
+     * Root
      */
-    success?: boolean;
+    root: string;
     /**
-     * Count
+     * Total Size Bytes
      */
-    count?: number | null;
+    total_size_bytes: number;
     /**
-     * Logs
+     * Files
      */
-    logs?: Array<string> | null;
+    files: Array<OrphanLogEntry>;
 };
 
 /**
@@ -6395,7 +6494,7 @@ export type DeleteLogApiMaintenanceDeleteLogPostResponses = {
     /**
      * Successful Response
      */
-    200: OperationResult;
+    200: MaintenanceDeleteResult;
 };
 
 export type DeleteLogApiMaintenanceDeleteLogPostResponse = DeleteLogApiMaintenanceDeleteLogPostResponses[keyof DeleteLogApiMaintenanceDeleteLogPostResponses];
@@ -6420,7 +6519,7 @@ export type DeleteFolderApiMaintenanceDeleteFolderPostResponses = {
     /**
      * Successful Response
      */
-    200: OperationResult;
+    200: MaintenanceDeleteResult;
 };
 
 export type DeleteFolderApiMaintenanceDeleteFolderPostResponse = DeleteFolderApiMaintenanceDeleteFolderPostResponses[keyof DeleteFolderApiMaintenanceDeleteFolderPostResponses];
@@ -6445,7 +6544,7 @@ export type BulkDeleteLogsApiMaintenanceBulkDeleteLogsPostResponses = {
     /**
      * Successful Response
      */
-    200: BulkOperationResult;
+    200: MaintenanceBulkDeleteResult;
 };
 
 export type BulkDeleteLogsApiMaintenanceBulkDeleteLogsPostResponse = BulkDeleteLogsApiMaintenanceBulkDeleteLogsPostResponses[keyof BulkDeleteLogsApiMaintenanceBulkDeleteLogsPostResponses];
@@ -6470,7 +6569,7 @@ export type BulkDeleteFoldersApiMaintenanceBulkDeleteFoldersPostResponses = {
     /**
      * Successful Response
      */
-    200: BulkOperationResult;
+    200: MaintenanceBulkDeleteResult;
 };
 
 export type BulkDeleteFoldersApiMaintenanceBulkDeleteFoldersPostResponse = BulkDeleteFoldersApiMaintenanceBulkDeleteFoldersPostResponses[keyof BulkDeleteFoldersApiMaintenanceBulkDeleteFoldersPostResponses];

--- a/frontend/src/routes/files/__tests__/files-page.test.ts
+++ b/frontend/src/routes/files/__tests__/files-page.test.ts
@@ -175,6 +175,7 @@ describe('Files Page', () => {
 
 		it('displays folder list in modal', async () => {
 			vi.mocked(fetchOrphanFolders).mockResolvedValueOnce({
+				roots: ['/media/raw', '/media/completed'],
 				total_size_bytes: 5000000,
 				folders: [
 					{ path: '/media/raw/orphan1', name: 'orphan1', size_bytes: 3000000, category: 'raw' },

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -282,7 +282,9 @@
 		cacheConfirmOpen = false;
 		try {
 			const result = await clearImageCache();
-			cacheFeedback = { type: 'success', message: `Cleared ${result.cleared} cached image${result.cleared !== 1 ? 's' : ''} (${(result.freed_bytes / 1048576).toFixed(1)} MB)` };
+			const cleared = result.cleared ?? 0;
+			const freedMb = ((result.freed_bytes ?? 0) / 1048576).toFixed(1);
+			cacheFeedback = { type: 'success', message: `Cleared ${cleared} cached image${cleared !== 1 ? 's' : ''} (${freedMb} MB)` };
 			cacheStats = await fetchImageCacheStats();
 		} catch (e) {
 			cacheFeedback = { type: 'error', message: e instanceof Error ? e.message : 'Failed to clear cache' };

--- a/tests/routers/test_maintenance.py
+++ b/tests/routers/test_maintenance.py
@@ -81,7 +81,11 @@ async def test_summary_arm_unavailable(app_client):
 
 async def test_orphan_logs_success(app_client):
     """GET /api/maintenance/orphan-logs returns log list from ARM."""
-    payload = {"success": True, "logs": ["/var/log/arm/orphan.log"]}
+    payload = {
+        "root": "/var/log/arm",
+        "total_size_bytes": 1024,
+        "files": [{"path": "/var/log/arm/orphan.log", "relative_path": "orphan.log", "size_bytes": 1024}],
+    }
     with patch(
         "backend.routers.maintenance.arm_client.get_orphan_logs",
         new_callable=AsyncMock,
@@ -90,8 +94,9 @@ async def test_orphan_logs_success(app_client):
         resp = await app_client.get("/api/maintenance/orphan-logs")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["success"] is True
-    assert "/var/log/arm/orphan.log" in data["logs"]
+    assert data["root"] == "/var/log/arm"
+    assert data["total_size_bytes"] == 1024
+    assert data["files"][0]["relative_path"] == "orphan.log"
 
 
 async def test_orphan_logs_arm_unreachable(app_client):
@@ -122,7 +127,16 @@ async def test_orphan_logs_arm_error(app_client):
 
 async def test_orphan_folders_success(app_client):
     """GET /api/maintenance/orphan-folders returns folder list from ARM."""
-    payload = {"success": True, "folders": ["/mnt/media/orphan_dir"]}
+    payload = {
+        "roots": ["/mnt/media/raw", "/mnt/media/completed"],
+        "total_size_bytes": 4096,
+        "folders": [{
+            "path": "/mnt/media/raw/orphan_dir",
+            "name": "orphan_dir",
+            "category": "raw",
+            "size_bytes": 4096,
+        }],
+    }
     with patch(
         "backend.routers.maintenance.arm_client.get_orphan_folders",
         new_callable=AsyncMock,
@@ -131,7 +145,8 @@ async def test_orphan_folders_success(app_client):
         resp = await app_client.get("/api/maintenance/orphan-folders")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["success"] is True
+    assert data["roots"] == ["/mnt/media/raw", "/mnt/media/completed"]
+    assert data["folders"][0]["name"] == "orphan_dir"
 
 
 async def test_orphan_folders_arm_unreachable(app_client):
@@ -153,14 +168,17 @@ async def test_delete_log_success(app_client):
     with patch(
         "backend.routers.maintenance.arm_client.delete_orphan_log",
         new_callable=AsyncMock,
-        return_value={"success": True, "deleted": "/var/log/arm/orphan.log"},
+        return_value={"success": True, "path": "orphan.log", "error": None},
     ):
         resp = await app_client.post(
             "/api/maintenance/delete-log",
-            json={"path": "/var/log/arm/orphan.log"},
+            json={"path": "orphan.log"},
         )
     assert resp.status_code == 200
-    assert resp.json()["success"] is True
+    body = resp.json()
+    assert body["success"] is True
+    assert body["error"] is None
+    assert body["path"] == "orphan.log"
 
 
 async def test_delete_log_arm_unreachable(app_client):
@@ -185,14 +203,16 @@ async def test_delete_folder_success(app_client):
     with patch(
         "backend.routers.maintenance.arm_client.delete_orphan_folder",
         new_callable=AsyncMock,
-        return_value={"success": True},
+        return_value={"success": True, "path": "orphan_dir", "error": None},
     ):
         resp = await app_client.post(
             "/api/maintenance/delete-folder",
-            json={"path": "/mnt/media/orphan_dir"},
+            json={"path": "orphan_dir"},
         )
     assert resp.status_code == 200
-    assert resp.json()["success"] is True
+    body = resp.json()
+    assert body["success"] is True
+    assert body["error"] is None
 
 
 # --- POST /api/maintenance/bulk-delete-logs ---
@@ -203,14 +223,17 @@ async def test_bulk_delete_logs_success(app_client):
     with patch(
         "backend.routers.maintenance.arm_client.bulk_delete_logs",
         new_callable=AsyncMock,
-        return_value={"success": True, "deleted": 2},
+        return_value={"success": True, "removed": ["a.log", "b.log"], "errors": []},
     ):
         resp = await app_client.post(
             "/api/maintenance/bulk-delete-logs",
-            json={"paths": ["/var/log/arm/a.log", "/var/log/arm/b.log"]},
+            json={"paths": ["a.log", "b.log"]},
         )
     assert resp.status_code == 200
-    assert resp.json()["success"] is True
+    body = resp.json()
+    assert body["success"] is True
+    assert body["removed"] == ["a.log", "b.log"]
+    assert body["errors"] == []
 
 
 async def test_bulk_delete_logs_arm_unreachable(app_client):
@@ -235,13 +258,16 @@ async def test_bulk_delete_folders_success(app_client):
     with patch(
         "backend.routers.maintenance.arm_client.bulk_delete_folders",
         new_callable=AsyncMock,
-        return_value={"success": True, "deleted": 1},
+        return_value={"success": True, "removed": ["orphan_dir"], "errors": []},
     ):
         resp = await app_client.post(
             "/api/maintenance/bulk-delete-folders",
-            json={"paths": ["/mnt/media/orphan_dir"]},
+            json={"paths": ["orphan_dir"]},
         )
     assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["removed"] == ["orphan_dir"]
 
 
 # --- POST /api/maintenance/dismiss-all-notifications ---
@@ -384,7 +410,14 @@ async def test_clear_raw_success(app_client):
     with patch(
         "backend.routers.maintenance.arm_client.clear_raw",
         new_callable=AsyncMock,
-        return_value={"success": True, "cleared": 3, "freed_bytes": 5000000, "errors": [], "path": "/home/arm/media/raw"},
+        return_value={
+            "success": True,
+            "cleared": 3,
+            "freed_bytes": 5000000,
+            "errors": [],
+            "path": "/home/arm/media/raw",
+            "error": None,
+        },
     ):
         resp = await app_client.post("/api/maintenance/clear-raw")
     assert resp.status_code == 200
@@ -393,6 +426,8 @@ async def test_clear_raw_success(app_client):
     assert data["cleared"] == 3
     assert data["freed_bytes"] == 5000000
     assert data["path"] == "/home/arm/media/raw"
+    assert data["errors"] == []
+    assert data["error"] is None
 
 
 async def test_clear_raw_arm_unreachable(app_client):
@@ -407,11 +442,22 @@ async def test_clear_raw_arm_unreachable(app_client):
 
 
 async def test_clear_raw_arm_error(app_client):
-    """POST /api/maintenance/clear-raw returns 502 when ARM returns error."""
+    """POST /api/maintenance/clear-raw returns 502 when ARM returns error.
+
+    With arm-neu PR #322, the failure path emits the full success-shape with
+    zero defaults plus `error`; the BFF still maps `success=False` to 502.
+    """
     with patch(
         "backend.routers.maintenance.arm_client.clear_raw",
         new_callable=AsyncMock,
-        return_value={"success": False, "error": "RAW_PATH not configured"},
+        return_value={
+            "success": False,
+            "cleared": 0,
+            "freed_bytes": 0,
+            "errors": [],
+            "path": "/nonexistent",
+            "error": "RAW_PATH not configured",
+        },
     ):
         resp = await app_client.post("/api/maintenance/clear-raw")
     assert resp.status_code == 502


### PR DESCRIPTION
## Summary

Tightens BFF maintenance \`response_model\`s to match the new invariant shapes shipped in arm-neu PR #322 (now merged), so codegen flows principled typed shapes through to the frontend instead of the loose permissive shapes from the initial codegen sweep (#284).

Re-opens #285 against \`main\` after parent branch \`feat/frontend-type-codegen\` was deleted on merge.

**Companion PR:** uprightbass360/automatic-ripping-machine-neu#322 (merged)

## Changes

### Backend models

- \`OrphanLogList\` -> \`{root, total_size_bytes, files: list[OrphanLogEntry]}\`
- \`OrphanFolderList\` -> \`{roots, total_size_bytes, folders: list[OrphanFolderEntry]}\` (new \`roots: list[str]\` field for symmetry with orphan-logs)
- \`MaintenanceDeleteResult\` -> \`{success, path, error: str | None}\` invariant across success/failure
- \`MaintenanceBulkDeleteResult\` -> \`{success, removed, errors}\` invariant
- \`ClearRawResult\` -> full success-shape including \`error: str | None\` (invariant)
- \`CleanupTranscoderResult\` -> required fields, no defaults
- \`ImageCacheStats\` expanded with \`size_mb / oldest / path / freed_bytes\`
- \`files.OperationResult\` -> dropped \`deleted: str | int | None\` union (the only reason it had one was the maintenance delete endpoints, which now have dedicated shapes)

### Frontend

- \`lib/api/maintenance.ts\`: import generated types from \`api.gen.ts\`; legacy hand-type names kept as aliases so all call sites stay untouched
- Files-page test fixture: add \`roots\` to orphan-folders mock
- Settings page: ?? guards for \`freed_bytes\` / \`cleared\` after \`clearImageCache\`
- \`api.gen.ts\` regenerated

## Tests

- 645/645 backend pass
- 910/910 frontend vitest pass
- 0 svelte-check errors

## Test plan

- [ ] Manual: orphan-folders modal shows entries from both raw and completed roots
- [ ] Manual: bulk-delete reports \`success: false\` on partial failure
- [ ] Manual: clear-raw failure path shows zero counts (not undefined) in UI feedback