### PR TITLE
fix(jobs): folder imports use the disc 5-stage lifecycle

### DIFF
--- a/frontend/src/lib/__tests__/job-lifecycle.test.ts
+++ b/frontend/src/lib/__tests__/job-lifecycle.test.ts
@@ -90,11 +90,12 @@ describe('deriveLifecycle - failure', () => {
 
 	it('folder import failure paints last non-complete stage too', () => {
 		const nodes = deriveLifecycle('fail', 'folder');
-		// 4 stages: waiting, identifying, transcoding, complete
+		// folder imports share the disc 5-stage lifecycle (folder_ripper still
+		// runs a MakeMKV remux that drives VIDEO_RIPPING)
 		expect(nodes.map((n) => n.id)).toEqual([
-			'waiting', 'identifying', 'transcoding', 'complete'
+			'waiting', 'identifying', 'ripping', 'transcoding', 'complete'
 		]);
-		expect(nodes[2].state).toBe('failed'); // transcoding (index 2, before complete)
+		expect(nodes[3].state).toBe('failed'); // transcoding, the last reachable non-complete
 	});
 });
 
@@ -106,20 +107,27 @@ describe('deriveLifecycle - paused', () => {
 });
 
 describe('deriveLifecycle - folder imports', () => {
-	it('folder source skips the ripping stage', () => {
+	it('folder source uses the same 5-stage lifecycle as disc', () => {
 		const nodes = deriveLifecycle('transcoding', 'folder');
 		expect(nodes.map((n) => n.id)).toEqual([
-			'waiting', 'identifying', 'transcoding', 'complete'
+			'waiting', 'identifying', 'ripping', 'transcoding', 'complete'
 		]);
+		expect(nodes[3].state).toBe('active');
+	});
+
+	it('video_ripping on folder source paints ripping active', () => {
+		// Repro: hifi job 224 (Annihilation folder import) reported
+		// status=video_ripping but earlier 4-stage FOLDER_STAGES had no
+		// ripping node, so deriveLifecycle returned all-pending.
+		const nodes = deriveLifecycle('video_ripping', 'folder');
+		expect(nodes[2].id).toBe('ripping');
 		expect(nodes[2].state).toBe('active');
 	});
 
-	it('importing wire string on folder source has no ripping node so falls through to pending', () => {
-		// Importing maps to the ripping stage but the folder-import lifecycle
-		// excludes that node; we render fully pending rather than misplace.
+	it('importing on folder source maps to ripping stage', () => {
 		const nodes = deriveLifecycle('importing', 'folder');
-		expect(nodes.length).toBe(4);
-		expect(nodes.every((n) => n.state === 'pending')).toBe(true);
+		expect(nodes[2].id).toBe('ripping');
+		expect(nodes[2].state).toBe('active');
 	});
 });
 

--- a/frontend/src/lib/components/JobLifecycle.test.ts
+++ b/frontend/src/lib/components/JobLifecycle.test.ts
@@ -17,13 +17,16 @@ describe('JobLifecycle', () => {
 			expect(screen.getByText('Complete')).toBeInTheDocument();
 		});
 
-		it('renders 4 stages for folder import (no Ripping node)', () => {
+		it('renders the same 5 stages for folder imports', () => {
+			// folder_ripper still drives a MakeMKV remux pass, so folder imports
+			// share the disc 5-stage lifecycle. An earlier 4-stage variant left
+			// video_ripping on folder jobs unmapped.
 			renderComponent(JobLifecycle, {
-				props: { status: 'transcoding', sourceType: 'folder' }
+				props: { status: 'video_ripping', sourceType: 'folder' }
 			});
 			expect(screen.getByText('Waiting')).toBeInTheDocument();
 			expect(screen.getByText('Identifying')).toBeInTheDocument();
-			expect(screen.queryByText('Ripping')).toBeNull();
+			expect(screen.getByText('Ripping')).toBeInTheDocument();
 			expect(screen.getByText('Transcoding')).toBeInTheDocument();
 			expect(screen.getByText('Complete')).toBeInTheDocument();
 		});

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -6867,31 +6867,3 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
-
-export type RootStaticOrSpaFilenameGetData = {
-    body?: never;
-    path: {
-        /**
-         * Filename
-         */
-        filename: string;
-    };
-    query?: never;
-    url: '/{filename}';
-};
-
-export type RootStaticOrSpaFilenameGetErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
-
-export type RootStaticOrSpaFilenameGetResponses = {
-    /**
-     * Successful Response
-     */
-    200: unknown;
-};

--- a/frontend/src/lib/utils/job-lifecycle.ts
+++ b/frontend/src/lib/utils/job-lifecycle.ts
@@ -2,7 +2,10 @@
  * Coarse 5-step lifecycle for visual progress display:
  * Waiting -> Identifying -> Ripping -> Transcoding -> Complete
  *
- * Folder imports skip the Ripping node (4 nodes total).
+ * Folder imports use the same 5 stages: folder_ripper still drives a
+ * MakeMKV remux pass (job.status = VIDEO_RIPPING) before handing off to
+ * the transcoder. An earlier 4-stage variant that omitted "Ripping"
+ * left video_ripping/audio_ripping unmapped, painting all nodes pending.
  *
  * Maps the disambiguated v2.0.0 JobState wire strings (and legacy pre-v2
  * strings, defensive) to lifecycle stages. Failures paint the active
@@ -38,12 +41,6 @@ const ALL_STAGES: { id: LifecycleStageId; label: string }[] = [
 	{ id: 'complete',     label: 'Complete' }
 ];
 
-const FOLDER_STAGES: { id: LifecycleStageId; label: string }[] = [
-	{ id: 'waiting',      label: 'Waiting' },
-	{ id: 'identifying',  label: 'Identifying' },
-	{ id: 'transcoding',  label: 'Transcoding' },
-	{ id: 'complete',     label: 'Complete' }
-];
 
 const STATUS_TO_STAGE: Record<string, LifecycleStageId> = {
 	// Waiting
@@ -94,7 +91,8 @@ export function deriveLifecycle(
 	status: string | null | undefined,
 	sourceType: string | null | undefined
 ): LifecycleNode[] {
-	const stages = isFolderImport(sourceType) ? FOLDER_STAGES : ALL_STAGES;
+	void sourceType;
+	const stages = ALL_STAGES;
 	const lower = (status ?? '').toLowerCase();
 
 	if (FAILURE_STATUSES.has(lower)) {


### PR DESCRIPTION
## Summary
- Folder-import job lifecycle widget rendered all-pending (no active stage) because the 4-stage FOLDER_STAGES variant had no Ripping node, while folder_ripper still drives status=VIDEO_RIPPING during MakeMKV remux.
- Drop FOLDER_STAGES; folder imports share the disc 5-stage lifecycle.
- isFolderImport remains exported - other components still use it to relabel the badge (\"Importing\") and hide track-count chips.

## Repro
hifi 18.1.0-rc job 224 (Annihilation folder import):
- source_type = folder
- status = video_ripping
- Job detail rendered: Waiting | Identifying | Transcoding | Complete - all painted pending with no active node, lifecycle looked frozen even though /api/dashboard polled fresh status every cycle.

## Test plan
- [x] 961 / 961 frontend tests pass (was 960; +1 regression test, 2 modified)
- [x] Lifecycle test asserts video_ripping on folder source paints ripping active (job-lifecycle.test.ts:117)
- [x] JobLifecycle component renders the 5 stage labels for folder imports
- [ ] Smoke on hifi: open job 224, verify Ripping node now lights up active