### PR TITLE
fix(dashboard): show transcode % on All Jobs card

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -73,6 +73,18 @@
 	}));
 
 	let progressMap = $state<Record<number, RipProgress>>({});
+	// Transcode progress keyed by ARM job_id, so the All Jobs grid can show a
+	// real percentage for "transcoding" cards (which the rip-side progressMap
+	// has no value for). Per the unified-ID schema, transcoder.id == arm.job_id
+	// for webhook-originated jobs.
+	let transcodeProgressMap = $derived<Record<number, number>>(
+		(dash.active_transcodes ?? []).reduce((acc, tc) => {
+			if (typeof tc.id === 'number' && typeof tc.progress === 'number') {
+				acc[tc.id] = tc.progress;
+			}
+			return acc;
+		}, {} as Record<number, number>)
+	);
 
 	function dismissJob(jobId: number) {
 		dismissedJobIds = new Set([...dismissedJobIds, jobId]);
@@ -592,7 +604,7 @@
 					{:else}
 						<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
 							{#each jobs as job (job.job_id)}
-								<JobCard {job} driveNames={dash.drive_names} progress={overallProgress(progressMap[job.job_id])} progressStage={progressMap[job.job_id]?.stage} />
+								<JobCard {job} driveNames={dash.drive_names} progress={overallProgress(progressMap[job.job_id]) ?? transcodeProgressMap[job.job_id] ?? null} progressStage={progressMap[job.job_id]?.stage} />
 							{/each}
 						</div>
 					{/if}


### PR DESCRIPTION
## Summary
- All Jobs grid card for a transcoding job rendered only the indeterminate marquee bar with no percentage.
- The dashboard's \`progressMap\` only holds rip-side progress (from \`fetchJobProgress\` against arm-neu); transcode progress lives separately on \`dash.active_transcodes\`.
- Build a derived \`transcodeProgressMap\` keyed by ARM \`job_id\` (transcoder \`id\` == arm \`job_id\` for webhook-originated jobs, per the unified-ID schema) and fall back to it when \`progressMap\` has no entry. The card now shows the same percentage that the dashboard's TRANSCODING strip already displays.

## Test plan
- [x] \`npm run check\` clean (only pre-existing DriveCard \$state warning)
- [x] \`JobCard.test.ts\` + \`dashboard-page.test.ts\` pass (64/64)
- [ ] Verify on hifi after deploy: All Jobs card for an actively-transcoding job shows the same % as the top TRANSCODING strip