### PR TITLE
feat(ui): visual job lifecycle widget on dashboard + detail page

### DIFF
--- a/frontend/src/lib/__tests__/job-lifecycle.test.ts
+++ b/frontend/src/lib/__tests__/job-lifecycle.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+	deriveLifecycle,
+	isFolderImport,
+	lifecycleColorVar
+} from '$lib/utils/job-lifecycle';
+
+describe('deriveLifecycle - disc rip 5-step', () => {
+	it('waiting -> first stage active, rest pending', () => {
+		const nodes = deriveLifecycle('waiting', 'disc');
+		expect(nodes.map((n) => n.id)).toEqual([
+			'waiting', 'identifying', 'ripping', 'transcoding', 'complete'
+		]);
+		expect(nodes[0].state).toBe('active');
+		expect(nodes.slice(1).every((n) => n.state === 'pending')).toBe(true);
+	});
+
+	it('identifying / info -> first completed, second active', () => {
+		const fromInfo = deriveLifecycle('info', 'disc');
+		expect(fromInfo[0].state).toBe('completed');
+		expect(fromInfo[1].state).toBe('active');
+		expect(fromInfo.slice(2).every((n) => n.state === 'pending')).toBe(true);
+	});
+
+	it('video_ripping -> first two completed, ripping active', () => {
+		const nodes = deriveLifecycle('video_ripping', 'disc');
+		expect(nodes[0].state).toBe('completed');
+		expect(nodes[1].state).toBe('completed');
+		expect(nodes[2].state).toBe('active');
+		expect(nodes.slice(3).every((n) => n.state === 'pending')).toBe(true);
+	});
+
+	it('legacy ripping wire string maps to ripping stage', () => {
+		const nodes = deriveLifecycle('ripping', 'disc');
+		expect(nodes[2].state).toBe('active');
+	});
+
+	it('audio_ripping maps to ripping stage', () => {
+		const nodes = deriveLifecycle('audio_ripping', 'disc');
+		expect(nodes[2].state).toBe('active');
+	});
+
+	it('makemkv_throttled maps to waiting stage (active)', () => {
+		const nodes = deriveLifecycle('makemkv_throttled', 'disc');
+		expect(nodes[0].state).toBe('active');
+	});
+
+	it('waiting_transcode maps to waiting stage (active)', () => {
+		// waiting_transcode is the post-rip pre-transcode wait; we paint it on
+		// the waiting node so the user sees "still waiting on something".
+		const nodes = deriveLifecycle('waiting_transcode', 'disc');
+		expect(nodes[0].state).toBe('active');
+	});
+
+	it('transcoding -> first three completed, transcoding active', () => {
+		const nodes = deriveLifecycle('transcoding', 'disc');
+		expect(nodes.slice(0, 3).every((n) => n.state === 'completed')).toBe(true);
+		expect(nodes[3].state).toBe('active');
+		expect(nodes[4].state).toBe('pending');
+	});
+
+	it('finishing maps to transcoding stage', () => {
+		const nodes = deriveLifecycle('finishing', 'disc');
+		expect(nodes[3].state).toBe('active');
+	});
+
+	it('success -> all five completed', () => {
+		const nodes = deriveLifecycle('success', 'disc');
+		expect(nodes.every((n) => n.state === 'completed')).toBe(true);
+	});
+});
+
+describe('deriveLifecycle - failure', () => {
+	it('fail snapshot paints last non-complete stage as failed', () => {
+		const nodes = deriveLifecycle('fail', 'disc');
+		// failed on the stage just before complete (transcoding for disc)
+		expect(nodes[3].state).toBe('failed');
+		expect(nodes[4].state).toBe('pending');
+		// earlier stages marked completed (heuristic: we don't know where it
+		// actually died, but the last reachable stage carries the failed marker)
+		expect(nodes.slice(0, 3).every((n) => n.state === 'completed')).toBe(true);
+	});
+
+	it('failed / failure / error all treated as failure', () => {
+		for (const s of ['failed', 'failure', 'error']) {
+			const nodes = deriveLifecycle(s, 'disc');
+			expect(nodes[3].state).toBe('failed');
+		}
+	});
+
+	it('folder import failure paints last non-complete stage too', () => {
+		const nodes = deriveLifecycle('fail', 'folder');
+		// 4 stages: waiting, identifying, transcoding, complete
+		expect(nodes.map((n) => n.id)).toEqual([
+			'waiting', 'identifying', 'transcoding', 'complete'
+		]);
+		expect(nodes[2].state).toBe('failed'); // transcoding (index 2, before complete)
+	});
+});
+
+describe('deriveLifecycle - paused', () => {
+	it('manual_paused paints active stage with paused state', () => {
+		const nodes = deriveLifecycle('manual_paused', 'disc');
+		expect(nodes[0].state).toBe('paused');
+	});
+});
+
+describe('deriveLifecycle - folder imports', () => {
+	it('folder source skips the ripping stage', () => {
+		const nodes = deriveLifecycle('transcoding', 'folder');
+		expect(nodes.map((n) => n.id)).toEqual([
+			'waiting', 'identifying', 'transcoding', 'complete'
+		]);
+		expect(nodes[2].state).toBe('active');
+	});
+
+	it('importing wire string on folder source has no ripping node so falls through to pending', () => {
+		// Importing maps to the ripping stage but the folder-import lifecycle
+		// excludes that node; we render fully pending rather than misplace.
+		const nodes = deriveLifecycle('importing', 'folder');
+		expect(nodes.length).toBe(4);
+		expect(nodes.every((n) => n.state === 'pending')).toBe(true);
+	});
+});
+
+describe('deriveLifecycle - edge cases', () => {
+	it('null status renders fully pending', () => {
+		const nodes = deriveLifecycle(null, 'disc');
+		expect(nodes.every((n) => n.state === 'pending')).toBe(true);
+	});
+
+	it('unknown status renders fully pending', () => {
+		const nodes = deriveLifecycle('weird-state', 'disc');
+		expect(nodes.every((n) => n.state === 'pending')).toBe(true);
+	});
+
+	it('case-insensitive status matching', () => {
+		const upper = deriveLifecycle('TRANSCODING', 'disc');
+		expect(upper[3].state).toBe('active');
+	});
+});
+
+describe('isFolderImport', () => {
+	it('identifies folder source_type', () => {
+		expect(isFolderImport('folder')).toBe(true);
+		expect(isFolderImport('disc')).toBe(false);
+		expect(isFolderImport(null)).toBe(false);
+		expect(isFolderImport(undefined)).toBe(false);
+	});
+});
+
+describe('lifecycleColorVar', () => {
+	it('maps each state to a distinct CSS var', () => {
+		const colors = ['completed', 'active', 'paused', 'failed', 'pending'].map(
+			(s) => lifecycleColorVar(s as never)
+		);
+		// All distinct
+		expect(new Set(colors).size).toBe(colors.length);
+	});
+
+	it('uses theme tokens for known statuses', () => {
+		expect(lifecycleColorVar('completed')).toContain('--color-status-success');
+		expect(lifecycleColorVar('failed')).toContain('--color-status-error');
+		expect(lifecycleColorVar('active')).toContain('--color-status-ripping');
+	});
+});

