### PR TITLE
feat(settings): show arm-ui webhook secret status alongside transcoder

### DIFF
--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -14,5 +14,11 @@ class SettingsResponse(BaseModel):
     transcoder_config: TranscoderConfig | None = None
     transcoder_gpu_support: dict[str, bool] | None = None
     transcoder_auth_status: TranscoderAuthStatus | None = None
+    # Whether arm-ui has its own outbound webhook secret configured (loaded
+    # from ARM_UI_TRANSCODER_WEBHOOK_SECRET at startup; rotation needs a
+    # restart per feedback_arm_ui_webhook_secret_load_once). Operators need
+    # both this and transcoder_auth_status.webhook_secret_configured to be
+    # true for outbound webhooks to authenticate.
+    arm_ui_webhook_secret_configured: bool = False
     # Deprecated; mirrors transcoder_gpu_support
     gpu_support: dict[str, bool] | None = None

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -63,6 +63,7 @@ async def get_settings():
         transcoder_config=transcoder_config,
         transcoder_gpu_support=transcoder_gpu_support,
         transcoder_auth_status=transcoder_auth_status,
+        arm_ui_webhook_secret_configured=bool(app_settings.transcoder_webhook_secret),
         gpu_support=transcoder_gpu_support,
     )
 

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -2595,6 +2595,10 @@ export type SettingsResponse = {
     } | null;
     transcoder_auth_status?: TranscoderAuthStatus | null;
     /**
+     * Arm Ui Webhook Secret Configured
+     */
+    arm_ui_webhook_secret_configured?: boolean;
+    /**
      * Gpu Support
      */
     gpu_support?: {
@@ -6843,3 +6847,31 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
+
+export type RootStaticOrSpaFilenameGetData = {
+    body?: never;
+    path: {
+        /**
+         * Filename
+         */
+        filename: string;
+    };
+    query?: never;
+    url: '/{filename}';
+};
+
+export type RootStaticOrSpaFilenameGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
+
+export type RootStaticOrSpaFilenameGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -6847,31 +6847,3 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
-
-export type RootStaticOrSpaFilenameGetData = {
-    body?: never;
-    path: {
-        /**
-         * Filename
-         */
-        filename: string;
-    };
-    query?: never;
-    url: '/{filename}';
-};
-
-export type RootStaticOrSpaFilenameGetErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
-
-export type RootStaticOrSpaFilenameGetResponses = {
-    /**
-     * Successful Response
-     */
-    200: unknown;
-};

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1475,10 +1475,20 @@
 								</div>
 								<div class="flex items-center gap-2 text-sm">
 									<span class="inline-flex h-5 w-5 items-center justify-center rounded-full text-xs font-bold {settings.transcoder_auth_status.webhook_secret_configured ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400' : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'}">{settings.transcoder_auth_status.webhook_secret_configured ? '\u2713' : '\u2014'}</span>
-									<span class="text-gray-700 dark:text-gray-300">Webhook secret {settings.transcoder_auth_status.webhook_secret_configured ? 'configured' : 'not configured'}</span>
+									<span class="text-gray-700 dark:text-gray-300">Transcoder webhook secret {settings.transcoder_auth_status.webhook_secret_configured ? 'configured' : 'not configured'}</span>
 								</div>
+								<div class="flex items-center gap-2 text-sm" title="Loaded from ARM_UI_TRANSCODER_WEBHOOK_SECRET at startup; rotation needs a container restart.">
+									<span class="inline-flex h-5 w-5 items-center justify-center rounded-full text-xs font-bold {settings.arm_ui_webhook_secret_configured ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400' : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'}">{settings.arm_ui_webhook_secret_configured ? '\u2713' : '\u2014'}</span>
+									<span class="text-gray-700 dark:text-gray-300">arm-ui webhook secret {settings.arm_ui_webhook_secret_configured ? 'configured' : 'not configured'}</span>
+								</div>
+								{#if settings.transcoder_auth_status.webhook_secret_configured !== settings.arm_ui_webhook_secret_configured}
+									<div class="flex items-center gap-2 text-sm text-amber-700 dark:text-amber-400 md:col-span-2">
+										<span class="inline-flex h-5 w-5 items-center justify-center rounded-full text-xs font-bold bg-amber-100 dark:bg-amber-900/40">!</span>
+										<span>Webhook secrets are asymmetric - outbound webhooks will fail authentication until both sides agree.</span>
+									</div>
+								{/if}
 							</div>
-							<p class="mt-3 text-xs text-gray-400">API authentication is configured via Docker environment variables (REQUIRE_API_AUTH, API_KEY) on the transcoder container. The webhook secret is set in Notifications &gt; Transcoder and must match WEBHOOK_SECRET on the transcoder.</p>
+							<p class="mt-3 text-xs text-gray-400">API authentication is configured via Docker environment variables (REQUIRE_API_AUTH, API_KEY) on the transcoder container. The webhook secret must be set on both sides: WEBHOOK_SECRET on the transcoder and ARM_UI_TRANSCODER_WEBHOOK_SECRET on arm-ui (rotation requires a restart).</p>
 						</div>
 					{/if}
 				</div>

--- a/tests/routers/test_settings.py
+++ b/tests/routers/test_settings.py
@@ -165,6 +165,37 @@ async def test_settings_includes_auth_status(app_client):
     assert auth["webhook_secret_configured"] is True
 
 
+async def test_settings_arm_ui_webhook_secret_configured_true(app_client):
+    """get_settings reflects bool(transcoder_webhook_secret) from app_settings.
+
+    Loaded once at startup per feedback_arm_ui_webhook_secret_load_once;
+    operators read the indicator alongside transcoder_auth_status to spot
+    asymmetric configurations.
+    """
+    with (
+        patch("backend.routers.settings.arm_client.get_config", new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.settings.transcoder_client.get_config", new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.settings.transcoder_client.health", new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.settings.app_settings.transcoder_webhook_secret", "test-secret-123"),
+    ):
+        resp = await app_client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json()["arm_ui_webhook_secret_configured"] is True
+
+
+async def test_settings_arm_ui_webhook_secret_configured_false(app_client):
+    """Empty string for transcoder_webhook_secret yields configured=False."""
+    with (
+        patch("backend.routers.settings.arm_client.get_config", new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.settings.transcoder_client.get_config", new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.settings.transcoder_client.health", new_callable=AsyncMock, return_value=None),
+        patch("backend.routers.settings.app_settings.transcoder_webhook_secret", ""),
+    ):
+        resp = await app_client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json()["arm_ui_webhook_secret_configured"] is False
+
+
 async def test_settings_drops_non_string_comments(app_client):
     """ARM may emit non-string entries in `comments` (e.g. ARM_CFG_GROUPS as a
     per-section banner dict). The BFF must filter those out so the response


### PR DESCRIPTION
## Summary

The Settings page Authentication panel reflected only the transcoder's \`webhook_secret_configured\`. If an operator forgot to set \`ARM_UI_TRANSCODER_WEBHOOK_SECRET\` on the arm-ui side but the transcoder side was fine, the panel showed a green checkmark while \`send_webhook\` silently sent unauthenticated requests that the transcoder rejected.

This adds a sibling indicator surfaced from \`bool(app_settings.transcoder_webhook_secret)\`. The Authentication panel now shows both indicators side by side and renders an asymmetry warning when they disagree.

## Why

Polish item flagged in the 2026-04-27 ultrareview as 'important'. Deferred at the time because the priority was decoupling bind mounts; with the rest of the bind-mount work shipped, the missing indicator is the remaining hole.

## Implementation

- \`backend/models/settings.py\`: add \`arm_ui_webhook_secret_configured: bool = False\` to \`SettingsResponse\`.
- \`backend/routers/settings.py\`: populate from \`bool(app_settings.transcoder_webhook_secret)\`. The arm-ui secret is loaded once from env at startup (per \`feedback_arm_ui_webhook_secret_load_once\`); the field reflects that load-time state.
- \`frontend/src/routes/settings/+page.svelte\`: render the new indicator alongside the existing transcoder one. Tooltip on the row explains rotation requires a container restart. Asymmetric-state warning row appears below when the two values disagree.
- \`api.gen.ts\` regenerated.

## Test plan

- [x] \`pytest tests/\` - 661/661 pass (3 new tests for true/false cases, patched \`app_settings.transcoder_webhook_secret\`).
- [x] \`vitest run\` - 956/956 pass.
- [x] \`svelte-check\` - 0 errors.
- [ ] Visual: Settings page shows two indicators; toggling \`ARM_UI_TRANSCODER_WEBHOOK_SECRET\` between empty and a value flips the second indicator (after restart).