### PR TITLE
fix(jobs): drop void operator in deriveLifecycle + S1244 in BFF test

### DIFF
--- a/frontend/src/lib/utils/job-lifecycle.ts
+++ b/frontend/src/lib/utils/job-lifecycle.ts
@@ -89,19 +89,21 @@ export function isFolderImport(sourceType: string | null | undefined): boolean {
  */
 export function deriveLifecycle(
 	status: string | null | undefined,
-	sourceType: string | null | undefined
+	_sourceType?: string | null
 ): LifecycleNode[] {
-	void sourceType;
 	const stages = ALL_STAGES;
 	const lower = (status ?? '').toLowerCase();
 
 	if (FAILURE_STATUSES.has(lower)) {
 		// Failure snapshot: paint the last non-complete stage red.
 		const failIndex = stages.length - 2; // index of stage before 'complete'
-		return stages.map((s, i) => ({
-			...s,
-			state: i < failIndex ? 'completed' : i === failIndex ? 'failed' : 'pending'
-		}));
+		return stages.map((s, i) => {
+			let state: LifecycleNodeState;
+			if (i < failIndex) state = 'completed';
+			else if (i === failIndex) state = 'failed';
+			else state = 'pending';
+			return { ...s, state };
+		});
 	}
 
 	const stageId = STATUS_TO_STAGE[lower];

--- a/tests/routers/test_progress_copy.py
+++ b/tests/routers/test_progress_copy.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 
 async def test_progress_endpoint_includes_copy_fields(app_client):
     """When arm-neu reports copy_progress / copy_stage, the BFF passes them
@@ -31,7 +33,7 @@ async def test_progress_endpoint_includes_copy_fields(app_client):
         response = await app_client.get("/api/jobs/42/progress")
     assert response.status_code == 200
     data = response.json()
-    assert data["copy_progress"] == 47.5
+    assert data["copy_progress"] == pytest.approx(47.5)
     assert data["copy_stage"] == "scratch-to-media"
 
 


### PR DESCRIPTION
## Summary
Two SonarCloud quality issues introduced by the recent PRs (#284 + #320):

1. `frontend/src/lib/utils/job-lifecycle.ts:94` - **CRITICAL** \"Remove this use of the 'void' operator\". The folder-lifecycle fix (#320) used `void sourceType` to suppress the unused-arg lint after FOLDER_STAGES was retired. Switch to the underscore-prefix convention (`_sourceType`), which is the standard intentional-unused signal across TS/ESLint/Sonar. Make the param optional since callers no longer need it.
2. `frontend/src/lib/utils/job-lifecycle.ts:103` - MAJOR nested-ternary. Refactor the failure-stage paint into an explicit if/else.
3. `tests/routers/test_progress_copy.py:34` - **BUG/MAJOR** `python:S1244`. Same treatment as the arm-neu sibling fix (use `pytest.approx`).

These were the issues blocking new_reliability_rating from A on the arm-ui quality gate.

## Test plan
- [x] 32/32 lifecycle tests pass (job-lifecycle.test.ts + JobLifecycle.test.ts)
- [x] `pytest tests/routers/test_progress_copy.py` -> 2/2 pass
- [ ] SonarCloud reliability rating returns to A on merge