### PR TITLE
chore(env): align .env.example with compose webhook-secret convention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,32 @@
+# Standalone arm-ui deployment env. Read by docker-compose.yml in this
+# repo and by the dev runner (`python -m backend.main`).
+#
+# When arm-ui is deployed alongside arm-rippers via the arm-neu repo's
+# docker-compose.yml, those env vars live in arm-neu's .env file - this
+# file is only relevant for the standalone "UI talking to an existing
+# ARM/Transcoder" use case.
+
 # ARM web UI base URL (for job actions: abandon, delete, fix permissions)
 ARM_UI_ARM_URL=http://localhost:8080
 
 # Transcoder API base URL
 ARM_UI_TRANSCODER_URL=http://localhost:5000
 
-# Optional: Transcoder API key
-ARM_UI_TRANSCODER_API_KEY=
-
-# Webhook secret for authenticating outbound transcoder webhooks. Must
-# match WEBHOOK_SECRET on the transcoder host. Read once at startup;
-# rotation requires a container restart.
-ARM_UI_TRANSCODER_WEBHOOK_SECRET=
-
 # Set to false for ripper-only deployments (no transcoder).
 # Hides all transcoder UI surfaces and short-circuits transcoder HTTP calls.
 ARM_UI_TRANSCODER_ENABLED=true
+
+# Optional: Transcoder API key
+ARM_UI_TRANSCODER_API_KEY=
+
+# Webhook secret for authenticating outbound transcoder webhooks.
+# Convention: set the bare WEBHOOK_SECRET below; docker-compose.yml
+# translates it into ARM_UI_TRANSCODER_WEBHOOK_SECRET inside the
+# container. The same WEBHOOK_SECRET value should match what
+# arm-neu and the transcoder .env files use, so all three services
+# agree on one secret.
+# Read once at startup; rotation requires a container restart.
+WEBHOOK_SECRET=
 
 # Directory for custom color scheme JSON/CSS files
 ARM_UI_THEMES_PATH=/data/themes
@@ -22,5 +34,7 @@ ARM_UI_THEMES_PATH=/data/themes
 # Directory for cached poster/cover images
 ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
 
-# Server port
-ARM_UI_PORT=8888
+# Internal listen port for the dev runner (`python -m backend.main`).
+# In Docker, the listener is hardcoded to 8888 by the Dockerfile CMD;
+# use UI_PORT instead to remap the host-side port binding.
+# ARM_UI_PORT=8888

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,9 @@
 # for themes and image cache. Zero filesystem coupling to the ripper.
 #
 # Set WEBHOOK_SECRET in .env to authenticate outbound transcoder webhook
-# calls. Must match WEBHOOK_SECRET on the transcoder host (same operator-
-# facing variable name used by the arm-neu compose stacks).
+# calls. The compose file translates that bare name into the
+# ARM_UI_-prefixed var the BFF reads, matching the same convention used
+# by the arm-neu and transcoder stacks (one secret, three translations).
 
 services:
   arm-ui:
@@ -15,6 +16,8 @@ services:
       - ARM_UI_TRANSCODER_URL=${ARM_UI_TRANSCODER_URL:-http://localhost:5000}
       - ARM_UI_TRANSCODER_ENABLED=${ARM_UI_TRANSCODER_ENABLED:-true}
       - ARM_UI_TRANSCODER_API_KEY=${ARM_UI_TRANSCODER_API_KEY:-}
+      # Translates bare WEBHOOK_SECRET (same name used by arm-neu and the
+      # transcoder) into the ARM_UI_-prefixed var the BFF reads.
       - ARM_UI_TRANSCODER_WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
       - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images


### PR DESCRIPTION
## Summary
Two cleanup items from a cross-file audit of arm-ui's compose + env:

### Real (HIGH)
\`.env.example\` told users to set \`ARM_UI_TRANSCODER_WEBHOOK_SECRET\` directly. The compose file actually reads bare \`WEBHOOK_SECRET\` from .env and translates it into the ARM_UI_-prefixed var inside the container:

\`\`\`yaml
- ARM_UI_TRANSCODER_WEBHOOK_SECRET=\${WEBHOOK_SECRET:-}
\`\`\`

Users following .env.example would set the wrong key and their webhook would silently authenticate with an empty secret. The transcoder webhook router would then either reject (when WEBHOOK_SECRET is set on the transcoder side) or accept (when both are empty), masking the misconfig.

This matches the cross-stack convention - arm-neu's .env.example and the transcoder's .env.example both use bare \`WEBHOOK_SECRET\` so all three services share one operator-facing key. arm-ui was the odd one out.

### Cleanup
\`ARM_UI_PORT\` was advertised as 'Server port' in .env.example but:
- Dockerfile CMD hardcodes \`uvicorn --port 8888\`
- Compose env block doesn't pass \`ARM_UI_PORT\` through

So the var only does anything when running \`python -m backend.main\` (dev runner outside docker). Commented it out with a note about \`UI_PORT\` being the right knob for Docker host-side port remapping.

Also reordered .env.example fields to match the compose env block ordering and added a header explaining this file's narrow scope (standalone UI talking to an existing ARM/Transcoder, not the full arm-neu deployment which has its own .env).

## Test plan
Doc/comment-only change. The actual env var the BFF reads (\`ARM_UI_TRANSCODER_WEBHOOK_SECRET\`) is unchanged - this PR only fixes the misleading user-facing documentation.