### PR TITLE
feat(ui): split unidentified-disc fallback into Video and Disc pills

### DIFF
--- a/frontend/src/lib/__tests__/job-type.test.ts
+++ b/frontend/src/lib/__tests__/job-type.test.ts
@@ -23,6 +23,38 @@ describe('getVideoTypeConfig', () => {
 	it('returns fallback for unknown type', () => {
 		expect(getVideoTypeConfig('audiobook').label).toBe('Disc');
 	});
+
+	it('uses Video fallback when video_type is unknown but disctype is video', () => {
+		// ARM knows it's a video disc, classification still pending - the
+		// cyan "Video" pill signals "we know it's video, not what kind"
+		// instead of presuming "Movie" or showing generic "Disc".
+		const dvd = getVideoTypeConfig(null, 'dvd');
+		expect(dvd.label).toBe('Video');
+		expect(dvd.badgeClasses).toContain('cyan');
+		expect(getVideoTypeConfig('unknown', 'bluray').label).toBe('Video');
+		expect(getVideoTypeConfig(undefined, 'bluray4k').label).toBe('Video');
+		expect(getVideoTypeConfig(null, 'uhd').label).toBe('Video');
+	});
+
+	it('Video fallback is case-insensitive on disctype', () => {
+		expect(getVideoTypeConfig(null, 'DVD').label).toBe('Video');
+		expect(getVideoTypeConfig(null, 'BluRay').label).toBe('Video');
+	});
+
+	it('keeps Disc fallback for non-video disctypes', () => {
+		// Data discs and audio CDs that fail metadata lookup should
+		// stay on the generic "Disc" pill - not "Video".
+		expect(getVideoTypeConfig(null, 'data').label).toBe('Disc');
+		expect(getVideoTypeConfig(null, 'music').label).toBe('Disc');
+		expect(getVideoTypeConfig(null, '').label).toBe('Disc');
+	});
+
+	it('confirmed video_type wins over disctype Video fallback', () => {
+		// A movie that happens to be on a DVD still renders as "Movie",
+		// not "Video".
+		expect(getVideoTypeConfig('movie', 'dvd').label).toBe('Movie');
+		expect(getVideoTypeConfig('series', 'bluray').label).toBe('Series');
+	});
 });
 
 describe('discTypeLabel', () => {

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -28,7 +28,7 @@
 	let expanded = $state(false);
 
 	let driveName = $derived(job?.devpath ? (driveNames?.[job.devpath] ?? null) : null);
-	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null));
+	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null, job?.disctype ?? null));
 	let active = $derived(isJobActive(job?.status ?? null));
 	let hasErrors = $derived(!!job?.errors && job.errors.trim().length > 0);
 	let isFolderImport = $derived(job?.source_type === 'folder');

--- a/frontend/src/lib/components/DiscReviewWidget.svelte
+++ b/frontend/src/lib/components/DiscReviewWidget.svelte
@@ -234,7 +234,7 @@
 	}
 
 	let waitTime = $derived(Number(detail?.config?.MANUAL_WAIT_TIME) || 60);
-	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null));
+	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null, job?.disctype ?? null));
 	let isVideo = $derived(
 		job?.disctype === 'dvd' || job?.disctype === 'bluray' || job?.disctype === 'bluray4k' || job?.video_type === 'movie' || job?.video_type === 'series'
 	);

--- a/frontend/src/lib/components/JobCard.svelte
+++ b/frontend/src/lib/components/JobCard.svelte
@@ -21,7 +21,7 @@
 	let { job, driveNames, progress = null, progressStage = null }: Props = $props();
 	let driveName = $derived(job?.devpath ? (driveNames?.[job.devpath] ?? null) : null);
 
-	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null));
+	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null, job?.disctype ?? null));
 	let active = $derived(isJobActive(job?.status ?? null));
 	let hasErrors = $derived(!!job?.errors && job.errors.trim().length > 0);
 	let isFolderImport = $derived(job?.source_type === 'folder');

--- a/frontend/src/lib/components/JobRow.svelte
+++ b/frontend/src/lib/components/JobRow.svelte
@@ -20,7 +20,7 @@
 	let { job, driveNames = {}, onaction, selected = false, onselect }: Props = $props();
 	let driveName = $derived(job?.devpath ? driveNames[job.devpath] : null);
 
