### PR TITLE
feat(ui): job-detail lifecycle as title-above-bar blocks below header

### DIFF
--- a/frontend/src/lib/components/JobLifecycle.svelte
+++ b/frontend/src/lib/components/JobLifecycle.svelte
@@ -37,43 +37,33 @@
 		{/each}
 	</div>
 {:else}
-	<!-- Detail-page sized: pills with labels and connector lines. -->
+	<!-- Detail-page sized: each stage is a block with the label above a
+	     small colored bar. Stages laid out side-by-side. -->
 	<ol
-		class="flex items-center gap-1.5 text-xs"
+		class="grid w-full gap-2 text-xs"
+		style="grid-template-columns: repeat({nodes.length}, minmax(0, 1fr));"
 		role="list"
 		aria-label="Job lifecycle"
 	>
-		{#each nodes as node, i (node.id)}
-			<li class="flex items-center gap-1.5">
-				<span
-					class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium {node.state ===
-					'active'
-						? 'lifecycle-pulse'
-						: ''}"
-					style="background: {node.state === 'pending'
-						? 'transparent'
-						: lifecycleColorVar(node.state)}; color: {node.state === 'pending'
+		{#each nodes as node (node.id)}
+			<li class="flex flex-col gap-1.5" title={`${node.label}: ${node.state}`}>
+				<div class="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider"
+					style="color: {node.state === 'pending'
 						? 'var(--color-status-pending, #9ca3af)'
-						: 'white'}; border: 1px solid {lifecycleColorVar(node.state)}; opacity: {node.state ===
-					'pending'
-						? 0.55
-						: 1}"
-					title={`${node.label}: ${node.state}`}
+						: node.state === 'failed'
+						? 'var(--color-status-error)'
+						: 'var(--color-text, currentColor)'}; opacity: {node.state === 'pending' ? 0.55 : 1}"
 				>
 					{#if node.state === 'paused'}
 						<Pause class="h-3 w-3" />
 					{/if}
-					{node.label}
-				</span>
-				{#if i < nodes.length - 1}
-					<span
-						class="inline-block h-px w-3"
-						style="background: {lifecycleColorVar(
-							node.state === 'completed' ? 'completed' : 'pending'
-						)}"
-						aria-hidden="true"
-					></span>
-				{/if}
+					<span class="truncate">{node.label}</span>
+				</div>
+				<span
+					class="block h-2 w-full rounded-sm {node.state === 'active' ? 'lifecycle-pulse' : ''}"
+					style="background: {lifecycleColorVar(node.state)}; opacity: {node.state === 'pending' ? 0.35 : 1}"
+					aria-hidden="true"
+				></span>
 			</li>
 		{/each}
 	</ol>

--- a/frontend/src/routes/jobs/[id]/+page.svelte
+++ b/frontend/src/routes/jobs/[id]/+page.svelte
@@ -422,11 +422,6 @@
 		<!-- Main header container -->
 		<div class="rounded-lg border border-primary/20 bg-surface shadow-xs overflow-hidden dark:border-primary/20 dark:bg-surface-dark">
 
-			<!-- Lifecycle bar -->
-			<div class="border-b border-primary/15 px-5 py-2.5 dark:border-primary/15">
-				<JobLifecycle status={job.status} sourceType={job.source_type} size="md" />
-			</div>
-
 			<!-- Title bar -->
 			<div class="flex flex-wrap items-center gap-2 border-b border-primary/15 px-5 py-3 dark:border-primary/15">
 				<h1 class="text-xl font-bold text-gray-900 dark:text-white">
@@ -580,6 +575,11 @@
 					<TranscodeOverrides {job} onsaved={loadJob} />
 				</div>
 			{/if}
+		</div>
+
+		<!-- Lifecycle widget: visual stage progression below header, above status bars -->
+		<div class="rounded-lg border border-primary/20 bg-surface px-4 py-3 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
+			<JobLifecycle status={job.status} sourceType={job.source_type} size="md" />
 		</div>
 
 		<!-- Progress widget: ripping, copying, waiting_transcode, transcoding -->


### PR DESCRIPTION
## Summary

Iteration on the lifecycle widget shipped in #287:

- **DOM placement**: moved out of the detail-page header container into its own bordered card sitting below the header and above the status/progress widget area.
- **Visual treatment**: each stage is now a small block with the stage label (uppercase, tracking-wider) above a thin colored bar, instead of a row of pills with connector lines.
- Same theme tokens, same pulse-on-active, same pause-icon overlay - only the layout changed.

## Verification

- Built locally and pointed the BFF at the live hifi-server arm-neu API.
- Verified visually:
  - Disc rip success (jobs/185): 5 green bars - WAITING / IDENTIFYING / RIPPING / TRANSCODING / COMPLETE.
  - Folder import success (jobs/175): 4 green bars (no RIPPING) - WAITING / IDENTIFYING / TRANSCODING / COMPLETE.
- 941/941 frontend tests pass.
- 0 svelte-check errors.

## Test plan

- [ ] Render verified on at least one active disc rip and one folder import on the deployed RC.
- [ ] Failure state paints last non-complete stage red on at least one historical \`fail\` job.