### PR TITLE
feat(presets): HandBrake preset picker fed from transcoder endpoint

### DIFF
--- a/backend/routers/transcoder.py
+++ b/backend/routers/transcoder.py
@@ -174,3 +174,15 @@ async def get_transcoder_job_for_arm(arm_job_id: int) -> dict[str, Any]:
         "progress": job.get("progress"),
         "current_fps": job.get("current_fps"),
     }
+
+
+@router.get("/handbrake-presets", response_model=dict[str, list[str]])
+async def get_handbrake_presets() -> dict[str, list[str]]:
+    """List HandBrakeCLI built-in preset names from the transcoder.
+
+    Empty dict when the transcoder is offline or running an older version
+    that doesn't expose the endpoint - the UI falls through to free-text
+    entry in that case.
+    """
+    result = await transcoder_client.list_handbrake_presets()
+    return result or {}

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -265,6 +265,26 @@ async def get_presets() -> dict[str, Any] | None:
         return None
 
 
+async def list_handbrake_presets() -> dict[str, list[str]] | None:
+    """Fetch HandBrakeCLI built-in preset names from transcoder.
+
+    Result shape: ``{category_name: [preset_name, ...]}``. Returns None
+    if the transcoder is offline OR if the endpoint isn't available
+    (older transcoder versions); the caller is expected to fall back to
+    free-text in either case.
+    """
+    try:
+        resp = await get_client().get("/api/v1/handbrake-presets")
+        if resp.status_code == 404:
+            # Older transcoder without the endpoint - signal "no list"
+            # rather than 500ing the BFF.
+            return None
+        resp.raise_for_status()
+        return resp.json()
+    except (httpx.HTTPError, httpx.ConnectError, RuntimeError, OSError):
+        return None
+
+
 async def create_preset(body: dict[str, Any]) -> dict[str, Any] | None:
     """Create a custom preset. Returns None if transcoder offline. Raises HTTPStatusError on 4xx/5xx."""
     try:

--- a/frontend/src/lib/api/transcoder.ts
+++ b/frontend/src/lib/api/transcoder.ts
@@ -33,3 +33,14 @@ export function deleteTranscoderJob(id: number): Promise<unknown> {
 export function retranscodeTranscoderJob(id: number): Promise<{ status: string; message: string }> {
 	return apiFetch(`/api/transcoder/jobs/${id}/retranscode`, { method: 'POST' });
 }
+
+export async function listHandbrakePresets(): Promise<Record<string, string[]>> {
+	try {
+		return await apiFetch<Record<string, string[]>>('/api/transcoder/handbrake-presets');
+	} catch {
+		// Endpoint missing (older transcoder), transcoder offline, or
+		// network error. The PresetEditor falls back to free-text in
+		// either case; an empty list is the agreed sentinel.
+		return {};
+	}
+}

--- a/frontend/src/lib/components/PresetEditor.svelte
+++ b/frontend/src/lib/components/PresetEditor.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import { onDestroy } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
     import type { Scheme, Preset, Overrides } from '$lib/types/api.gen';
     import type { PresetEditorState } from '$lib/types/presets';
+    import { listHandbrakePresets } from '$lib/api/transcoder';
     interface Props {
         scope: 'global' | 'job';
         initialState: PresetEditorState;
@@ -96,6 +97,20 @@
     let undoToast = $state<{ message: string; previous: { slug: string; overrides: Overrides } } | null>(null);
     let undoTimer: ReturnType<typeof setTimeout> | null = null;
     onDestroy(() => { if (undoTimer) clearTimeout(undoTimer); });
+
+    // HandBrake preset picker. The transcoder enumerates its built-in
+    // preset list via /api/v1/handbrake-presets; the BFF passes through.
+    // When the list is empty (transcoder offline, older version, parser
+    // failure) we fall back to free-text entry so the field is never
+    // un-editable.
+    let handbrakePresetGroups = $state<Record<string, string[]>>({});
+    const handbrakeKnown = $derived(
+        new Set(Object.values(handbrakePresetGroups).flat())
+    );
+    const handbrakeAvailable = $derived(handbrakeKnown.size > 0);
+    onMount(async () => {
+        handbrakePresetGroups = await listHandbrakePresets();
+    });
 
     function handleDropdownChange(newSlug: string) {
         const wasDirty = dirty;
@@ -307,14 +322,43 @@
                             <label class="space-y-1 lg:col-span-2">
                                 <span class="text-xs text-gray-600 dark:text-gray-400">HandBrake preset</span>
                                 <div class={isTierDirty(tier, 'handbrake_preset') ? dirtyRing : ''}>
-                                    <input
-                                        type="text"
-                                        value={effectiveTier(tier, 'handbrake_preset')}
-                                        oninput={(e) => setTier(tier, 'handbrake_preset', (e.target as HTMLInputElement).value)}
-                                        disabled={saving || isUnavailable}
-                                        class="{inputClass} w-full"
-                                    />
+                                    {#if handbrakeAvailable && handbrakeKnown.has(String(effectiveTier(tier, 'handbrake_preset')))}
+                                        <select
+                                            value={effectiveTier(tier, 'handbrake_preset')}
+                                            onchange={(e) => {
+                                                const v = (e.target as HTMLSelectElement).value;
+                                                setTier(tier, 'handbrake_preset', v === '__custom__' ? '' : v);
+                                            }}
+                                            disabled={saving || isUnavailable}
+                                            class="{inputClass} w-full"
+                                        >
+                                            {#each Object.entries(handbrakePresetGroups) as [category, names]}
+                                                <optgroup label={category}>
+                                                    {#each names as name}
+                                                        <option value={name}>{name}</option>
+                                                    {/each}
+                                                </optgroup>
+                                            {/each}
+                                            <option value="__custom__">Custom...</option>
+                                        </select>
+                                    {:else}
+                                        <input
+                                            type="text"
+                                            value={effectiveTier(tier, 'handbrake_preset')}
+                                            oninput={(e) => setTier(tier, 'handbrake_preset', (e.target as HTMLInputElement).value)}
+                                            disabled={saving || isUnavailable}
+                                            class="{inputClass} w-full"
+                                            placeholder={handbrakeAvailable ? 'Custom preset name' : 'HandBrake preset name'}
+                                        />
+                                    {/if}
                                 </div>
+                                {#if handbrakeAvailable && handbrakeKnown.has(String(effectiveTier(tier, 'handbrake_preset')))}
+                                    <button
+                                        type="button"
+                                        class="text-xs text-primary hover:underline"
+                                        onclick={() => setTier(tier, 'handbrake_preset', '')}
+                                    >Use a custom preset name</button>
+                                {/if}
                             </label>
                             {#each Object.entries(scheme.advanced_fields ?? {}) as [key, def]}
                                 <label class="space-y-1">

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -6863,31 +6863,3 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
-
-export type RootStaticOrSpaFilenameGetData = {
-    body?: never;
-    path: {
-        /**
-         * Filename
-         */
-        filename: string;
-    };
-    query?: never;
-    url: '/{filename}';
-};
-
-export type RootStaticOrSpaFilenameGetErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
-
-export type RootStaticOrSpaFilenameGetResponses = {
-    /**
-     * Successful Response
-     */
-    200: unknown;
-};

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -5033,6 +5033,26 @@ export type GetTranscoderJobForArmApiTranscoderJobForArmArmJobIdGetResponses = {
 
 export type GetTranscoderJobForArmApiTranscoderJobForArmArmJobIdGetResponse = GetTranscoderJobForArmApiTranscoderJobForArmArmJobIdGetResponses[keyof GetTranscoderJobForArmApiTranscoderJobForArmArmJobIdGetResponses];
 
+export type GetHandbrakePresetsApiTranscoderHandbrakePresetsGetData = {
+    body?: never;
+    path?: never;
+    query?: never;
+    url: '/api/transcoder/handbrake-presets';
+};
+
+export type GetHandbrakePresetsApiTranscoderHandbrakePresetsGetResponses = {
+    /**
+     * Response Get Handbrake Presets Api Transcoder Handbrake Presets Get
+     *
+     * Successful Response
+     */
+    200: {
+        [key: string]: Array<string>;
+    };
+};
+
+export type GetHandbrakePresetsApiTranscoderHandbrakePresetsGetResponse = GetHandbrakePresetsApiTranscoderHandbrakePresetsGetResponses[keyof GetHandbrakePresetsApiTranscoderHandbrakePresetsGetResponses];
+
 export type ListDrivesApiDrivesGetData = {
     body?: never;
     path?: never;
@@ -6843,3 +6863,31 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
+
+export type RootStaticOrSpaFilenameGetData = {
+    body?: never;
+    path: {
+        /**
+         * Filename
+         */
+        filename: string;
+    };
+    query?: never;
+    url: '/{filename}';
+};
+
+export type RootStaticOrSpaFilenameGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
+
+export type RootStaticOrSpaFilenameGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};

--- a/tests/routers/test_transcoder.py
+++ b/tests/routers/test_transcoder.py
@@ -438,6 +438,36 @@ async def test_get_job_for_arm_filters_by_job_id_not_most_recent(app_client):
     assert "arm_job_id" not in kwargs
 
 
+# --- HandBrake presets ---
+
+
+async def test_handbrake_presets_passes_through(app_client):
+    """BFF returns the categorized list verbatim from transcoder_client."""
+    fake = {"General": ["Fast 1080p30", "HQ 1080p30"], "Web": ["Vimeo 1080p"]}
+    with patch(
+        "backend.routers.transcoder.transcoder_client.list_handbrake_presets",
+        new_callable=AsyncMock,
+        return_value=fake,
+    ):
+        resp = await app_client.get("/api/transcoder/handbrake-presets")
+    assert resp.status_code == 200
+    assert resp.json() == fake
+
+
+async def test_handbrake_presets_empty_when_offline(app_client):
+    """When transcoder_client returns None (offline / older version), the
+    BFF returns an empty dict so the UI falls through to free-text input
+    rather than 500ing."""
+    with patch(
+        "backend.routers.transcoder.transcoder_client.list_handbrake_presets",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        resp = await app_client.get("/api/transcoder/handbrake-presets")
+    assert resp.status_code == 200
+    assert resp.json() == {}
+
+
 # --- Ripper-only gating ---
 
 TRANSCODER_GATED_ENDPOINTS = [
@@ -451,6 +481,7 @@ TRANSCODER_GATED_ENDPOINTS = [
     ("GET", "/api/transcoder/logs/foo.log/structured"),
     ("POST", "/api/transcoder/jobs/1/retranscode"),
     ("GET", "/api/transcoder/job-for-arm/1"),
+    ("GET", "/api/transcoder/handbrake-presets"),
 ]
 
 


### PR DESCRIPTION
## Summary

Replaces the free-text \`handbrake_preset\` input in PresetEditor with a real \`<select>\` populated from \`GET /api/transcoder/handbrake-presets\` (BFF passthrough to the new transcoder endpoint).

Companion to **transcoder PR #167** which adds the upstream endpoint.

## Why

Free-text input silently breaks encodes when the operator typos a preset name. A picker fed from the actual HandBrakeCLI output eliminates that class of failure.

## Implementation

**BFF:**
- \`backend/services/transcoder_client.py\`: new \`list_handbrake_presets()\` method. Returns \`None\` on 404 or transcoder offline so the BFF can swallow into an empty dict.
- \`backend/routers/transcoder.py\`: new \`GET /api/transcoder/handbrake-presets\` endpoint, gated on the existing \`require_transcoder_enabled\` dependency. Empty dict on offline/older-version transcoder.

**Frontend:**
- \`frontend/src/lib/api/transcoder.ts\`: new \`listHandbrakePresets()\` client wrapper. Empty dict on any failure.
- \`frontend/src/lib/components/PresetEditor.svelte\`: 
  - Loads the list on mount via \`onMount\`.
  - When the list is non-empty AND the current value is in it, renders a \`<select>\` with categorized \`<optgroup>\`s.
  - When the list is empty (transcoder offline) OR the current value is custom (not in list), renders the existing free-text input.
  - "Custom..." sentinel option in the select drops back to free-text.
  - "Use a custom preset name" link below the select also drops back.
- \`api.gen.ts\` regenerated.

## Test plan

- [x] \`pytest tests/\` - 662/662 (2 new tests for passthrough + None-from-client + 1 new ripper-only gating row).
- [x] \`vitest run\` - 956/956.
- [x] \`svelte-check\` - 0 errors.
- [ ] Visual: with transcoder PR #167 deployed, edit a preset; the HandBrake field is a select with optgroups. Without transcoder PR #167, the field is free-text (unchanged behavior).

## Release ordering

This PR is safe to merge before transcoder PR #167 ships (the picker just stays in free-text mode until the upstream endpoint exists). To get the picker live in prod, transcoder PR #167 needs to be deployed first or alongside.