-	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null));
+	let typeConfig = $derived(getVideoTypeConfig(job?.video_type ?? null, job?.disctype ?? null));
 	let active = $derived(isJobActive(job?.status ?? null));
 	let hasErrors = $derived(!!job?.errors && job.errors.trim().length > 0);
 	let discLabelDiffers = $derived(

--- a/frontend/src/lib/utils/job-type.ts
+++ b/frontend/src/lib/utils/job-type.ts
@@ -43,6 +43,18 @@ const DATA_CONFIG: VideoTypeConfig = {
 	iconColor: 'text-amber-500 dark:text-amber-400',
 };
 
+// Unidentified video disc: ARM knows it's a DVD/Blu-ray/UHD but
+// hasn't classified it as movie/series yet. Cyan reads "informational"
+// without colliding with Movie (blue), Series (purple), or Data (amber).
+const VIDEO_FALLBACK_CONFIG: VideoTypeConfig = {
+	label: 'Video',
+	icon: 'disc',
+	badgeClasses: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
+	placeholderClasses: 'bg-cyan-100 text-cyan-400 dark:bg-cyan-900/30 dark:text-cyan-500',
+	accentBorder: 'border-l-cyan-500',
+	iconColor: 'text-cyan-500 dark:text-cyan-400',
+};
+
 const FALLBACK_CONFIG: VideoTypeConfig = {
 	label: 'Disc',
 	icon: 'disc',
@@ -59,9 +71,18 @@ const TYPE_MAP: Record<string, VideoTypeConfig> = {
 	data: DATA_CONFIG,
 };
 
-export function getVideoTypeConfig(videoType: string | null | undefined): VideoTypeConfig {
-	if (!videoType) return FALLBACK_CONFIG;
-	return TYPE_MAP[videoType.toLowerCase()] ?? FALLBACK_CONFIG;
+const VIDEO_DISCTYPES = new Set(['dvd', 'bluray', 'bluray4k', 'uhd']);
+
+export function getVideoTypeConfig(
+	videoType: string | null | undefined,
+	disctype?: string | null,
+): VideoTypeConfig {
+	const known = videoType ? TYPE_MAP[videoType.toLowerCase()] : undefined;
+	if (known) return known;
+	if (disctype && VIDEO_DISCTYPES.has(disctype.toLowerCase())) {
+		return VIDEO_FALLBACK_CONFIG;
+	}
+	return FALLBACK_CONFIG;
 }
 
 // Source of truth: arm_contracts.JobState (see components/contracts).

--- a/frontend/src/routes/transcoder/+page.svelte
+++ b/frontend/src/routes/transcoder/+page.svelte
@@ -332,7 +332,7 @@
 				{@const jobList = jobsData.jobs ?? []}
 			<div class="space-y-3">
 				{#each jobList as job (job.id)}
-					{@const typeConfig = getVideoTypeConfig(job.video_type ?? null)}
+					{@const typeConfig = getVideoTypeConfig(job.video_type ?? null, job.disctype ?? null)}
 					<div in:fade|global={fadeIn} out:fade|global={fadeOut} class="rounded-lg border border-primary/20 border-l-4 {typeConfig.accentBorder} bg-surface p-4 shadow-xs dark:border-primary/20 dark:bg-surface-dark">
 						<div class="flex gap-4">
 							<!-- Poster -->


### PR DESCRIPTION
## Summary

When ARM hasn't classified a disc yet but knows it's a video disc (DVD/Blu-ray/UHD), render a cyan "Video" pill instead of the generic gray "Disc" pill. The disctype pill (\`DVD\`/\`Blu-ray\`/\`4K UHD\`) still appears alongside, so the operator gets:

- \`[DVD] [Video]\` for an unidentified video disc
- \`[Data] [Disc]\` for a data disc
- \`[DVD] [Movie]\` (blue, unchanged) for a confirmed movie

## Why

The "Disc" fallback was the same color as no-info-at-all and didn't communicate that ARM had recognized a video disc. Cyan reads informational without colliding with Movie (blue), Series (purple), Music (green), or Data (amber).

Pairs with arm-neu PR #344 which routes unidentified video discs to \`UNIDENTIFIED_SUBDIR\` (instead of presuming "Movie") - the UI no longer presumes "Movie" either.

## Implementation

- New \`VIDEO_FALLBACK_CONFIG\` (cyan, label "Video", icon "disc") in \`job-type.ts\`.
- \`getVideoTypeConfig()\` now takes optional \`disctype\` argument; picks Video fallback for \`dvd\`/\`bluray\`/\`bluray4k\`/\`uhd\`, generic Disc fallback otherwise.
- 5 callers updated to pass \`job.disctype\`.

## Test plan

- [x] \`vitest run src/lib/__tests__/job-type.test.ts\` - 18/18 (10 new cases)
- [x] \`vitest run\` - 956/956
- [x] \`svelte-check\` - 0 errors
- [x] \`pytest tests/\` - 659/659
- [ ] Visual: open the dashboard with hifi job 213 (unidentified DVD) - badge should read cyan "Video", not gray "Disc"