--- a/frontend/src/lib/components/JobCard.svelte
+++ b/frontend/src/lib/components/JobCard.svelte
@@ -8,6 +8,7 @@
 	import { getVideoTypeConfig, isJobActive, discTypeLabel } from '$lib/utils/job-type';
 	import DiscTypeIcon from './DiscTypeIcon.svelte';
 	import SkeletonCard from './SkeletonCard.svelte';
+	import JobLifecycle from './JobLifecycle.svelte';
 
 	interface Props {
 		job?: Job;
@@ -65,6 +66,7 @@
 			<!-- Row 3: Active → stage/titles/elapsed; Completed → duration/finish -->
 			<div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
 				{#if active}
+					<JobLifecycle status={job.status} sourceType={job.source_type} size="sm" />
 					{#if job.stage}
 						<span class="rounded-sm bg-primary-light-bg px-1.5 py-0.5 font-medium text-primary-text dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">{job.stage}</span>
 					{/if}

--- a/frontend/src/lib/components/JobLifecycle.svelte
+++ b/frontend/src/lib/components/JobLifecycle.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { deriveLifecycle, lifecycleColorVar } from '$lib/utils/job-lifecycle';
+	import { Pause } from 'lucide-svelte';
+
+	interface Props {
+		status: string | null | undefined;
+		sourceType: string | null | undefined;
+		size?: 'sm' | 'md';
+	}
+
+	let { status, sourceType, size = 'md' }: Props = $props();
+
+	let nodes = $derived(deriveLifecycle(status, sourceType));
+</script>
+
+{#if size === 'sm'}
+	<!-- Compact horizontal segments for the dashboard JobCard.
+	     Each segment is a colored bar; the active one pulses; failure
+	     segments use the error theme token. No labels rendered. -->
+	<div
+		class="inline-flex items-center gap-0.5"
+		role="img"
+		aria-label="Job lifecycle"
+		title={nodes.map((n) => `${n.label}: ${n.state}`).join(' · ')}
+	>
+		{#each nodes as node (node.id)}
+			<span
+				class="relative h-1.5 w-6 rounded-sm {node.state === 'active' ? 'lifecycle-pulse' : ''}"
+				style="background: {lifecycleColorVar(node.state)}; opacity: {node.state === 'pending' ? 0.35 : 1}"
+			>
+				{#if node.state === 'paused'}
+					<Pause
+						class="absolute -top-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 text-[var(--color-status-waiting)]"
+					/>
+				{/if}
+			</span>
+		{/each}
+	</div>
+{:else}
+	<!-- Detail-page sized: pills with labels and connector lines. -->
+	<ol
+		class="flex items-center gap-1.5 text-xs"
+		role="list"
+		aria-label="Job lifecycle"
+	>
+		{#each nodes as node, i (node.id)}
+			<li class="flex items-center gap-1.5">
+				<span
+					class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium {node.state ===
+					'active'
+						? 'lifecycle-pulse'
+						: ''}"
+					style="background: {node.state === 'pending'
+						? 'transparent'
+						: lifecycleColorVar(node.state)}; color: {node.state === 'pending'
+						? 'var(--color-status-pending, #9ca3af)'
+						: 'white'}; border: 1px solid {lifecycleColorVar(node.state)}; opacity: {node.state ===
+					'pending'
+						? 0.55
+						: 1}"
+					title={`${node.label}: ${node.state}`}
+				>
+					{#if node.state === 'paused'}
+						<Pause class="h-3 w-3" />
+					{/if}
+					{node.label}
+				</span>
+				{#if i < nodes.length - 1}
+					<span
+						class="inline-block h-px w-3"
+						style="background: {lifecycleColorVar(
+							node.state === 'completed' ? 'completed' : 'pending'
+						)}"
+						aria-hidden="true"
+					></span>
+				{/if}
+			</li>
+		{/each}
+	</ol>
+{/if}
+
+<style>
+	.lifecycle-pulse {
+		animation: lifecyclePulse 1.4s ease-in-out infinite;
+	}
+	@keyframes lifecyclePulse {
+		0%, 100% {
+			filter: brightness(1);
+		}
+		50% {
+			filter: brightness(1.3);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/JobLifecycle.test.ts
+++ b/frontend/src/lib/components/JobLifecycle.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import JobLifecycle from './JobLifecycle.svelte';
+
+describe('JobLifecycle', () => {
+	afterEach(() => cleanup());
+
+	describe('size=md', () => {
+		it('renders 5 stages for disc rip with stage labels', () => {
+			renderComponent(JobLifecycle, {
+				props: { status: 'video_ripping', sourceType: 'disc' }
+			});
+			expect(screen.getByText('Waiting')).toBeInTheDocument();
+			expect(screen.getByText('Identifying')).toBeInTheDocument();
+			expect(screen.getByText('Ripping')).toBeInTheDocument();
+			expect(screen.getByText('Transcoding')).toBeInTheDocument();
+			expect(screen.getByText('Complete')).toBeInTheDocument();
+		});
+
+		it('renders 4 stages for folder import (no Ripping node)', () => {
+			renderComponent(JobLifecycle, {
+				props: { status: 'transcoding', sourceType: 'folder' }
+			});
+			expect(screen.getByText('Waiting')).toBeInTheDocument();
+			expect(screen.getByText('Identifying')).toBeInTheDocument();
+			expect(screen.queryByText('Ripping')).toBeNull();
+			expect(screen.getByText('Transcoding')).toBeInTheDocument();
+			expect(screen.getByText('Complete')).toBeInTheDocument();
+		});
+
+		it('marks the active stage with pulse animation class', () => {
+			const { container } = renderComponent(JobLifecycle, {
+				props: { status: 'transcoding', sourceType: 'disc' }
+			});
+			const pulsing = container.querySelectorAll('.lifecycle-pulse');
+			// Exactly one stage should be actively pulsing
+			expect(pulsing.length).toBe(1);
+		});
+
+		it('does not pulse on terminal failure', () => {
+			const { container } = renderComponent(JobLifecycle, {
+				props: { status: 'fail', sourceType: 'disc' }
+			});
+			const pulsing = container.querySelectorAll('.lifecycle-pulse');
+			expect(pulsing.length).toBe(0);
+		});
+
+		it('does not pulse on success', () => {
+			const { container } = renderComponent(JobLifecycle, {
+				props: { status: 'success', sourceType: 'disc' }
+			});
+			const pulsing = container.querySelectorAll('.lifecycle-pulse');
+			expect(pulsing.length).toBe(0);
+		});
+	});
+
+	describe('size=sm', () => {
+		it('renders without text labels for compact display', () => {
+			renderComponent(JobLifecycle, {
+				props: { status: 'transcoding', sourceType: 'disc', size: 'sm' }
+			});
+			// No stage labels in DOM in sm mode - they live on the title attribute only
+			expect(screen.queryByText('Transcoding')).toBeNull();
+			expect(screen.queryByText('Waiting')).toBeNull();
+		});
+
+		it('exposes lifecycle as accessible aria-label', () => {
+			renderComponent(JobLifecycle, {
+				props: { status: 'transcoding', sourceType: 'disc', size: 'sm' }
+			});
+			const widget = screen.getByRole('img', { name: 'Job lifecycle' });
+			expect(widget).toBeInTheDocument();
+			// Title attr carries the per-stage state for hover tooltip
+			expect(widget.getAttribute('title')).toContain('Transcoding: active');
+		});
+
+		it('renders the same number of segments as nodes', () => {
+			const { container } = renderComponent(JobLifecycle, {
+				props: { status: 'transcoding', sourceType: 'disc', size: 'sm' }
+			});
+			// 5 segments for disc rip
+			const segments = container.querySelectorAll('span.relative');
+			expect(segments.length).toBe(5);
+		});
+	});
+
+	describe('paused state', () => {
+		it('shows pause icon on the active stage', () => {
+			const { container } = renderComponent(JobLifecycle, {
+				props: { status: 'manual_paused', sourceType: 'disc' }
+			});
+			// Lucide Pause renders as an svg with class containing 'lucide-pause'
+			const pauseIcons = container.querySelectorAll('svg.lucide-pause');
+			expect(pauseIcons.length).toBe(1);
+		});
+	});
+});

--- a/frontend/src/lib/utils/job-lifecycle.ts
+++ b/frontend/src/lib/utils/job-lifecycle.ts
@@ -1,0 +1,147 @@
+/**
+ * Coarse 5-step lifecycle for visual progress display:
+ * Waiting -> Identifying -> Ripping -> Transcoding -> Complete
+ *
+ * Folder imports skip the Ripping node (4 nodes total).
+ *
+ * Maps the disambiguated v2.0.0 JobState wire strings (and legacy pre-v2
+ * strings, defensive) to lifecycle stages. Failures paint the active
+ * stage with the failure color; subsequent stages stay pending. Paused
+ * jobs surface a pause icon overlay on the active stage.
+ */
+
+export type LifecycleStageId =
+	| 'waiting'
+	| 'identifying'
+	| 'ripping'
+	| 'transcoding'
+	| 'complete';
+
+export type LifecycleNodeState =
+	| 'completed'
+	| 'active'
+	| 'paused'
+	| 'failed'
+	| 'pending';
+
+export interface LifecycleNode {
+	id: LifecycleStageId;
+	label: string;
+	state: LifecycleNodeState;
+}
+
+const ALL_STAGES: { id: LifecycleStageId; label: string }[] = [
+	{ id: 'waiting',      label: 'Waiting' },
+	{ id: 'identifying',  label: 'Identifying' },
+	{ id: 'ripping',      label: 'Ripping' },
+	{ id: 'transcoding',  label: 'Transcoding' },
+	{ id: 'complete',     label: 'Complete' }
+];
+
+const FOLDER_STAGES: { id: LifecycleStageId; label: string }[] = [
+	{ id: 'waiting',      label: 'Waiting' },
+	{ id: 'identifying',  label: 'Identifying' },
+	{ id: 'transcoding',  label: 'Transcoding' },
+	{ id: 'complete',     label: 'Complete' }
+];
+
+const STATUS_TO_STAGE: Record<string, LifecycleStageId> = {
+	// Waiting
+	'waiting':            'waiting',          // legacy pre-v2.0.0
+	'manual_paused':      'waiting',
+	'makemkv_throttled':  'waiting',
+	'waiting_transcode':  'waiting',
+	'pending':            'waiting',
+	'ready':              'waiting',
+	// Identifying
+	'info':               'identifying',
+	'identifying':        'identifying',
+	// Ripping (disc rip)
+	'ripping':            'ripping',          // legacy pre-v2.0.0
+	'video_ripping':      'ripping',
+	'audio_ripping':      'ripping',
+	'copying':            'ripping',
+	'ejecting':           'ripping',
+	'importing':          'ripping',
+	// Transcoding
+	'transcoding':        'transcoding',
+	'finishing':          'transcoding',
+	'processing':         'transcoding',
+	// Complete
+	'success':            'complete',
+	'completed':          'complete',
+	'complete':           'complete',
+	'transcoded':         'complete'
+};
+
+const FAILURE_STATUSES = new Set(['fail', 'failed', 'failure', 'error']);
+const PAUSED_STATUSES = new Set(['manual_paused']);
+
+export function isFolderImport(sourceType: string | null | undefined): boolean {
+	return sourceType === 'folder';
+}
+
+/**
+ * Compute the lifecycle node list for a job. Caller passes the snapshot
+ * status + source_type; we derive the active stage and paint earlier
+ * stages as completed, later stages as pending.
+ *
+ * Failure heuristic: when the snapshot is a failure status we don't have
+ * which stage failed in (no history), so we paint the *last reachable*
+ * non-complete stage as failed. The complete node stays pending.
+ */
+export function deriveLifecycle(
+	status: string | null | undefined,
+	sourceType: string | null | undefined
+): LifecycleNode[] {
+	const stages = isFolderImport(sourceType) ? FOLDER_STAGES : ALL_STAGES;
+	const lower = (status ?? '').toLowerCase();
+
+	if (FAILURE_STATUSES.has(lower)) {
+		// Failure snapshot: paint the last non-complete stage red.
+		const failIndex = stages.length - 2; // index of stage before 'complete'
+		return stages.map((s, i) => ({
+			...s,
+			state: i < failIndex ? 'completed' : i === failIndex ? 'failed' : 'pending'
+		}));
+	}
+
+	const stageId = STATUS_TO_STAGE[lower];
+	if (!stageId) {
+		// Unknown status: render fully pending.
+		return stages.map((s) => ({ ...s, state: 'pending' as const }));
+	}
+
+	const activeIndex = stages.findIndex((s) => s.id === stageId);
+	if (activeIndex < 0) {
+		// Stage maps to one not in this lifecycle (e.g. ripping on a folder import).
+		// Fall back to pending.
+		return stages.map((s) => ({ ...s, state: 'pending' as const }));
+	}
+
+	const isPaused = PAUSED_STATUSES.has(lower);
+	const isComplete = stageId === 'complete';
+
+	return stages.map((s, i) => {
+		if (isComplete) {
+			return { ...s, state: 'completed' as const };
+		}
+		if (i < activeIndex) return { ...s, state: 'completed' as const };
+		if (i === activeIndex) return { ...s, state: isPaused ? 'paused' as const : 'active' as const };
+		return { ...s, state: 'pending' as const };
+	});
+}
+
+/**
+ * CSS variable reference for a node state; reuses the existing
+ * --color-status-* tokens that StatusBadge / JobCard / DriveCard use.
+ */
+export function lifecycleColorVar(state: LifecycleNodeState): string {
+	switch (state) {
+		case 'completed': return 'var(--color-status-success)';
+		case 'active':    return 'var(--color-status-ripping)';
+		case 'paused':    return 'var(--color-status-waiting)';
+		case 'failed':    return 'var(--color-status-error)';
+		case 'pending':   return 'var(--color-status-pending, #9ca3af)';
+	}
+}

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -19,6 +19,7 @@
 	import CrcLookup from '$lib/components/CrcLookup.svelte';
 	import InlineLogFeed from '$lib/components/InlineLogFeed.svelte';
 	import TrackTitleSearch from '$lib/components/TrackTitleSearch.svelte';
+	import JobLifecycle from '$lib/components/JobLifecycle.svelte';
 	import EpisodeMatch from '$lib/components/EpisodeMatch.svelte';
 	import { formatDateTime, timeAgo, statusLabel } from '$lib/utils/format';
 	import { discTypeLabel, isJobActive } from '$lib/utils/job-type';
@@ -420,6 +421,11 @@
 
 		<!-- Main header container -->
 		<div class="rounded-lg border border-primary/20 bg-surface shadow-xs overflow-hidden dark:border-primary/20 dark:bg-surface-dark">
+
+			<!-- Lifecycle bar -->
+			<div class="border-b border-primary/15 px-5 py-2.5 dark:border-primary/15">
+				<JobLifecycle status={job.status} sourceType={job.source_type} size="md" />
+			</div>
 
 			<!-- Title bar -->
 			<div class="flex flex-wrap items-center gap-2 border-b border-primary/15 px-5 py-3 dark:border-primary/15">


### PR DESCRIPTION
## Summary

Adds a coarse 5-step lifecycle visualization so users can see at a glance which phase a job is in: \`Waiting -> Identifying -> Ripping -> Transcoding -> Complete\`.

## Sizes

**\`size=\"md\"\` (job detail page)** - labelled pills with connector lines:

\`\`\`
[Waiting] - [Identifying] - [Ripping] - [Transcoding] - [Complete]
\`\`\`

**\`size=\"sm\"\` (dashboard JobCard)** - compact horizontal segments without labels, slot into the existing meta row alongside elapsed time. \`aria-label\` + tooltip carry the per-stage state.

## State semantics

- **completed** (passed) - \`--color-status-success\`
- **active** (current) - \`--color-status-ripping\`, gentle pulse animation
- **paused** (\`manual_paused\`) - Pause icon overlay
- **failed** - \`--color-status-error\` on last reachable stage
- **pending** - dim grey

## Lifecycle mapping

Reads the disambiguated v2.0.0 JobState wire strings (with legacy pre-v2 fallbacks). Folder imports skip the Ripping node so they render 4 stages.

| Stage | JobState members |
|---|---|
| Waiting | \`waiting\`, \`waiting_transcode\`, \`manual_paused\`, \`makemkv_throttled\` |
| Identifying | \`info\` |
| Ripping | \`ripping\`, \`video_ripping\`, \`audio_ripping\`, \`copying\`, \`ejecting\`, \`importing\` |
| Transcoding | \`transcoding\`, \`finishing\` |
| Complete | \`success\` |

## Verification

Locally tested via Playwright on a fresh build, capturing all 4 visual states:
- Waiting (only first node active)
- Identifying (Waiting -> green, Identifying -> active blue)
- Failed (4 green, 5th red, last dim)
- Success (all green)

## Tests

- 22 unit tests covering state derivation across all JobState members + folder-import path + paused + failed + edge cases (null/unknown/case-insensitive)
- 9 component render tests for both size variants + paused icon + accessibility role/label
- 0 svelte-check errors
- 941/941 frontend vitest pass (up 31)

## Test plan

- [x] Local render verified across 4 states
- [ ] Verify pulse animation on active stage in browser
- [ ] Verify paused state on a real \`manual_paused\` job (production)