### PR TITLE
fix(quality): clear SonarCloud gate on main (float ==, generated file)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.python.version=3.12
-sonar.cpd.exclusions=**/stores/colorScheme.ts,**/__tests__/**,**/*.test.ts
+sonar.exclusions=**/*.gen.ts
+sonar.cpd.exclusions=**/stores/colorScheme.ts,**/__tests__/**,**/*.test.ts,**/*.gen.ts

--- a/tests/services/test_transcoder_client_shape.py
+++ b/tests/services/test_transcoder_client_shape.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from backend.models.transcoder import (
     TranscoderJobListResponse,
     TranscoderStatsResponse,
@@ -32,7 +34,7 @@ def test_job_list_shape_matches_contract():
     job = parsed.jobs[0]
     assert job.id == 1
     assert job.status == "processing"
-    assert job.progress == 42.5
+    assert job.progress == pytest.approx(42.5)
 
 
 def test_stats_shape_matches_contract():


### PR DESCRIPTION
## Summary

The SonarCloud gate on `main` is failing with two errors:

- **Reliability C** (required A): `python:S1244` flagged a float `==` in `tests/services/test_transcoder_client_shape.py:35`
- **Duplication 3.9%** (required ≤ 3%): driven entirely by `frontend/src/lib/types/api.gen.ts` (528 duplicated lines, 2 blocks)

Both fixes are mechanical.

### Fix 1 - float equality

Switch `assert job.progress == 42.5` to `pytest.approx(42.5)`. This matches the convention already used in `tests/routers/test_transcoder.py:358` for the exact same fixture value.

### Fix 2 - exclude generated code

`frontend/src/lib/types/api.gen.ts` is regenerated by `scripts/codegen.sh` from the BFF FastAPI OpenAPI schema (`@hey-api/openapi-ts` pipeline, banner says `// DO NOT EDIT`). It should not count toward any new-code metric. Add `**/*.gen.ts` to both `sonar.exclusions` and `sonar.cpd.exclusions`.

## Test plan

- [x] `pytest tests/services/test_transcoder_client_shape.py -v` - 2/2 pass
- [x] `pytest tests/` - 659/659 pass
- [ ] Sonar PR scan reports `Reliability A` and `Duplication < 3%`