### PR TITLE
fix(dashboard): render 0% progress bar instead of indeterminate spinner

### DIFF
--- a/frontend/src/lib/components/ActiveJobRow.svelte
+++ b/frontend/src/lib/components/ActiveJobRow.svelte
@@ -165,7 +165,10 @@
 	<!-- Progress row: own line below a divider, indented under content -->
 	{#if active}
 		<div class="mt-2 border-t border-primary/10 dark:border-primary/15 px-4 pl-[64px] pr-4 py-2.5">
-			{#if progress != null && progress > 0}
+			{#if progress != null}
+				<!-- Render the bar even at 0%. The MakeMKV prelude (libredrive
+				     init, key ingest) can sit at 0 for several seconds and
+				     "ripping 0%" is more honest than an indeterminate spinner. -->
 				<ProgressBar value={progress} colorVar={accentVar} />
 			{:else}
 				<div class="flex items-center gap-2">

--- a/frontend/src/lib/components/TranscodeCard.svelte
+++ b/frontend/src/lib/components/TranscodeCard.svelte
@@ -118,7 +118,11 @@
 	<!-- Progress row: own line below a divider, indented under content -->
 	{#if isActive}
 		<div class="mt-2 border-t border-primary/10 dark:border-primary/15 px-4 pl-[64px] pr-4 py-2.5">
-			{#if typeof job.progress === 'number' && job.progress > 0}
+			{#if typeof job.progress === 'number'}
+				<!-- Render the bar even at 0%. Encoding can sit at 0 for the first
+				     pass (HandBrake/ffmpeg analyze + indexing) and the user wants
+				     to see "encoding 0%" not an indeterminate spinner with no
+				     percentage. -->
 				<ProgressBar value={job.progress} colorVar={accentVar} />
 			{:else}
 				<div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
Live observation on hifi 18.1.0 GA, job 225 (Star Knight DVD rip into transcode): the TRANSCODING dashboard section rendered TranscodeCard with no percentage and an animated bar that never resolved into a number for the entire encode prelude.

### Cause
\`TranscodeCard.svelte:121\` gated the progress bar on:
\`\`\`ts
typeof job.progress === 'number' && job.progress > 0
\`\`\`

The transcoder reports \`progress=0\` from job creation through HandBrake's analyze + index pass - multi-second window on small DVDs, multi-minute on Blu-ray. The strict \`> 0\` check caused the else branch (indeterminate spinner with no percentage) to render the whole time.

Same pattern existed at \`ActiveJobRow.svelte:168\` for the rip side: MakeMKV's libredrive init + key-ingest stage holds \`rip_progress\` at 0 for several seconds, again hiding the percentage behind a spinner.

### Fix
Drop the \`> 0\` clause from both gates. A 0% bar with the percentage label is more honest than an indeterminate animation that hides actual state. The indeterminate branch still fires when progress is genuinely null (no telemetry yet).

## Test plan
- [x] TranscodeCard.test.ts: 9 existing tests pass without modification (the 0% indeterminate behavior was never explicitly tested - it was incidental)
- [x] ActiveJobRow.test.ts: 14 tests pass
- [x] dashboard-page.test.ts: 47 tests pass
- [ ] Smoke on hifi: next rip should show "encoding 0%" / "ripping 0%" instead of an animated spinner