### PR TITLE
feat: MediaMetadata pass-through + dynamic pattern-token chips

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from backend.routers import (
     logs,
     maintenance,
     notifications,
+    patterns,
     settings,
     setup,
     system,
@@ -70,6 +71,7 @@ app.include_router(setup.router)
 app.include_router(system.router)
 app.include_router(images.router)
 app.include_router(maintenance.router)
+app.include_router(patterns.router)
 
 # Serve static frontend build if it exists
 static_dir = Path(__file__).parent.parent / "frontend" / "build"

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -253,6 +253,17 @@ async def get_job_progress(job_id: int):
     }
 
 
+@router.get("/jobs/{job_id}/metadata", responses=_404_502_ARM)
+async def get_job_metadata(job_id: int):
+    """Pass-through to ARM's merged MediaMetadata for a job."""
+    data = await arm_client.get_job_metadata(job_id)
+    if data is None:
+        raise HTTPException(status_code=502, detail=_ARM_UNREACHABLE)
+    if isinstance(data, dict) and data.get("detail") == "Job not found":
+        raise HTTPException(status_code=404, detail=_JOB_NOT_FOUND)
+    return data
+
+
 @router.get("/jobs/{job_id}/crc-lookup", responses=_404_502_ARM)
 async def crc_lookup_endpoint(job_id: int):
     """Look up a job's CRC64 hash in the community database."""

--- a/backend/routers/patterns.py
+++ b/backend/routers/patterns.py
@@ -1,0 +1,24 @@
+"""Pattern-token vocabulary endpoint - feeds the UI's pattern-editor
+autocomplete. Sourced from arm_contracts.PATTERN_TOKENS so adding a new
+token in contracts auto-flows through to the UI on the next BFF restart.
+"""
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from arm_contracts import PATTERN_TOKENS
+
+router = APIRouter(prefix="/api/patterns", tags=["patterns"])
+
+
+class PatternTokenInfo(BaseModel):
+    field_name: str
+    description: str
+
+
+@router.get("/tokens", response_model=dict[str, PatternTokenInfo])
+async def get_pattern_tokens():
+    """Return all available naming-pattern tokens with their descriptions."""
+    return {
+        alias: PatternTokenInfo(field_name=field, description=desc)
+        for alias, (field, desc, _accessor) in PATTERN_TOKENS.items()
+    }

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -300,6 +300,22 @@ async def get_media_detail(imdb_id: str) -> dict[str, Any] | None:
     return resp.json()
 
 
