### PR TITLE
chore: point CLAUDE.md at arm-ai memory and commit-rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,19 @@
 
 Plans, specs, and research for this project live in a **separate private repo**, not in this repo. This keeps AI-collaboration artifacts out of the project history and syncs them across machines.
 
-Expected location: `../ai/<project-subdir>/docs/superpowers/`
-  - arm-neu        -> ../ai/arm-neu/docs/superpowers/
-  - arm-ui         -> ../ai/arm-ui/docs/superpowers/
-  - arm-transcoder -> ../ai/arm-transcoder/docs/superpowers/
+Expected location: `../arm-ai/<project-subdir>/docs/superpowers/`
+  - arm-neu        -> ../arm-ai/arm-neu/docs/superpowers/
+  - arm-ui         -> ../arm-ai/arm-ui/docs/superpowers/
+  - arm-transcoder -> ../arm-ai/arm-transcoder/docs/superpowers/
 
-When the brainstorming, writing-plans, or executing-plans skills reference `docs/superpowers/specs/...` or `docs/superpowers/plans/...`, resolve those paths against the sibling `ai/` repo above, not this repo.
+When the brainstorming, writing-plans, or executing-plans skills reference `docs/superpowers/specs/...` or `docs/superpowers/plans/...`, resolve those paths against the sibling `arm-ai/` repo above, not this repo.
 
-If the sibling `ai/` directory does not exist, ask the user before creating specs/plans anywhere else. Other developers using this fork should maintain their own equivalent sibling repo.
+If the sibling `arm-ai/` directory does not exist, ask the user before creating specs/plans anywhere else. Other developers using this fork should maintain their own equivalent sibling repo.
 
-## Git Commits
-- Never include `Co-Authored-By` lines in commit messages
-- Do not sign commits with Claude's name or email
+## Memory
+
+Auto-memory for this repo lives at `../arm-ai/arm-ui/memory/` (start with `MEMORY.md`). Read and write memories there, not in this repo.
+
+## Commit Rules
+
+Engineering standards (branching, PR targets, CI gates, deploy commands) are in `../arm-ai/commit-rules.md` and `../arm-ai/arm-ui/commit-rules.md`. Follow both before committing.


### PR DESCRIPTION
## Summary
- Add `## Memory` section pointing to `../arm-ai/arm-ui/memory/` (start at `MEMORY.md`)
- Add `## Commit Rules` section pointing to `../arm-ai/commit-rules.md` + `../arm-ai/arm-ui/commit-rules.md`
- Remove the inline `Co-Authored-By` / signing bullets — they're already covered by the top-level commit-rules.md

Keeps CLAUDE.md minimal: pointers only, no duplicated content.

## Test plan
- [ ] Verify `../arm-ai/arm-ui/memory/MEMORY.md` resolves from this repo root
- [ ] Verify `../arm-ai/commit-rules.md` and `../arm-ai/arm-ui/commit-rules.md` resolve