### PR TITLE
refactor(settings): unify per-provider key-test buttons

### DIFF
--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -330,13 +330,19 @@ async def lookup_crc(crc64: str) -> dict[str, Any]:
 
 
 async def test_metadata_key(key: str | None = None, provider: str | None = None) -> dict[str, Any]:
-    """Test a metadata API key via ARM. Uses saved config if overrides are omitted."""
+    """Test a metadata API key via ARM. Uses saved config if overrides are omitted.
+
+    The makemkv provider runs prep_mkv() which can fetch a fresh beta key from
+    forum.makemkv.com on a cold check (15-30s); other providers respond
+    quickly. Use a 30-second timeout uniformly so any provider has enough
+    headroom for a slow upstream.
+    """
     params: dict[str, str] = {}
     if key:
         params["key"] = key
     if provider:
         params["provider"] = provider
-    resp = await get_client().get("/api/v1/metadata/test-key", params=params)
+    resp = await get_client().get("/api/v1/metadata/test-key", params=params, timeout=30.0)
     resp.raise_for_status()
     return resp.json()
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -14,7 +14,6 @@
 	import type { DiagnosticResult } from '$lib/api/drives';
 	import DriveCard from '$lib/components/DriveCard.svelte';
 	import { restartArm, restartTranscoder } from '$lib/api/system';
-	import { checkMakemkvKey } from '$lib/api/dashboard';
 	import { fetchImageCacheStats, clearImageCache, type ImageCacheStats } from '$lib/api/maintenance';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import SystemHealth from '$lib/components/settings/SystemHealth.svelte';
@@ -142,33 +141,6 @@
 			const fb = { type: 'error' as const, message: `Failed to restart ${label}` };
 			if (service === 'arm') { armRestartFeedback = fb; armRestarting = false; }
 			else { tcRestartFeedback = fb; tcRestarting = false; }
-		}
-	}
-
-	// --- Key check state ---
-	let checkingKey = $state(false);
-	let keyCheckResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
-	let keyCheckTimeout: ReturnType<typeof setTimeout> | null = null;
-
-	async function handleKeyCheck() {
-		if (checkingKey) return;
-		checkingKey = true;
-		keyCheckResult = null;
-		if (keyCheckTimeout) clearTimeout(keyCheckTimeout);
-		try {
-			const res = await checkMakemkvKey();
-			keyCheckResult = {
-				type: res.key_valid ? 'success' : 'error',
-				message: res.message
-			};
-		} catch (e) {
-			keyCheckResult = {
-				type: 'error',
-				message: e instanceof Error ? e.message : 'Failed to check key'
-			};
-		} finally {
-			checkingKey = false;
-			keyCheckTimeout = setTimeout(() => (keyCheckResult = null), 10000);
 		}
 	}
 
@@ -959,34 +931,48 @@
 		'MAKEMKV_PERMA_KEY',
 	]);
 
-	// Keys hidden based on metadata provider selection
-	const METADATA_API_KEYS = new Set(['OMDB_API_KEY', 'TMDB_API_KEY']);
+	// Map of API-key form fields to the provider name used by the unified
+	// /api/v1/metadata/test-key endpoint. OMDB/TMDB are mutually exclusive
+	// (METADATA_PROVIDER picks one); TVDB and MakeMKV are always shown.
+	const KEY_TEST_PROVIDERS: Record<string, string> = {
+		OMDB_API_KEY: 'omdb',
+		TMDB_API_KEY: 'tmdb',
+		TVDB_API_KEY: 'tvdb',
+		MAKEMKV_PERMA_KEY: 'makemkv',
+	};
+	const METADATA_PROVIDER_KEYS = new Set(['OMDB_API_KEY', 'TMDB_API_KEY']);
 
 	function isMetadataKeyHidden(key: string): boolean {
-		if (!METADATA_API_KEYS.has(key)) return false;
+		if (!METADATA_PROVIDER_KEYS.has(key)) return false;
 		const provider = (armForm['METADATA_PROVIDER'] ?? 'omdb').toString().toLowerCase();
 		if (key === 'OMDB_API_KEY') return provider !== 'omdb';
 		if (key === 'TMDB_API_KEY') return provider !== 'tmdb';
 		return false;
 	}
 