+async def get_job_metadata(job_id: int) -> dict[str, Any] | None:
+    """Fetch merged MediaMetadata for a job via ARM.
+
+    Returns None on 404 (caller raises 404 to its own client) or on
+    transport failure (caller raises 502).
+    """
+    try:
+        resp = await get_client().get(f"/api/v1/jobs/{job_id}/metadata")
+    except (httpx.ConnectError, httpx.HTTPError):
+        return None
+    if resp.status_code == 404:
+        return {"detail": "Job not found"}
+    resp.raise_for_status()
+    return resp.json()
+
+
 async def search_music_metadata(
     query: str, **kwargs: Any
 ) -> dict[str, Any]:

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -2291,6 +2291,20 @@ export type PathRequest = {
 };
 
 /**
+ * PatternTokenInfo
+ */
+export type PatternTokenInfo = {
+    /**
+     * Field Name
+     */
+    field_name: string;
+    /**
+     * Description
+     */
+    description: string;
+};
+
+/**
  * PreflightFixResult
  */
 export type PreflightFixResult = {
@@ -3562,6 +3576,42 @@ export type GetJobProgressApiJobsJobIdProgressGetErrors = {
 export type GetJobProgressApiJobsJobIdProgressGetError = GetJobProgressApiJobsJobIdProgressGetErrors[keyof GetJobProgressApiJobsJobIdProgressGetErrors];
 
 export type GetJobProgressApiJobsJobIdProgressGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type GetJobMetadataApiJobsJobIdMetadataGetData = {
+    body?: never;
+    path: {
+        /**
+         * Job Id
+         */
+        job_id: number;
+    };
+    query?: never;
+    url: '/api/jobs/{job_id}/metadata';
+};
+
+export type GetJobMetadataApiJobsJobIdMetadataGetErrors = {
+    /**
+     * Job not found
+     */
+    404: unknown;
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+    /**
+     * ARM service unreachable
+     */
+    502: unknown;
+};
+
+export type GetJobMetadataApiJobsJobIdMetadataGetError = GetJobMetadataApiJobsJobIdMetadataGetErrors[keyof GetJobMetadataApiJobsJobIdMetadataGetErrors];
+
+export type GetJobMetadataApiJobsJobIdMetadataGetResponses = {
     /**
      * Successful Response
      */
@@ -6867,3 +6917,51 @@ export type ClearImageCacheApiMaintenanceClearImageCachePostResponses = {
 };
 
 export type ClearImageCacheApiMaintenanceClearImageCachePostResponse = ClearImageCacheApiMaintenanceClearImageCachePostResponses[keyof ClearImageCacheApiMaintenanceClearImageCachePostResponses];
+
+export type GetPatternTokensApiPatternsTokensGetData = {
+    body?: never;
+    path?: never;
+    query?: never;
+    url: '/api/patterns/tokens';
+};
+
+export type GetPatternTokensApiPatternsTokensGetResponses = {
+    /**
+     * Response Get Pattern Tokens Api Patterns Tokens Get
+     *
+     * Successful Response
+     */
+    200: {
+        [key: string]: PatternTokenInfo;
+    };
+};
+
+export type GetPatternTokensApiPatternsTokensGetResponse = GetPatternTokensApiPatternsTokensGetResponses[keyof GetPatternTokensApiPatternsTokensGetResponses];
+
+export type RootStaticOrSpaFilenameGetData = {
+    body?: never;
+    path: {
+        /**
+         * Filename
+         */
+        filename: string;
+    };
+    query?: never;
+    url: '/{filename}';
+};
+
+export type RootStaticOrSpaFilenameGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
+
+export type RootStaticOrSpaFilenameGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -6937,31 +6937,3 @@ export type GetPatternTokensApiPatternsTokensGetResponses = {
 };
 
 export type GetPatternTokensApiPatternsTokensGetResponse = GetPatternTokensApiPatternsTokensGetResponses[keyof GetPatternTokensApiPatternsTokensGetResponses];
-
-export type RootStaticOrSpaFilenameGetData = {
-    body?: never;
-    path: {
-        /**
-         * Filename
-         */
-        filename: string;
-    };
-    query?: never;
-    url: '/{filename}';
-};
-
-export type RootStaticOrSpaFilenameGetErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
-
-export type RootStaticOrSpaFilenameGetResponses = {
-    /**
-     * Successful Response
-     */
-    200: unknown;
-};

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1245,11 +1245,7 @@
 			{/if}
 
 			{#if key.endsWith('_PATTERN') && settings?.naming_variables}
-				{@const patternVars = Object.entries(settings.naming_variables).filter(([v]) => {
-					if (key.startsWith('MUSIC_')) return ['title', 'year', 'artist', 'album', 'label'].includes(v);
-					if (key.startsWith('TV_')) return ['show', 'title', 'year', 'season', 'episode', 'episode_name', 'label', 'video_type', 'disc_number', 'disc_total'].includes(v);
-					return ['title', 'year', 'label', 'video_type', 'disc_number', 'disc_total'].includes(v);
-				})}
+				{@const patternVars = Object.entries(settings.naming_variables).sort(([a], [b]) => a.localeCompare(b))}
 				<div class="mt-1.5 flex flex-wrap gap-1">
 					{#each patternVars as [varName, varDesc]}
 						<span

--- a/tests/routers/test_metadata.py
+++ b/tests/routers/test_metadata.py
@@ -318,3 +318,62 @@ class TestSettingsTestMetadata:
         data = resp.json()
         assert data["success"] is False
         assert "unreachable" in data["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/jobs/{job_id}/metadata - MediaMetadata pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestJobMediaMetadata:
+    async def test_passthrough(self, app_client):
+        """ARM returns a merged MediaMetadata dict; BFF passes it through."""
+        fake_metadata = {
+            "title": "Annihilation",
+            "year": "2018",
+            "directors": ["Alex Garland"],
+            "genres": ["Sci-Fi"],
+        }
+        with patch("backend.routers.jobs.arm_client.get_job_metadata",
+                   new_callable=AsyncMock, return_value=fake_metadata):
+            resp = await app_client.get("/api/jobs/42/metadata")
+        assert resp.status_code == 200
+        assert resp.json()["directors"] == ["Alex Garland"]
+
+    async def test_job_not_found(self, app_client):
+        with patch("backend.routers.jobs.arm_client.get_job_metadata",
+                   new_callable=AsyncMock,
+                   return_value={"detail": "Job not found"}):
+            resp = await app_client.get("/api/jobs/999/metadata")
+        assert resp.status_code == 404
+
+    async def test_arm_unreachable(self, app_client):
+        with patch("backend.routers.jobs.arm_client.get_job_metadata",
+                   new_callable=AsyncMock, return_value=None):
+            resp = await app_client.get("/api/jobs/42/metadata")
+        assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# GET /api/patterns/tokens - PATTERN_TOKENS vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestPatternTokens:
+    async def test_returns_full_vocabulary(self, app_client):
+        """Lists every PATTERN_TOKENS alias with field_name + description."""
+        resp = await app_client.get("/api/patterns/tokens")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Spot-check a few aliases the contract guarantees.
+        for alias in ("title", "year", "director", "genre", "video_type"):
+            assert alias in data, f"missing token: {alias}"
+            assert data[alias]["description"]
+        assert data["director"]["field_name"] == "directors"
+        assert data["genre"]["field_name"] == "genres"
+
+    async def test_returns_17_tokens(self, app_client):
+        """v3.2.0 ships exactly 17 tokens; this guards regressions."""
+        resp = await app_client.get("/api/patterns/tokens")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 17


### PR DESCRIPTION
## Summary

Phase 3 of the MediaMetadata-contract rollout (Phase 1 = contracts v3.2.0, Phase 2 = arm-neu PR #361 merged 2026-05-11).

Bumps the contracts submodule to v3.2.0 and adds two BFF endpoints + a one-line settings-page fix so the new 17-token contract vocabulary surfaces in the pattern-editor UI.

## BFF changes

- **GET /api/jobs/{job_id}/metadata** - thin pass-through to ARM's /api/v1/jobs/{id}/metadata. Returns the merged MediaMetadata blob. 404 on job-not-found from ARM; 502 on transport failure.
- **GET /api/patterns/tokens** - serves arm_contracts.PATTERN_TOKENS as a {alias: {field_name, description}} map for the pattern-editor autocomplete. Adding a new token in contracts auto-flows through on the next BFF restart.

openapi-ts codegen picks up both endpoints + the new \`PatternTokenInfo\` schema; frontend type-safety follows for free.

## Frontend change

The settings page renders {token} chips below each *_TITLE_PATTERN and *_FOLDER_PATTERN field. Previously hard-coded per-category whitelists filtered the chip list down to 5-10 tokens per pattern type, hiding every new contract token. Replaced with a sorted listing of every available token. The naming engine accepts any of them in any pattern (movie patterns with {director} work today after Phase 2), so gating the chips was misleading.

## Tests

- 5 new BFF tests (\`tests/routers/test_metadata.py::TestJobMediaMetadata\` + \`::TestPatternTokens\`)
- 672 backend tests pass
- 961 frontend tests pass

## Commits

- \`570668e\` chore: bump components/contracts to MediaMetadata release
- \`826836d\` feat(bff): /api/jobs/{id}/metadata + /api/patterns/tokens endpoints
- \`e9ca223\` feat(ui): pattern editor shows all PATTERN_TOKENS, sorted alphabetically

## Smoke plan

After merge, deploy RC images on hifi and verify:
1. Pattern editor in settings shows the full token set (director, genre, runtime_minutes, etc.)
2. Editing a pattern with {director} renders correctly on a movie job
3. GET /api/jobs/{id}/metadata returns the merged blob for an active job