### PR TITLE
feat(progress): render copy progress for copying / finalizing jobs

### DIFF
--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -248,6 +248,8 @@ async def get_job_progress(job_id: int):
         "tracks_total": counts["tracks_total"],
         "tracks_ripped": max(realtime, db_ripped),
         "no_of_titles": state.get("no_of_titles"),
+        "copy_progress": state.get("copy_progress"),
+        "copy_stage": state.get("copy_stage"),
     }
 
 

--- a/frontend/src/lib/api/jobs.ts
+++ b/frontend/src/lib/api/jobs.ts
@@ -168,6 +168,8 @@ export interface RipProgress {
 	tracks_total: number;
 	tracks_ripped: number;
 	no_of_titles: number | null;
+	copy_progress: number | null;
+	copy_stage: string | null;
 }
 
 export function fetchJobProgress(id: number): Promise<RipProgress> {

--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -22,6 +22,12 @@
 
 	let { job, driveNames, progress = null, progressStage = null, tracksRipped = null, tracksTotal = null }: Props = $props();
 
+	function formatStage(s: string): string {
+		if (s === 'scratch-to-media') return 'Copying to shared storage';
+		if (s === 'work-to-completed') return 'Moving to completed';
+		return s;
+	}
+
 	// Use progress-polled counts when available (real-time), fall back to DB counts
 	let displayRipped = $derived(tracksRipped ?? job?.track_counts?.ripped ?? 0);
 	let displayTotal = $derived(tracksTotal ?? job?.track_counts?.total ?? 0);
@@ -289,7 +295,7 @@
 									{#if !active && job.stop_time}
 										<TimeAgo date={job.stop_time} />
 									{:else if active && progressStage}
-										{progressStage}
+										{formatStage(progressStage)}
 									{:else}
 										—
 									{/if}

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -6867,3 +6867,31 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
+
+export type RootStaticOrSpaFilenameGetData = {
+    body?: never;
+    path: {
+        /**
+         * Filename
+         */
+        filename: string;
+    };
+    query?: never;
+    url: '/{filename}';
+};
+
+export type RootStaticOrSpaFilenameGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
+
+export type RootStaticOrSpaFilenameGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -102,7 +102,14 @@
 	}
 
 	function overallProgress(p: RipProgress | undefined): number | null {
-		if (!p || p.progress == null) return null;
+		if (!p) return null;
+		// Copy phases (scratch-to-media on the ripper side) are surfaced via
+		// copy_progress. The UI gate on stage means an old arm-neu reporting
+		// copy_progress=null still falls through to rip_progress correctly.
+		if (p.copy_stage && p.copy_progress != null) {
+			return p.copy_progress;
+		}
+		if (p.progress == null) return null;
 		const total = p.tracks_total > 0 ? p.tracks_total : (p.no_of_titles ?? 0);
 		if (total > 0 && p.tracks_ripped > 0) {
 			// Per-track progress: some tracks done, current track partially complete
@@ -118,17 +125,18 @@
 		// 'ripping' is the legacy pre-v2.0.0 wire string; arm-neu now emits
 		// 'video_ripping' (DVD/Blu-ray) and 'audio_ripping' (music). Match all
 		// three so progress polling stays accurate during the deploy and
-		// continues working post-deploy.
-		const rippingJobs = activeJobs.filter(j => {
+		// continues working post-deploy. 'copying' is also tracked so the
+		// FINISHING section can render rsync copy progress.
+		const trackedJobs = activeJobs.filter(j => {
 			const s = j.status?.toLowerCase();
-			return s === 'video_ripping' || s === 'audio_ripping' || s === 'ripping';
+			return s === 'video_ripping' || s === 'audio_ripping' || s === 'ripping' || s === 'copying';
 		});
-		if (rippingJobs.length === 0) {
+		if (trackedJobs.length === 0) {
 			progressMap = {};
 			return;
 		}
 		const entries = await Promise.allSettled(
-			rippingJobs.map(async (j) => {
+			trackedJobs.map(async (j) => {
 				const prog = await fetchJobProgress(j.job_id);
 				return [j.job_id, prog] as const;
 			})
@@ -436,7 +444,12 @@
 				<div class="space-y-2">
 					{#each finishingJobs as job (job.job_id)}
 						<div in:fade|local={fadeIn} out:fade|local={fadeOut}>
-							<ActiveJobRow {job} driveNames={dash.drive_names} />
+							<ActiveJobRow
+								{job}
+								driveNames={dash.drive_names}
+								progress={overallProgress(progressMap[job.job_id])}
+								progressStage={progressMap[job.job_id]?.copy_stage ?? progressMap[job.job_id]?.stage ?? null}
+							/>
 						</div>
 					{/each}
 				</div>

--- a/frontend/src/routes/__tests__/dashboard-page.test.ts
+++ b/frontend/src/routes/__tests__/dashboard-page.test.ts
@@ -362,4 +362,48 @@ describe('Dashboard Page', () => {
 		renderComponent(DashboardPage);
 		await waitFor(() => expect(screen.getByText('No jobs found.')).toBeInTheDocument());
 	});
+
+	it('polls progress for jobs in copying status and renders the copy bar', async () => {
+		// Repro: hifi job in JobState.COPYING shows just the "Copying" label
+		// with no bar today; this test asserts copy_progress is fetched and
+		// rendered. The mock fetchJobProgress returns copy_progress=47.0 and
+		// copy_stage='scratch-to-media'; the dashboard should display 47%.
+		const COPYING_JOB = {
+			job_id: 42, title: 'Annihilation', status: 'copying',
+			disctype: 'bluray4k', source_type: 'folder', video_type: 'movie',
+			year: '2018', label: 'ANNI', start_time: '2026-05-09T18:00:00Z',
+			stop_time: null, job_length: null, devpath: '/dev/sr0',
+			imdb_id: null, poster_url: null, errors: null, stage: null,
+			no_of_titles: 0, logfile: null, track_counts: null,
+			wait_start_time: null
+		};
+
+		const { fetchDashboard } = await import('$lib/api/dashboard');
+		(fetchDashboard as ReturnType<typeof vi.fn>).mockResolvedValue({
+			db_available: true, arm_online: true,
+			active_jobs: [COPYING_JOB],
+			system_info: null, drives_online: 1, drive_names: { '/dev/sr0': 'Main Drive' },
+			notification_count: 2, ripping_enabled: true,
+			transcoder_online: false, transcoder_stats: null, transcoder_system_stats: null,
+			active_transcodes: [], system_stats: null, transcoder_info: null
+		});
+
+		const { fetchJobProgress } = await import('$lib/api/jobs');
+		(fetchJobProgress as ReturnType<typeof vi.fn>).mockResolvedValue({
+			progress: null, stage: null,
+			tracks_total: 0, tracks_ripped: 0, no_of_titles: null,
+			copy_progress: 47.0, copy_stage: 'scratch-to-media',
+		});
+
+		renderComponent(DashboardPage);
+		await waitFor(() => {
+			expect(screen.getByText('Annihilation')).toBeInTheDocument();
+		});
+
+		// Wait for the progress poll to land - ProgressBar renders "47%"
+		await waitFor(() => {
+			const matches = screen.queryAllByText(/47/);
+			expect(matches.length).toBeGreaterThan(0);
+		}, { timeout: 5000 });
+	});
 });

--- a/tests/routers/test_progress_copy.py
+++ b/tests/routers/test_progress_copy.py
@@ -1,0 +1,64 @@
+"""BFF pass-through tests for copy_progress / copy_stage on /api/jobs/{id}/progress."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+
+async def test_progress_endpoint_includes_copy_fields(app_client):
+    """When arm-neu reports copy_progress / copy_stage, the BFF passes them
+    through on /api/jobs/{id}/progress."""
+    state = {
+        "track_counts": {"total": 2, "ripped": 1},
+        "disctype": "bluray",
+        "logfile": None,
+        "no_of_titles": 2,
+        "rip_progress": None,
+        "rip_stage": None,
+        "tracks_ripped_realtime": None,
+        "music_progress": None,
+        "music_stage": None,
+        "copy_progress": 47.5,
+        "copy_stage": "scratch-to-media",
+    }
+    from backend.routers import jobs as jobs_router
+    jobs_router._PROGRESS_CACHE.clear()
+    with patch(
+        "backend.routers.jobs.arm_client.get_job_progress_state",
+        new_callable=AsyncMock,
+        return_value=state,
+    ):
+        response = await app_client.get("/api/jobs/42/progress")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["copy_progress"] == 47.5
+    assert data["copy_stage"] == "scratch-to-media"
+
+
+async def test_progress_endpoint_copy_fields_default_to_none(app_client):
+    """No copy in flight - copy_progress and copy_stage are None on the wire."""
+    state = {
+        "track_counts": {"total": 0, "ripped": 0},
+        "disctype": "dvd",
+        "logfile": None,
+        "no_of_titles": None,
+        "rip_progress": 50.0,
+        "rip_stage": "Title 1: Saving to MKV file",
+        "tracks_ripped_realtime": 0,
+        "music_progress": None,
+        "music_stage": None,
+        "copy_progress": None,
+        "copy_stage": None,
+    }
+    from backend.routers import jobs as jobs_router
+    jobs_router._PROGRESS_CACHE.clear()
+    with patch(
+        "backend.routers.jobs.arm_client.get_job_progress_state",
+        new_callable=AsyncMock,
+        return_value=state,
+    ):
+        response = await app_client.get("/api/jobs/42/progress")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["copy_progress"] is None
+    assert data["copy_stage"] is None


### PR DESCRIPTION
## Summary
- BFF `/api/jobs/{id}/progress` passes through `copy_progress` and `copy_stage` from arm-neu's `JobProgressState`
- `RipProgress` interface extended with the two new fields (BFF endpoint isn't response-model-typed so codegen can't pick them up; hand-written interface is the source of truth here)
- Dashboard `pollProgress` now includes `JobState.copying` jobs
- `overallProgress` prefers `copy_progress` when `copy_stage` is set; falls through to existing rip-progress when not
- `ActiveJobRow` renders 'Copying to shared storage' / 'Moving to completed' instead of the raw wire stage names
- Bumps `components/contracts` to `307bef8`

## Why
The FINISHING dashboard section showed a bare 'Copying' label with no bar; users could not tell a healthy NFS copy from a stalled mount. Closes the loop on the unified-rsync-progress design across all four repos.

Spec: `../ai/arm-neu/docs/superpowers/specs/2026-05-09-unified-rsync-progress-design.md`
Plan: `../ai/arm-neu/docs/superpowers/plans/2026-05-09-unified-rsync-progress.md`

## Test plan
- [x] BFF tests cover present + absent `copy_progress` (2 new tests in `test_progress_copy.py`)
- [x] Dashboard test renders 47% for a copying job
- [x] Full backend suite green (667 passed)
- [x] Full frontend suite green (957 passed)
- [x] svelte-check + typecheck clean (1 pre-existing DriveCard warning, unrelated)
- [ ] Smoke on hifi after RC: trigger a folder import and observe percentage during copying status
- [ ] Smoke on transcoder-server: observe percentage during copying_source and finalizing phases on a real rip