### PR TITLE
docs: link contracts repo in Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Part of the Automatic Ripping Machine (neu) ecosystem:
 | [automatic-ripping-machine-neu](https://github.com/uprightbass360/automatic-ripping-machine-neu) | Fork of the original ARM with bug fixes and improvements |
 | **automatic-ripping-machine-ui** | Modern replacement dashboard (this project) |
 | [automatic-ripping-machine-transcoder](https://github.com/uprightbass360/automatic-ripping-machine-transcoder) | GPU-accelerated transcoding service |
+| [automatic-ripping-machine-contracts](https://github.com/uprightbass360/automatic-ripping-machine-contracts) | Typed shared-contracts layer keeping the services in lockstep |
 
 The original upstream project: [automatic-ripping-machine/automatic-ripping-machine](https://github.com/automatic-ripping-machine/automatic-ripping-machine)
 


### PR DESCRIPTION
## Summary
- Add automatic-ripping-machine-contracts row to the Related Projects table in README so the shared-contracts repo is discoverable alongside the other three components.

## Test plan
- [ ] Render README on GitHub and confirm the contracts link resolves.