-	function isMetadataApiKey(key: string): boolean {
-		return METADATA_API_KEYS.has(key);
+	function keyTestProvider(key: string): string | null {
+		return KEY_TEST_PROVIDERS[key] ?? null;
 	}
 
-	async function handleTestMetadata() {
+	let metadataTestKey = $state<string | null>(null);
+
+	async function handleTestKey(key: string) {
+		const provider = keyTestProvider(key);
+		if (!provider) return;
 		metadataTesting = true;
+		metadataTestKey = key;
 		metadataTestResult = null;
 		try {
-			const provider = (armForm['METADATA_PROVIDER'] ?? 'omdb').toString().toLowerCase();
-			const keyField = provider === 'tmdb' ? 'TMDB_API_KEY' : 'OMDB_API_KEY';
-			const currentKey = armForm[keyField]?.toString().trim() || undefined;
+			const currentKey = armForm[key]?.toString().trim() || undefined;
 			metadataTestResult = await testMetadataKey(currentKey, provider);
 		} catch {
 			metadataTestResult = { success: false, message: 'Failed to reach test endpoint' };
 		} finally {
 			metadataTesting = false;
-			clearFeedback(() => (metadataTestResult = null));
+			clearFeedback(() => {
+				metadataTestResult = null;
+				metadataTestKey = null;
+			});
 		}
 	}
 
@@ -1218,35 +1204,20 @@
 					>
 						{armRevealedKeys.has(key) ? 'Hide' : 'Show'}
 					</button>
-					{#if isMetadataApiKey(key)}
+					{#if keyTestProvider(key)}
 						<button
 							type="button"
-							onclick={handleTestMetadata}
+							onclick={() => handleTestKey(key)}
 							disabled={metadataTesting}
 							class="rounded-md border border-primary/25 px-2 py-2 text-xs font-medium text-primary-text hover:bg-primary/10 disabled:opacity-50 dark:border-primary/30 dark:text-primary-text-dark dark:hover:bg-primary/15"
 						>
-							{metadataTesting ? 'Testing...' : 'Test'}
-						</button>
-					{/if}
-					{#if key === 'MAKEMKV_PERMA_KEY'}
-						<button
-							type="button"
-							onclick={handleKeyCheck}
-							disabled={checkingKey}
-							class="rounded-md border border-primary/25 px-2 py-2 text-xs font-medium text-primary-text hover:bg-primary/10 disabled:opacity-50 dark:border-primary/30 dark:text-primary-text-dark dark:hover:bg-primary/15"
-						>
-							{checkingKey ? 'Checking...' : 'Check Key'}
+							{metadataTesting && metadataTestKey === key ? 'Testing...' : 'Test'}
 						</button>
 					{/if}
 				</div>
-				{#if isMetadataApiKey(key) && metadataTestResult}
+				{#if metadataTestKey === key && metadataTestResult}
 					<p class="mt-1 text-xs font-medium {metadataTestResult.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
 						{metadataTestResult.message}
-					</p>
-				{/if}
-				{#if key === 'MAKEMKV_PERMA_KEY' && keyCheckResult}
-					<p class="mt-1 text-xs font-medium {keyCheckResult.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
-						{keyCheckResult.message}
 					</p>
 				{/if}
 			{:else if isIntStr(val?.toString())}

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -89,10 +89,6 @@ vi.mock('$lib/api/system', () => ({
 	restartTranscoder: vi.fn(() => Promise.resolve())
 }));
 
-vi.mock('$lib/api/dashboard', () => ({
-	checkMakemkvKey: vi.fn(() => Promise.resolve({ valid: true, message: 'OK' }))
-}));
-
 vi.mock('$lib/api/maintenance', () => ({
 	fetchImageCacheStats: vi.fn(() => Promise.resolve({ count: 5, size_bytes: 5242880, size_mb: '5.0' })),
 	clearImageCache: vi.fn(() => Promise.resolve({ success: true, cleared: 5, freed_bytes: 5242880 }))

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -332,7 +332,7 @@ async def test_metadata_key_success(mock_client):
     _set_get_response(mock_client, {"success": True, "message": "OMDb key valid", "provider": "omdb"})
     result = await arm_client.test_metadata_key()
     assert result["success"] is True
-    mock_client.get.assert_awaited_once_with("/api/v1/metadata/test-key", params={})
+    mock_client.get.assert_awaited_once_with("/api/v1/metadata/test-key", params={}, timeout=30.0)
 
 
 async def test_metadata_key_with_key_and_provider(mock_client):
@@ -341,7 +341,19 @@ async def test_metadata_key_with_key_and_provider(mock_client):
     result = await arm_client.test_metadata_key(key="abc123", provider="tmdb")
     assert result["success"] is True
     mock_client.get.assert_awaited_once_with(
-        "/api/v1/metadata/test-key", params={"key": "abc123", "provider": "tmdb"})
+        "/api/v1/metadata/test-key",
+        params={"key": "abc123", "provider": "tmdb"},
+        timeout=30.0,
+    )
+
+
+async def test_metadata_key_uses_30s_timeout(mock_client):
+    """test_metadata_key uses 30s timeout: makemkv prep_mkv() can take 15-30s
+    on a cold check (fetches a fresh beta key from forum.makemkv.com)."""
+    _set_get_response(mock_client, {"success": True, "message": "ok", "provider": "makemkv"})
+    await arm_client.test_metadata_key(provider="makemkv")
+    args, kwargs = mock_client.get.await_args
+    assert kwargs["timeout"] == 30.0
 
 
 async def test_metadata_key_raises_on_error(mock_client):

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -353,7 +353,7 @@ async def test_metadata_key_uses_30s_timeout(mock_client):
     _set_get_response(mock_client, {"success": True, "message": "ok", "provider": "makemkv"})
     await arm_client.test_metadata_key(provider="makemkv")
     args, kwargs = mock_client.get.await_args
-    assert kwargs["timeout"] == 30.0
+    assert kwargs["timeout"] == pytest.approx(30.0)
 
 
 async def test_metadata_key_raises_on_error(mock_client):


### PR DESCRIPTION
## Summary
- Collapses the OMDB / TMDB "Test" + MakeMKV "Check Key" buttons in Settings into a single provider-aware handler
- Replaces the `METADATA_API_KEYS` set + `handleKeyCheck` parallel path with a one-line `KEY_TEST_PROVIDERS` map
- Adds TVDB to the testable-key set for free (it was always in the unified endpoint, just missing a UI button)
- Drops the now-unused `checkMakemkvKey` import + dashboard test mock

## Why
arm-neu PR #348 unified the per-provider key-check endpoints behind `GET /api/v1/metadata/test-key?provider=...`. The Settings page was still calling the legacy `/api/dashboard/makemkv-key-check` for one provider and the unified endpoint for the other two; this normalises the call site so future providers are a single map entry.

## Backend impact
None - the BFF still proxies the unified endpoint and the legacy `/api/dashboard/makemkv-key-check` is left in place (deprecated alias in arm-neu).

## Test plan
- [x] `npm run check` clean (1 pre-existing warning in DriveCard, unrelated)
- [x] 956 / 956 frontend tests pass
- [x] 659 / 659 BFF tests pass
- [ ] Smoke on hifi: open Settings -> Ripping panel, click Test next to OMDB / TMDB / TVDB / MakeMKV keys, verify each renders the result inline next to the right field