### PR TITLE
ci(prerelease): allow manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -10,6 +10,11 @@ on:
       - "Dockerfile"
       - "requirements*.txt"
       - "VERSION"
+  workflow_dispatch:
+    # Manual trigger to rebuild the RC from main between release-please
+    # PRs (e.g. after a chore(deps) bump that doesn't refresh the
+    # release-please PR). Reads VERSION from the dispatched ref and
+    # publishes <VERSION>-rc.
 
 permissions:
   contents: read
@@ -17,7 +22,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: prerelease-${{ github.head_ref }}
+  group: prerelease-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -26,7 +31,7 @@ env:
 
 jobs:
   prerelease:
-    if: startsWith(github.head_ref, 'release-please')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -71,6 +76,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}-rc
 
       - name: Find existing pre-release comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
@@ -79,6 +85,7 @@ jobs:
           body-includes: Pre-release image published
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

The publish-prerelease workflow only runs on release-please PRs (`if: startsWith(github.head_ref, 'release-please')`). Commits that don't bump the release version (`chore(deps):`, `chore:`) don't refresh the release-please PR and so the RC image isn't rebuilt — meaning the RC drifts from main between release cycles.

Add `workflow_dispatch:` so an RC build can be triggered manually from main whenever needed (e.g. after a batch of dependabot bumps you want to smoke test). The if-gate is widened to `github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please')`. The PR-comment step is wrapped in `if: github.event_name == 'pull_request'` so it no-ops on manual runs.

## Test plan

- [x] YAML parses (`python -c 'yaml.safe_load(...)'`)
- [ ] After merge: dispatch the workflow on `main`, confirm `arm-ui:18.0.0-rc` is rebuilt with the latest commits