### PR TITLE
feat(notifications)!: channels management page (sub-spec 3)

### DIFF
--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -27,3 +27,89 @@ async def dismiss_notification(notify_id: int) -> dict[str, Any]:
         detail = result.get("message") or "Failed to dismiss notification"
         raise HTTPException(status_code=502, detail=detail)
     return result
+
+
+# --- Channels (v4 channels system) ---
+
+_UNREACHABLE = "ARM web UI is unreachable"
+
+
+@router.get("/notifications/channels")
+async def list_channels() -> Any:
+    resp = await arm_client.list_channels()
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.get("/notifications/channels/{channel_id}")
+async def get_channel(channel_id: int) -> Any:
+    resp = await arm_client.get_channel(channel_id)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.post("/notifications/channels")
+async def create_channel(body: dict[str, Any]) -> Any:
+    resp = await arm_client.create_channel(body)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.patch("/notifications/channels/{channel_id}")
+async def update_channel(channel_id: int, body: dict[str, Any]) -> Any:
+    resp = await arm_client.update_channel(channel_id, body)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.delete("/notifications/channels/{channel_id}")
+async def delete_channel(channel_id: int) -> Any:
+    resp = await arm_client.delete_channel(channel_id)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.post("/notifications/channels/{channel_id}/test")
+async def test_send_channel(channel_id: int, body: dict[str, Any] | None = None) -> Any:
+    resp = await arm_client.test_send_channel(channel_id, body or {})
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.get("/notifications/dispatch/{dispatch_id}")
+async def get_dispatch(dispatch_id: int) -> Any:
+    resp = await arm_client.get_dispatch(dispatch_id)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.get("/notifications/dispatches")
+async def list_dispatches(channel_id: int | None = None, status: str | None = None,
+                          limit: int = 50) -> Any:
+    resp = await arm_client.list_dispatches(channel_id=channel_id, status=status, limit=limit)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.get("/notifications/services")
+async def get_services() -> Any:
+    resp = await arm_client.get_services()
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp
+
+
+@router.post("/notifications/services/{service_id}/compose-url")
+async def compose_channel_url(service_id: str, body: dict[str, Any]) -> Any:
+    resp = await arm_client.compose_channel_url(service_id, body)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -793,7 +793,11 @@ async def get_services() -> dict[str, Any] | None:
 
 async def compose_channel_url(service_id: str, body: dict[str, Any]) -> dict[str, Any] | None:
     """Compose an apprise URL from form values. Returns None if unreachable."""
-    return await _request("POST", f"/api/v1/notifications/services/{service_id}/compose-url", json=body)
+    return await _request(
+        "POST",
+        f"/api/v1/notifications/services/{quote(service_id, safe='')}/compose-url",
+        json=body,
+    )
 
 
 # --- Health ---

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -740,7 +740,7 @@ async def purge_cleared_notifications() -> dict[str, Any] | None:
 # --- Notification channels (v4 channels system) ---
 
 
-async def list_channels() -> Any:
+async def list_channels() -> list[dict[str, Any]] | None:
     """List notification channels. Returns None if ARM is unreachable."""
     return await _request("GET", "/api/v1/notifications/channels")
 
@@ -776,7 +776,7 @@ async def get_dispatch(dispatch_id: int) -> dict[str, Any] | None:
 
 
 async def list_dispatches(channel_id: int | None = None, status: str | None = None,
-                          limit: int = 50) -> Any:
+                          limit: int = 50) -> list[dict[str, Any]] | None:
     """List dispatches with optional filters. Returns None if unreachable."""
     params: dict[str, Any] = {"limit": limit}
     if channel_id is not None:

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -737,6 +737,65 @@ async def purge_cleared_notifications() -> dict[str, Any] | None:
     return await _request("POST", "/api/v1/notifications/purge")
 
 
+# --- Notification channels (v4 channels system) ---
+
+
+async def list_channels() -> Any:
+    """List notification channels. Returns None if ARM is unreachable."""
+    return await _request("GET", "/api/v1/notifications/channels")
+
+
+async def get_channel(channel_id: int) -> dict[str, Any] | None:
+    """Fetch one channel. Returns None if ARM is unreachable."""
+    return await _request("GET", f"/api/v1/notifications/channels/{channel_id}")
+
+
+async def create_channel(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Create a channel. Returns None if ARM is unreachable."""
+    return await _request("POST", "/api/v1/notifications/channels", json=body)
+
+
+async def update_channel(channel_id: int, body: dict[str, Any]) -> dict[str, Any] | None:
+    """Patch a channel. Returns None if ARM is unreachable."""
+    return await _request("PATCH", f"/api/v1/notifications/channels/{channel_id}", json=body)
+
+
+async def delete_channel(channel_id: int) -> dict[str, Any] | None:
+    """Delete a channel. Returns None if ARM is unreachable."""
+    return await _request("DELETE", f"/api/v1/notifications/channels/{channel_id}")
+
+
+async def test_send_channel(channel_id: int, body: dict[str, Any]) -> dict[str, Any] | None:
+    """Trigger a test send. Returns None if ARM is unreachable."""
+    return await _request("POST", f"/api/v1/notifications/channels/{channel_id}/test", json=body)
+
+
+async def get_dispatch(dispatch_id: int) -> dict[str, Any] | None:
+    """Fetch one dispatch (outbox row) status. Returns None if unreachable."""
+    return await _request("GET", f"/api/v1/notifications/dispatch/{dispatch_id}")
+
+
+async def list_dispatches(channel_id: int | None = None, status: str | None = None,
+                          limit: int = 50) -> Any:
+    """List dispatches with optional filters. Returns None if unreachable."""
+    params: dict[str, Any] = {"limit": limit}
+    if channel_id is not None:
+        params["channel_id"] = channel_id
+    if status is not None:
+        params["status"] = status
+    return await _request("GET", "/api/v1/notifications/dispatches", params=params)
+
+
+async def get_services() -> dict[str, Any] | None:
+    """Fetch the apprise service catalog. Returns None if unreachable."""
+    return await _request("GET", "/api/v1/notifications/services")
+
+
+async def compose_channel_url(service_id: str, body: dict[str, Any]) -> dict[str, Any] | None:
+    """Compose an apprise URL from form values. Returns None if unreachable."""
+    return await _request("POST", f"/api/v1/notifications/services/{service_id}/compose-url", json=body)
+
+
 # --- Health ---
 
 

--- a/frontend/src/lib/__tests__/channels-api.test.ts
+++ b/frontend/src/lib/__tests__/channels-api.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as client from '$lib/api/client';
+import {
+	fetchChannels, fetchChannel, createChannel, updateChannel,
+	deleteChannel, testSendChannel, fetchDispatch, fetchDispatches,
+	fetchServices, composeUrl
+} from '$lib/api/channels';
+
+describe('channels api', () => {
+	beforeEach(() => vi.restoreAllMocks());
+
+	it('fetchChannels GETs the list', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue([{ id: 1 }] as never);
+		const out = await fetchChannels();
+		expect(spy).toHaveBeenCalledWith('/api/notifications/channels');
+		expect(out).toEqual([{ id: 1 }]);
+	});
+
+	it('fetchChannel GETs by id', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ id: 3 } as never);
+		await fetchChannel(3);
+		expect(spy).toHaveBeenCalledWith('/api/notifications/channels/3');
+	});
+
+	it('createChannel POSTs the body', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ id: 9 } as never);
+		const body = { type: 'apprise', name: 'x', config: { type: 'apprise', url: 'discord://a/b' }, subscribed_events: [] };
+		await createChannel(body as never);
+		expect(spy).toHaveBeenCalledWith('/api/notifications/channels', {
+			method: 'POST', body: JSON.stringify(body)
+		});
+	});
+
+	it('updateChannel PATCHes', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ id: 9 } as never);
+		await updateChannel(9, { name: 'r' } as never);
+		expect(spy).toHaveBeenCalledWith('/api/notifications/channels/9', {
+			method: 'PATCH', body: JSON.stringify({ name: 'r' })
+		});
+	});
+
+	it('deleteChannel DELETEs', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({} as never);
+		await deleteChannel(9);
+		expect(spy).toHaveBeenCalledWith('/api/notifications/channels/9', { method: 'DELETE' });
+	});
+
+	it('testSendChannel POSTs event_key', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ dispatch_id: 5 } as never);
+		await testSendChannel(2, 'job.started');
+		expect(spy).toHaveBeenCalledWith('/api/notifications/channels/2/test', {
+			method: 'POST', body: JSON.stringify({ event_key: 'job.started' })
+		});
+	});
+
+	it('fetchDispatch GETs by id', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ status: 'success' } as never);
+		await fetchDispatch(5);
+		expect(spy).toHaveBeenCalledWith('/api/notifications/dispatch/5');
+	});
+
+	it('fetchDispatches builds query', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue([] as never);
+		await fetchDispatches({ channelId: 2, limit: 20 });
+		expect(spy).toHaveBeenCalledWith('/api/notifications/dispatches?channel_id=2&limit=20');
+	});
+
+	it('fetchServices GETs the catalog', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ featured: [], services: [] } as never);
+		await fetchServices();
+		expect(spy).toHaveBeenCalledWith('/api/notifications/services');
+	});
+
+	it('composeUrl POSTs required+advanced', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ url: 'discord://1' } as never);
+		await composeUrl('discord', { webhook_id: '1' }, { tts: true });
+		expect(spy).toHaveBeenCalledWith('/api/notifications/services/discord/compose-url', {
+			method: 'POST', body: JSON.stringify({ required: { webhook_id: '1' }, advanced: { tts: true } })
+		});
+	});
+});

--- a/frontend/src/lib/__tests__/notifications-types.test.ts
+++ b/frontend/src/lib/__tests__/notifications-types.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { EVENT_KEYS, isCatalogField } from '$lib/types/notifications';
+
+describe('notification types', () => {
+	it('exposes the six closed event keys', () => {
+		expect(EVENT_KEYS).toEqual([
+			'job.started',
+			'job.rip_complete',
+			'job.transcode_complete',
+			'job.failed',
+			'job.manual_wait_required',
+			'job.duplicate_detected'
+		]);
+	});
+
+	it('isCatalogField accepts a well-formed field', () => {
+		expect(isCatalogField({ key: 'tts', label: 'TTS', type: 'bool', private: false, required: false })).toBe(true);
+	});
+
+	it('isCatalogField rejects a missing key', () => {
+		expect(isCatalogField({ label: 'TTS', type: 'bool' })).toBe(false);
+	});
+});

--- a/frontend/src/lib/api/channels.ts
+++ b/frontend/src/lib/api/channels.ts
@@ -1,0 +1,70 @@
+import { apiFetch } from './client';
+import type {
+	Channel, ChannelCreate, ChannelUpdate, Catalog,
+	DispatchRow, DispatchStatus, TestSendResult, EventKey
+} from '$lib/types/notifications';
+
+export function fetchChannels(): Promise<Channel[]> {
+	return apiFetch<Channel[]>('/api/notifications/channels');
+}
+
+export function fetchChannel(id: number): Promise<Channel> {
+	return apiFetch<Channel>(`/api/notifications/channels/${id}`);
+}
+
+export function createChannel(body: ChannelCreate): Promise<Channel> {
+	return apiFetch<Channel>('/api/notifications/channels', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	});
+}
+
+export function updateChannel(id: number, body: ChannelUpdate): Promise<Channel> {
+	return apiFetch<Channel>(`/api/notifications/channels/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	});
+}
+
+export function deleteChannel(id: number): Promise<unknown> {
+	return apiFetch<unknown>(`/api/notifications/channels/${id}`, { method: 'DELETE' });
+}
+
+export function testSendChannel(id: number, eventKey: EventKey | string): Promise<TestSendResult> {
+	return apiFetch<TestSendResult>(`/api/notifications/channels/${id}/test`, {
+		method: 'POST',
+		body: JSON.stringify({ event_key: eventKey })
+	});
+}
+
+export function fetchDispatch(id: number): Promise<DispatchStatus> {
+	return apiFetch<DispatchStatus>(`/api/notifications/dispatch/${id}`);
+}
+
+export function fetchDispatches(params?: {
+	channelId?: number;
+	status?: string;
+	limit?: number;
+}): Promise<DispatchRow[]> {
+	const query = new URLSearchParams();
+	if (params?.channelId !== undefined) query.set('channel_id', String(params.channelId));
+	if (params?.status) query.set('status', params.status);
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	const qs = query.toString();
+	return apiFetch<DispatchRow[]>(`/api/notifications/dispatches${qs ? `?${qs}` : ''}`);
+}
+
+export function fetchServices(): Promise<Catalog> {
+	return apiFetch<Catalog>('/api/notifications/services');
+}
+
+export function composeUrl(
+	serviceId: string,
+	required: Record<string, unknown>,
+	advanced: Record<string, unknown>
+): Promise<{ url: string }> {
+	return apiFetch<{ url: string }>(`/api/notifications/services/${serviceId}/compose-url`, {
+		method: 'POST',
+		body: JSON.stringify({ required, advanced })
+	});
+}

--- a/frontend/src/lib/components/notifications/ChannelCard.svelte
+++ b/frontend/src/lib/components/notifications/ChannelCard.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import type { Channel } from '$lib/types/notifications';
+
+	let {
+		channel,
+		ontest,
+		ondelete
+	}: { channel: Channel; ontest: (id: number) => void; ondelete: (id: number) => void } = $props();
+
+	const statusClass = $derived(
+		!channel.enabled ? 'status-dot--disabled' : channel.last_error ? 'status-dot--error' : 'status-dot--healthy'
+	);
+</script>
+
+<div class="channel-card">
+	<span class="status-dot {statusClass}"></span>
+	<div class="channel-card__main">
+		<strong>{channel.name}</strong>
+		<span class="channel-card__type">{channel.type}{channel.enabled ? '' : ' · disabled'}</span>
+		{#if channel.last_error}
+			<span class="channel-card__error">⚠ {channel.last_error}</span>
+		{/if}
+		<span class="channel-card__events">Events: {channel.subscribed_events.join(', ')}</span>
+	</div>
+	<div class="channel-card__actions">
+		<button type="button" onclick={() => ontest(channel.id)}>Test</button>
+		<a href={`/settings/notifications/${channel.id}`}>Edit</a>
+		<button type="button" class="channel-card__delete" onclick={() => ondelete(channel.id)}>Delete</button>
+	</div>
+</div>

--- a/frontend/src/lib/components/notifications/DispatchHistory.svelte
+++ b/frontend/src/lib/components/notifications/DispatchHistory.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { DispatchRow } from '$lib/types/notifications';
+
+	let { rows }: { rows: DispatchRow[] } = $props();
+
+	function statusIcon(status: DispatchRow['status']): string {
+		if (status === 'success') return '✓';
+		if (status === 'failed') return '⚠';
+		return '⏱';
+	}
+</script>
+
+<div class="dispatch-history">
+	<h4>Recent sends</h4>
+	{#if rows.length === 0}
+		<p class="dispatch-history__empty">No sends yet.</p>
+	{:else}
+		<ul>
+			{#each rows as row (row.id)}
+				<li>
+					<span class="dispatch-history__icon">{statusIcon(row.status)}</span>
+					<span class="dispatch-history__event">{row.event_key}</span>
+					<span class="dispatch-history__time">{row.created_at ?? ''}</span>
+					{#if row.last_error}
+						<span class="dispatch-history__error">· {row.last_error}</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/frontend/src/lib/components/notifications/EventSubscriptions.svelte
+++ b/frontend/src/lib/components/notifications/EventSubscriptions.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { EVENT_KEYS, EVENT_LABELS, type EventKey } from '$lib/types/notifications';
+
+	let { selected = $bindable() }: { selected: string[] } = $props();
+
+	function toggle(key: EventKey, checked: boolean) {
+		if (checked) {
+			if (!selected.includes(key)) selected = [...selected, key];
+		} else {
+			selected = selected.filter((k) => k !== key);
+		}
+	}
+</script>
+
+<fieldset class="event-subs">
+	<legend>Events</legend>
+	{#each EVENT_KEYS as key}
+		<label>
+			<input
+				type="checkbox"
+				aria-label={EVENT_LABELS[key]}
+				checked={selected.includes(key)}
+				onchange={(e) => toggle(key, (e.currentTarget as HTMLInputElement).checked)}
+			/>
+			{EVENT_LABELS[key]}
+		</label>
+	{/each}
+</fieldset>

--- a/frontend/src/lib/components/notifications/SchemaField.svelte
+++ b/frontend/src/lib/components/notifications/SchemaField.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import type { CatalogField } from '$lib/types/notifications';
+
+	let { field, value = $bindable() }: { field: CatalogField; value: unknown } = $props();
+
+	const inputType = $derived(field.private ? 'password' : 'text');
+
+	let boolValue = $derived(Boolean(value));
+</script>
+
+<label class="schema-field">
+	<span class="schema-field__label">{field.label}{field.required ? ' *' : ''}</span>
+
+	{#if field.type === 'bool'}
+		<input
+			type="checkbox"
+			aria-label={field.label}
+			checked={boolValue}
+			onchange={(e) => (value = e.currentTarget.checked)}
+		/>
+	{:else if field.type === 'choice'}
+		<select aria-label={field.label} bind:value required={field.required}>
+			{#each field.values ?? [] as opt}
+				<option value={opt}>{opt}</option>
+			{/each}
+		</select>
+	{:else if field.type === 'int' || field.type === 'float'}
+		<input
+			type="number"
+			aria-label={field.label}
+			step={field.type === 'float' ? 'any' : '1'}
+			bind:value
+			required={field.required}
+		/>
+	{:else}
+		<input
+			type={inputType}
+			aria-label={field.label}
+			bind:value
+			required={field.required}
+		/>
+	{/if}
+</label>

--- a/frontend/src/lib/components/notifications/ServicePicker.svelte
+++ b/frontend/src/lib/components/notifications/ServicePicker.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { Catalog, CatalogService } from '$lib/types/notifications';
+
+	let { catalog, onpick }: { catalog: Catalog; onpick: (id: string) => void } = $props();
+
+	let search = $state('');
+	let showAll = $state(false);
+
+	const byId = $derived(new Map(catalog.services.map((s) => [s.id, s])));
+
+	const featuredServices = $derived(
+		catalog.featured.map((id) => byId.get(id)).filter((s): s is CatalogService => !!s)
+	);
+
+	const filtered = $derived(
+		search.trim()
+			? catalog.services.filter((s) => s.name.toLowerCase().includes(search.trim().toLowerCase()))
+			: showAll
+				? catalog.services
+				: featuredServices
+	);
+</script>
+
+<div class="service-picker">
+	<input
+		type="search"
+		placeholder="Search services"
+		bind:value={search}
+	/>
+
+	<div class="service-picker__grid">
+		{#each filtered as svc (svc.id)}
+			<button type="button" class="service-picker__item" onclick={() => onpick(svc.id)}>
+				{svc.name}
+			</button>
+		{/each}
+	</div>
+
+	{#if !search.trim() && !showAll}
+		<button type="button" class="service-picker__more" onclick={() => (showAll = true)}>
+			Show all ({catalog.services.length})
+		</button>
+	{/if}
+</div>

--- a/frontend/src/lib/components/notifications/TemplateEditor.svelte
+++ b/frontend/src/lib/components/notifications/TemplateEditor.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { EVENT_VARIABLES, EVENT_LABELS, type EventKey } from '$lib/types/notifications';
+	import type { ChannelTemplate } from '$lib/types/notifications';
+
+	let {
+		subscribedEvents,
+		templates = $bindable()
+	}: { subscribedEvents: string[]; templates: Record<string, ChannelTemplate> } = $props();
+
+	function ensure(key: string): ChannelTemplate {
+		if (!templates[key]) templates[key] = { title: null, body: null };
+		return templates[key];
+	}
+
+	function varsFor(key: string): string[] {
+		return EVENT_VARIABLES[key as EventKey] ?? [];
+	}
+</script>
+
+<div class="template-editor">
+	{#each subscribedEvents as key}
+		<div class="template-editor__event">
+			<h4>{EVENT_LABELS[key as EventKey] ?? key}</h4>
+			<label>
+				Title
+				<input
+					aria-label={`${key} title`}
+					value={templates[key]?.title ?? ''}
+					oninput={(e) => (ensure(key).title = (e.currentTarget as HTMLInputElement).value || null)}
+				/>
+			</label>
+			<label>
+				Body
+				<textarea
+					aria-label={`${key} body`}
+					value={templates[key]?.body ?? ''}
+					oninput={(e) => (ensure(key).body = (e.currentTarget as HTMLTextAreaElement).value || null)}
+				></textarea>
+			</label>
+			<p class="template-editor__vars">
+				Available variables:
+				{#each varsFor(key) as v}
+					<code>{`{${v}}`}</code>
+				{/each}
+			</p>
+		</div>
+	{/each}
+</div>

--- a/frontend/src/lib/components/notifications/__tests__/ChannelCard.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ChannelCard.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, cleanup } from '$lib/test-utils';
+import ChannelCard from '../ChannelCard.svelte';
+import type { Channel } from '$lib/types/notifications';
+
+function chan(over: Partial<Channel> = {}): Channel {
+	return {
+		id: 1, type: 'apprise', name: 'Family Discord', enabled: true,
+		config: { type: 'apprise', url: 'discord://a/b' },
+		subscribed_events: ['job.started', 'job.failed'],
+		templates: {}, last_fired_at: null, last_success_at: null, last_error: null,
+		...over
+	} as Channel;
+}
+
+describe('ChannelCard', () => {
+	afterEach(() => cleanup());
+
+	it('shows the channel name and type', () => {
+		renderComponent(ChannelCard, { props: { channel: chan(), ontest: () => {}, ondelete: () => {} } });
+		expect(screen.getByText('Family Discord')).toBeTruthy();
+		expect(screen.getByText(/apprise/)).toBeTruthy();
+	});
+
+	it('shows a healthy status dot when enabled and no error', () => {
+		const { container } = renderComponent(ChannelCard, { props: { channel: chan(), ontest: () => {}, ondelete: () => {} } });
+		expect(container.querySelector('.status-dot--healthy')).toBeTruthy();
+	});
+
+	it('shows an error status dot when last_error is set', () => {
+		const { container } = renderComponent(ChannelCard, { props: { channel: chan({ last_error: 'http 503' }), ontest: () => {}, ondelete: () => {} } });
+		expect(container.querySelector('.status-dot--error')).toBeTruthy();
+	});
+
+	it('shows a disabled status dot when not enabled', () => {
+		const { container } = renderComponent(ChannelCard, { props: { channel: chan({ enabled: false }), ontest: () => {}, ondelete: () => {} } });
+		expect(container.querySelector('.status-dot--disabled')).toBeTruthy();
+	});
+
+	it('calls ontest when Test is clicked', async () => {
+		let tested = 0;
+		renderComponent(ChannelCard, { props: { channel: chan(), ontest: () => (tested = 1), ondelete: () => {} } });
+		await fireEvent.click(screen.getByText('Test'));
+		expect(tested).toBe(1);
+	});
+});

--- a/frontend/src/lib/components/notifications/__tests__/DispatchHistory.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/DispatchHistory.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import DispatchHistory from '../DispatchHistory.svelte';
+import type { DispatchRow } from '$lib/types/notifications';
+
+const rows: DispatchRow[] = [
+	{ id: 1, channel_id: 2, event_key: 'job.rip_complete', status: 'success', attempts: 1, last_error: null, created_at: '2026-05-20T00:00:00Z', completed_at: '2026-05-20T00:00:01Z' },
+	{ id: 2, channel_id: 2, event_key: 'job.failed', status: 'failed', attempts: 5, last_error: 'http 503', created_at: '2026-05-20T00:00:00Z', completed_at: null }
+];
+
+describe('DispatchHistory', () => {
+	afterEach(() => cleanup());
+
+	it('renders one row per dispatch with event key and status', () => {
+		renderComponent(DispatchHistory, { props: { rows } });
+		expect(screen.getByText('job.rip_complete')).toBeTruthy();
+		expect(screen.getByText('job.failed')).toBeTruthy();
+	});
+
+	it('shows the error for a failed dispatch', () => {
+		renderComponent(DispatchHistory, { props: { rows } });
+		expect(screen.getByText(/http 503/)).toBeTruthy();
+	});
+
+	it('renders an empty state when there are no rows', () => {
+		renderComponent(DispatchHistory, { props: { rows: [] } });
+		expect(screen.getByText(/No sends yet/i)).toBeTruthy();
+	});
+});

--- a/frontend/src/lib/components/notifications/__tests__/EventSubscriptions.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/EventSubscriptions.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, cleanup } from '$lib/test-utils';
+import EventSubscriptions from '../EventSubscriptions.svelte';
+
+describe('EventSubscriptions', () => {
+	afterEach(() => cleanup());
+
+	it('renders a checkbox per event with labels', () => {
+		renderComponent(EventSubscriptions, { props: { selected: [] } });
+		expect(screen.getByLabelText('Job started')).toBeTruthy();
+		expect(screen.getByLabelText('Rip complete')).toBeTruthy();
+		expect(screen.getByLabelText('Transcode complete')).toBeTruthy();
+		expect(screen.getByLabelText('Job failed')).toBeTruthy();
+		expect(screen.getByLabelText('Manual wait required')).toBeTruthy();
+		expect(screen.getByLabelText('Duplicate detected')).toBeTruthy();
+	});
+
+	it('checks boxes for already-selected events', () => {
+		renderComponent(EventSubscriptions, { props: { selected: ['job.started', 'job.failed'] } });
+		expect((screen.getByLabelText('Job started') as HTMLInputElement).checked).toBe(true);
+		expect((screen.getByLabelText('Rip complete') as HTMLInputElement).checked).toBe(false);
+	});
+
+	it('checks a box when its event is clicked', async () => {
+		renderComponent(EventSubscriptions, { props: { selected: [] } });
+		await fireEvent.click(screen.getByLabelText('Job failed'));
+		expect((screen.getByLabelText('Job failed') as HTMLInputElement).checked).toBe(true);
+	});
+});

--- a/frontend/src/lib/components/notifications/__tests__/SchemaField.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/SchemaField.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import SchemaField from '../SchemaField.svelte';
+import type { CatalogField } from '$lib/types/notifications';
+
+function field(over: Partial<CatalogField>): CatalogField {
+	return { key: 'k', label: 'Label', type: 'string', private: false, required: false, ...over };
+}
+
+describe('SchemaField', () => {
+	afterEach(() => cleanup());
+
+	it('renders a text input for string', () => {
+		renderComponent(SchemaField, { props: { field: field({}), value: '' } });
+		const input = screen.getByLabelText('Label') as HTMLInputElement;
+		expect(input.type).toBe('text');
+	});
+
+	it('renders a password input when private', () => {
+		renderComponent(SchemaField, { props: { field: field({ private: true, label: 'Secret' }), value: '' } });
+		expect((screen.getByLabelText('Secret') as HTMLInputElement).type).toBe('password');
+	});
+
+	it('renders a checkbox for bool', () => {
+		renderComponent(SchemaField, { props: { field: field({ type: 'bool', label: 'Flag' }), value: false } });
+		expect((screen.getByLabelText('Flag') as HTMLInputElement).type).toBe('checkbox');
+	});
+
+	it('renders a select for choice with values', () => {
+		renderComponent(SchemaField, { props: { field: field({ type: 'choice', label: 'Fmt', values: ['a', 'b'] }), value: 'a' } });
+		const sel = screen.getByLabelText('Fmt') as HTMLSelectElement;
+		expect(sel.tagName).toBe('SELECT');
+		expect(sel.options.length).toBe(2);
+	});
+
+	it('renders a number input for int', () => {
+		renderComponent(SchemaField, { props: { field: field({ type: 'int', label: 'Num' }), value: 0 } });
+		expect((screen.getByLabelText('Num') as HTMLInputElement).type).toBe('number');
+	});
+
+	it('marks required fields', () => {
+		renderComponent(SchemaField, { props: { field: field({ required: true }), value: '' } });
+		expect((screen.getByLabelText('Label') as HTMLInputElement).required).toBe(true);
+	});
+});

--- a/frontend/src/lib/components/notifications/__tests__/ServicePicker.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ServicePicker.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, cleanup } from '$lib/test-utils';
+import ServicePicker from '../ServicePicker.svelte';
+import type { Catalog } from '$lib/types/notifications';
+
+const catalog: Catalog = {
+	featured: ['discord', 'slack'],
+	services: [
+		{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord', required_fields: [], advanced_fields: [] },
+		{ id: 'slack', name: 'Slack', docs_url: '', url_scheme: 'slack', required_fields: [], advanced_fields: [] },
+		{ id: 'telegram', name: 'Telegram', docs_url: '', url_scheme: 'tgram', required_fields: [], advanced_fields: [] }
+	]
+};
+
+describe('ServicePicker', () => {
+	afterEach(() => cleanup());
+
+	it('renders featured services', () => {
+		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
+		expect(screen.getByText('Discord')).toBeTruthy();
+		expect(screen.getByText('Slack')).toBeTruthy();
+	});
+
+	it('filters by search substring', async () => {
+		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
+		await fireEvent.input(screen.getByPlaceholderText('Search services'), { target: { value: 'tele' } });
+		expect(screen.queryByText('Telegram')).toBeTruthy();
+		expect(screen.queryByText('Discord')).toBeNull();
+	});
+
+	it('calls onpick with the service id', async () => {
+		let picked = '';
+		renderComponent(ServicePicker, { props: { catalog, onpick: (id: string) => (picked = id) } });
+		await fireEvent.click(screen.getByText('Discord'));
+		expect(picked).toBe('discord');
+	});
+});

--- a/frontend/src/lib/components/notifications/__tests__/TemplateEditor.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/TemplateEditor.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import TemplateEditor from '../TemplateEditor.svelte';
+
+describe('TemplateEditor', () => {
+	afterEach(() => cleanup());
+
+	it('renders title/body inputs only for subscribed events', () => {
+		renderComponent(TemplateEditor, { props: { subscribedEvents: ['job.started'], templates: {} } });
+		expect(screen.getByLabelText('job.started title')).toBeTruthy();
+		expect(screen.getByLabelText('job.started body')).toBeTruthy();
+		expect(screen.queryByLabelText('job.failed title')).toBeNull();
+	});
+
+	it('shows available variables for an event', () => {
+		renderComponent(TemplateEditor, { props: { subscribedEvents: ['job.started'], templates: {} } });
+		expect(screen.getByText(/\{job_title\}/)).toBeTruthy();
+		expect(screen.getByText(/\{drive_mount\}/)).toBeTruthy();
+	});
+
+	it('prefills existing template values', () => {
+		renderComponent(TemplateEditor, {
+			props: {
+				subscribedEvents: ['job.started'],
+				templates: { 'job.started': { title: 'Hi {job_title}', body: 'B' } }
+			}
+		});
+		expect((screen.getByLabelText('job.started title') as HTMLInputElement).value).toBe('Hi {job_title}');
+	});
+});

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -5982,6 +5982,301 @@ export type DismissNotificationApiNotificationsNotifyIdPatchResponses = {
 
 export type DismissNotificationApiNotificationsNotifyIdPatchResponse = DismissNotificationApiNotificationsNotifyIdPatchResponses[keyof DismissNotificationApiNotificationsNotifyIdPatchResponses];
 
+export type ListChannelsApiNotificationsChannelsGetData = {
+    body?: never;
+    path?: never;
+    query?: never;
+    url: '/api/notifications/channels';
+};
+
+export type ListChannelsApiNotificationsChannelsGetResponses = {
+    /**
+     * Response List Channels Api Notifications Channels Get
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type CreateChannelApiNotificationsChannelsPostData = {
+    /**
+     * Body
+     */
+    body: {
+        [key: string]: unknown;
+    };
+    path?: never;
+    query?: never;
+    url: '/api/notifications/channels';
+};
+
+export type CreateChannelApiNotificationsChannelsPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type CreateChannelApiNotificationsChannelsPostError = CreateChannelApiNotificationsChannelsPostErrors[keyof CreateChannelApiNotificationsChannelsPostErrors];
+
+export type CreateChannelApiNotificationsChannelsPostResponses = {
+    /**
+     * Response Create Channel Api Notifications Channels Post
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type DeleteChannelApiNotificationsChannelsChannelIdDeleteData = {
+    body?: never;
+    path: {
+        /**
+         * Channel Id
+         */
+        channel_id: number;
+    };
+    query?: never;
+    url: '/api/notifications/channels/{channel_id}';
+};
+
+export type DeleteChannelApiNotificationsChannelsChannelIdDeleteErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type DeleteChannelApiNotificationsChannelsChannelIdDeleteError = DeleteChannelApiNotificationsChannelsChannelIdDeleteErrors[keyof DeleteChannelApiNotificationsChannelsChannelIdDeleteErrors];
+
+export type DeleteChannelApiNotificationsChannelsChannelIdDeleteResponses = {
+    /**
+     * Response Delete Channel Api Notifications Channels  Channel Id  Delete
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type GetChannelApiNotificationsChannelsChannelIdGetData = {
+    body?: never;
+    path: {
+        /**
+         * Channel Id
+         */
+        channel_id: number;
+    };
+    query?: never;
+    url: '/api/notifications/channels/{channel_id}';
+};
+
+export type GetChannelApiNotificationsChannelsChannelIdGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type GetChannelApiNotificationsChannelsChannelIdGetError = GetChannelApiNotificationsChannelsChannelIdGetErrors[keyof GetChannelApiNotificationsChannelsChannelIdGetErrors];
+
+export type GetChannelApiNotificationsChannelsChannelIdGetResponses = {
+    /**
+     * Response Get Channel Api Notifications Channels  Channel Id  Get
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type UpdateChannelApiNotificationsChannelsChannelIdPatchData = {
+    /**
+     * Body
+     */
+    body: {
+        [key: string]: unknown;
+    };
+    path: {
+        /**
+         * Channel Id
+         */
+        channel_id: number;
+    };
+    query?: never;
+    url: '/api/notifications/channels/{channel_id}';
+};
+
+export type UpdateChannelApiNotificationsChannelsChannelIdPatchErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type UpdateChannelApiNotificationsChannelsChannelIdPatchError = UpdateChannelApiNotificationsChannelsChannelIdPatchErrors[keyof UpdateChannelApiNotificationsChannelsChannelIdPatchErrors];
+
+export type UpdateChannelApiNotificationsChannelsChannelIdPatchResponses = {
+    /**
+     * Response Update Channel Api Notifications Channels  Channel Id  Patch
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type TestSendChannelApiNotificationsChannelsChannelIdTestPostData = {
+    /**
+     * Body
+     */
+    body?: {
+        [key: string]: unknown;
+    } | null;
+    path: {
+        /**
+         * Channel Id
+         */
+        channel_id: number;
+    };
+    query?: never;
+    url: '/api/notifications/channels/{channel_id}/test';
+};
+
+export type TestSendChannelApiNotificationsChannelsChannelIdTestPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type TestSendChannelApiNotificationsChannelsChannelIdTestPostError = TestSendChannelApiNotificationsChannelsChannelIdTestPostErrors[keyof TestSendChannelApiNotificationsChannelsChannelIdTestPostErrors];
+
+export type TestSendChannelApiNotificationsChannelsChannelIdTestPostResponses = {
+    /**
+     * Response Test Send Channel Api Notifications Channels  Channel Id  Test Post
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type GetDispatchApiNotificationsDispatchDispatchIdGetData = {
+    body?: never;
+    path: {
+        /**
+         * Dispatch Id
+         */
+        dispatch_id: number;
+    };
+    query?: never;
+    url: '/api/notifications/dispatch/{dispatch_id}';
+};
+
+export type GetDispatchApiNotificationsDispatchDispatchIdGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type GetDispatchApiNotificationsDispatchDispatchIdGetError = GetDispatchApiNotificationsDispatchDispatchIdGetErrors[keyof GetDispatchApiNotificationsDispatchDispatchIdGetErrors];
+
+export type GetDispatchApiNotificationsDispatchDispatchIdGetResponses = {
+    /**
+     * Response Get Dispatch Api Notifications Dispatch  Dispatch Id  Get
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type ListDispatchesApiNotificationsDispatchesGetData = {
+    body?: never;
+    path?: never;
+    query?: {
+        /**
+         * Channel Id
+         */
+        channel_id?: number | null;
+        /**
+         * Status
+         */
+        status?: string | null;
+        /**
+         * Limit
+         */
+        limit?: number;
+    };
+    url: '/api/notifications/dispatches';
+};
+
+export type ListDispatchesApiNotificationsDispatchesGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type ListDispatchesApiNotificationsDispatchesGetError = ListDispatchesApiNotificationsDispatchesGetErrors[keyof ListDispatchesApiNotificationsDispatchesGetErrors];
+
+export type ListDispatchesApiNotificationsDispatchesGetResponses = {
+    /**
+     * Response List Dispatches Api Notifications Dispatches Get
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type GetServicesApiNotificationsServicesGetData = {
+    body?: never;
+    path?: never;
+    query?: never;
+    url: '/api/notifications/services';
+};
+
+export type GetServicesApiNotificationsServicesGetResponses = {
+    /**
+     * Response Get Services Api Notifications Services Get
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
+export type ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostData = {
+    /**
+     * Body
+     */
+    body: {
+        [key: string]: unknown;
+    };
+    path: {
+        /**
+         * Service Id
+         */
+        service_id: string;
+    };
+    query?: never;
+    url: '/api/notifications/services/{service_id}/compose-url';
+};
+
+export type ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostError = ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostErrors[keyof ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostErrors];
+
+export type ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostResponses = {
+    /**
+     * Response Compose Channel Url Api Notifications Services  Service Id  Compose Url Post
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
 export type ListThemesApiThemesGetData = {
     body?: never;
     path?: never;
@@ -6937,3 +7232,31 @@ export type GetPatternTokensApiPatternsTokensGetResponses = {
 };
 
 export type GetPatternTokensApiPatternsTokensGetResponse = GetPatternTokensApiPatternsTokensGetResponses[keyof GetPatternTokensApiPatternsTokensGetResponses];
+
+export type RootStaticOrSpaFilenameGetData = {
+    body?: never;
+    path: {
+        /**
+         * Filename
+         */
+        filename: string;
+    };
+    query?: never;
+    url: '/{filename}';
+};
+
+export type RootStaticOrSpaFilenameGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
+
+export type RootStaticOrSpaFilenameGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -7232,31 +7232,3 @@ export type GetPatternTokensApiPatternsTokensGetResponses = {
 };
 
 export type GetPatternTokensApiPatternsTokensGetResponse = GetPatternTokensApiPatternsTokensGetResponses[keyof GetPatternTokensApiPatternsTokensGetResponses];
-
-export type RootStaticOrSpaFilenameGetData = {
-    body?: never;
-    path: {
-        /**
-         * Filename
-         */
-        filename: string;
-    };
-    query?: never;
-    url: '/{filename}';
-};
-
-export type RootStaticOrSpaFilenameGetErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
-
-export type RootStaticOrSpaFilenameGetResponses = {
-    /**
-     * Successful Response
-     */
-    200: unknown;
-};

--- a/frontend/src/lib/types/notifications.ts
+++ b/frontend/src/lib/types/notifications.ts
@@ -1,0 +1,146 @@
+// Hand-written types for the notification channel + catalog system.
+// The BFF proxies channel data as opaque dicts, so these are not in the
+// generated api.gen.ts. Catalog types mirror apprise-introspection output.
+
+export const EVENT_KEYS = [
+	'job.started',
+	'job.rip_complete',
+	'job.transcode_complete',
+	'job.failed',
+	'job.manual_wait_required',
+	'job.duplicate_detected'
+] as const;
+
+export type EventKey = (typeof EVENT_KEYS)[number];
+
+export type ChannelType = 'apprise' | 'webhook' | 'bash';
+
+export interface AppriseConfig {
+	type: 'apprise';
+	url: string;
+}
+
+export interface WebhookConfig {
+	type: 'webhook';
+	url: string;
+	shared_secret?: string | null;
+	headers?: Record<string, string> | null;
+}
+
+export interface BashConfig {
+	type: 'bash';
+	script_path: string;
+}
+
+export type ChannelConfig = AppriseConfig | WebhookConfig | BashConfig;
+
+export interface ChannelTemplate {
+	title?: string | null;
+	body?: string | null;
+}
+
+export interface Channel {
+	id: number;
+	type: ChannelType;
+	name: string;
+	enabled: boolean;
+	config: ChannelConfig;
+	subscribed_events: string[];
+	templates: Record<string, ChannelTemplate>;
+	last_fired_at: string | null;
+	last_success_at: string | null;
+	last_error: string | null;
+}
+
+export interface ChannelCreate {
+	type: ChannelType;
+	name: string;
+	enabled?: boolean;
+	config: ChannelConfig;
+	subscribed_events: string[];
+	templates?: Record<string, ChannelTemplate>;
+}
+
+export interface ChannelUpdate {
+	name?: string;
+	enabled?: boolean;
+	config?: ChannelConfig;
+	subscribed_events?: string[];
+	templates?: Record<string, ChannelTemplate>;
+}
+
+export type FieldType = 'string' | 'bool' | 'choice' | 'int' | 'float';
+
+export interface CatalogField {
+	key: string;
+	label: string;
+	type: FieldType;
+	private: boolean;
+	required: boolean;
+	default?: string | number | boolean | null;
+	values?: string[];
+}
+
+export interface CatalogService {
+	id: string;
+	name: string;
+	docs_url: string;
+	url_scheme: string;
+	required_fields: CatalogField[];
+	advanced_fields: CatalogField[];
+}
+
+export interface Catalog {
+	featured: string[];
+	services: CatalogService[];
+}
+
+export interface DispatchRow {
+	id: number;
+	channel_id: number;
+	event_key: string;
+	status: 'pending' | 'in_flight' | 'success' | 'failed';
+	attempts: number;
+	last_error: string | null;
+	created_at: string | null;
+	completed_at: string | null;
+}
+
+export interface DispatchStatus {
+	id: number;
+	status: 'pending' | 'in_flight' | 'success' | 'failed';
+	attempts: number;
+	last_error: string | null;
+	completed_at: string | null;
+}
+
+export interface TestSendResult {
+	sent_at: string;
+	dispatch_id: number;
+}
+
+// Per-event template variable hints, keyed off event_key. Mirrors the
+// contracts event schema fields available to str.format_map on the backend.
+export const EVENT_VARIABLES: Record<EventKey, string[]> = {
+	'job.started': ['job_id', 'job_title', 'job_disc_type', 'job_imdb_id', 'drive_mount'],
+	'job.rip_complete': ['job_id', 'job_title', 'job_disc_type', 'job_imdb_id', 'rip_duration_seconds', 'track_count'],
+	'job.transcode_complete': ['job_id', 'job_title', 'job_disc_type', 'job_imdb_id', 'transcode_duration_seconds', 'output_path'],
+	'job.failed': ['job_id', 'job_title', 'job_disc_type', 'job_imdb_id', 'phase', 'error_message', 'error_code'],
+	'job.manual_wait_required': ['job_id', 'job_title', 'job_disc_type', 'job_imdb_id', 'wait_minutes_remaining', 'reason'],
+	'job.duplicate_detected': ['job_id', 'job_title', 'job_disc_type', 'job_imdb_id', 'existing_job_id', 'existing_output_path']
+};
+
+export const EVENT_LABELS: Record<EventKey, string> = {
+	'job.started': 'Job started',
+	'job.rip_complete': 'Rip complete',
+	'job.transcode_complete': 'Transcode complete',
+	'job.failed': 'Job failed',
+	'job.manual_wait_required': 'Manual wait required',
+	'job.duplicate_detected': 'Duplicate detected'
+};
+
+export function isCatalogField(v: unknown): v is CatalogField {
+	if (typeof v !== 'object' || v === null) return false;
+	const f = v as Record<string, unknown>;
+	return typeof f.key === 'string' && typeof f.label === 'string' && typeof f.type === 'string';
+}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -763,18 +763,6 @@
 		EMBY_USERID: { label: 'Emby User ID', description: 'Emby internal user ID' },
 		EMBY_PASSWORD: { label: 'Emby Password', description: 'Emby account password' },
 		EMBY_API_KEY: { label: 'Emby API Key', description: 'API key for Emby server access' },
-		// Notifications
-		NOTIFY_RIP: { label: 'Notify After Rip', description: 'Send a notification when ripping completes' },
-		NOTIFY_TRANSCODE: { label: 'Notify After Transcode', description: 'Send a notification when transcoding completes' },
-		NOTIFY_JOBID: { label: 'Include Job ID', description: 'Append the job ID to notification titles' },
-		PB_KEY: { label: 'Pushbullet Key', description: 'API key for Pushbullet notifications' },
-		IFTTT_KEY: { label: 'IFTTT Key', description: 'Webhook key for IFTTT notifications' },
-		IFTTT_EVENT: { label: 'IFTTT Event', description: 'IFTTT webhook event name' },
-		PO_USER_KEY: { label: 'Pushover User Key', description: 'User key for Pushover notifications' },
-		PO_APP_KEY: { label: 'Pushover App Key', description: 'Application key for Pushover notifications' },
-		BASH_SCRIPT: { label: 'Notification Script', description: 'Path to a custom bash script run on notifications' },
-		JSON_URL: { label: 'Apprise JSON URL', description: 'Apprise webhook URL for notifications' },
-		APPRISE: { label: 'Apprise Config', description: 'Apprise notification service configuration string' },
 		// TVDB
 		TVDB_API_KEY: { label: 'TVDB API Key', description: 'API key for TheTVDB v4 — get one free at thetvdb.com/dashboard' },
 		TVDB_MATCH_TOLERANCE: { label: 'Match Tolerance (sec)', description: 'Max runtime difference in seconds for a track-to-episode match (default 300)' },
@@ -865,29 +853,9 @@
 			]},
 		],
 		notifications: [
-			{ label: 'Triggers', subpanels: [
-				{ keys: $transcoderEnabled
-					? ['NOTIFY_RIP', 'NOTIFY_TRANSCODE', 'NOTIFY_JOBID']
-					: ['NOTIFY_RIP', 'NOTIFY_JOBID'] },
-			]},
 			...($transcoderEnabled ? [{ label: 'Transcoder', subpanels: [
 				{ keys: ['TRANSCODER_URL', 'TRANSCODER_WEBHOOK_SECRET', 'LOCAL_RAW_PATH', 'SHARED_RAW_PATH'] },
 			]}] : []),
-			{ label: 'Apprise', subpanels: [
-				{ keys: ['JSON_URL', 'APPRISE'] },
-			]},
-			{ label: 'Pushbullet', subpanels: [
-				{ keys: ['PB_KEY'] },
-			]},
-			{ label: 'Pushover', subpanels: [
-				{ keys: ['PO_USER_KEY', 'PO_APP_KEY'] },
-			]},
-			{ label: 'IFTTT', subpanels: [
-				{ keys: ['IFTTT_KEY', 'IFTTT_EVENT'] },
-			]},
-			{ label: 'Custom Script', subpanels: [
-				{ keys: ['BASH_SCRIPT'] },
-			]},
 			{ label: 'Emby Integration', subpanels: [
 				{ label: 'Connection', keys: ['EMBY_REFRESH', 'EMBY_SERVER', 'EMBY_PORT'] },
 				{ label: 'Authentication', keys: ['EMBY_USERNAME', 'EMBY_USERID', 'EMBY_PASSWORD', 'EMBY_API_KEY'] },
@@ -919,11 +887,6 @@
 		'EMBY_USERID',
 		'EMBY_PASSWORD',
 		'EMBY_API_KEY',
-		'PB_KEY',
-		'IFTTT_KEY',
-		'PO_KEY',
-		'PO_USER_KEY',
-		'PO_APP_KEY',
 		'ARM_API_KEY',
 		'TMDB_API_KEY',
 		'TVDB_API_KEY',
@@ -1947,6 +1910,10 @@
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Notifications</h2>
 					{@render armSearchBar()}
 				</div>
+				<p class="mb-4 rounded-lg border border-primary/30 bg-primary-light-bg px-4 py-3 text-sm text-primary-dark dark:border-primary/30 dark:bg-primary-light-bg-dark/20 dark:text-primary-text-dark">
+					Notification channels (Discord, Slack, webhooks, scripts, and more) are now managed on the
+					<a href="/settings/notifications" class="underline text-primary hover:text-primary-hover">Notifications page</a>.
+				</p>
 				{@render armSettingsSection('notifications')}
 			</section>
 		{/if}

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -16,9 +16,7 @@ const mockArmConfig: Record<string, string | null> = {
 	TV_TITLE_PATTERN: '{title} S{season}E{episode}', TV_FOLDER_PATTERN: '{title}/Season {season}',
 	MUSIC_TITLE_PATTERN: '{artist} - {album}', MUSIC_FOLDER_PATTERN: '{artist}/{album}',
 	GET_AUDIO_TITLE: 'true', AUDIO_FORMAT: 'flac', ABCDE_CONFIG_FILE: '/etc/abcde.conf',
-	NOTIFY_RIP: 'true', NOTIFY_TRANSCODE: 'true', NOTIFY_JOBID: 'true',
-	TRANSCODER_URL: 'http://localhost:8080', JSON_URL: '', APPRISE: '',
-	PB_KEY: '', IFTTT_KEY: '', PO_USER_KEY: '', PO_APP_KEY: '',
+	TRANSCODER_URL: 'http://localhost:8080',
 	USE_DISC_LABEL_FOR_TV: 'false', GROUP_TV_DISCS_UNDER_SERIES: 'false',
 	MAKEMKV_PERMA_KEY: '', ARM_CHILDREN: '1', EXTRAS_SUB: 'extras',
 	TRANSCODER_WEBHOOK_SECRET: '', LOCAL_RAW_PATH: '', SHARED_RAW_PATH: '',
@@ -284,6 +282,26 @@ describe('Settings Page', () => {
 				expect(screen.getByText('Locked by theme')).toBeInTheDocument();
 			});
 			expect(screen.queryByLabelText('Dark mode')).not.toBeInTheDocument();
+		});
+
+		it('notifications tab points to the new Notifications page and drops legacy fields', async () => {
+			renderComponent(SettingsPage);
+			await waitFor(() => {
+				expect(screen.getByText('Music')).toBeInTheDocument();
+			});
+			// Switch to the notifications tab
+			const notificationsTab = screen.getAllByText('Notifications');
+			await fireEvent.click(notificationsTab[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Notifications page')).toBeTruthy();
+			});
+			// Legacy notification-channel fields are gone
+			expect(screen.queryByText('Pushbullet Key')).toBeNull();
+			expect(screen.queryByText('IFTTT Key')).toBeNull();
+			expect(screen.queryByText('Apprise Config')).toBeNull();
+			expect(screen.queryByText('Notify After Rip')).toBeNull();
+			// Pointer link present
+			expect(screen.getByText('Notifications page')).toBeTruthy();
 		});
 
 		it('renders drives tab with collapsible diagnostics toggle', async () => {

--- a/frontend/src/routes/settings/notifications/+page.svelte
+++ b/frontend/src/routes/settings/notifications/+page.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import ChannelCard from '$lib/components/notifications/ChannelCard.svelte';
+	import { deleteChannel, testSendChannel } from '$lib/api/channels';
+	import { invalidateAll } from '$app/navigation';
+	import type { Channel } from '$lib/types/notifications';
+
+	let { data }: { data: { channels: Channel[] } } = $props();
+
+	let toast = $state<string | null>(null);
+
+	async function onTest(id: number) {
+		try {
+			await testSendChannel(id, 'job.started');
+			toast = 'Test queued — check Recent sends on the channel.';
+		} catch (e) {
+			toast = e instanceof Error ? e.message : 'Test failed';
+		}
+	}
+
+	async function onDelete(id: number) {
+		if (!confirm('Delete this channel? This cannot be undone.')) return;
+		try {
+			await deleteChannel(id);
+			await invalidateAll();
+		} catch (e) {
+			toast = e instanceof Error ? e.message : 'Delete failed';
+		}
+	}
+</script>
+
+<section class="notifications-list">
+	<header>
+		<h1>Notifications</h1>
+		<a class="btn" href="/settings/notifications/new">Add channel</a>
+	</header>
+
+	{#if toast}
+		<p class="toast">{toast}</p>
+	{/if}
+
+	{#if data.channels.length === 0}
+		<p class="empty">No notification channels yet.</p>
+	{:else}
+		{#each data.channels as channel (channel.id)}
+			<ChannelCard {channel} ontest={onTest} ondelete={onDelete} />
+		{/each}
+	{/if}
+</section>

--- a/frontend/src/routes/settings/notifications/+page.ts
+++ b/frontend/src/routes/settings/notifications/+page.ts
@@ -1,0 +1,11 @@
+import { fetchChannels } from '$lib/api/channels';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+	try {
+		const channels = await fetchChannels();
+		return { channels };
+	} catch {
+		return { channels: [] };
+	}
+};

--- a/frontend/src/routes/settings/notifications/[id]/+page.svelte
+++ b/frontend/src/routes/settings/notifications/[id]/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import EventSubscriptions from '$lib/components/notifications/EventSubscriptions.svelte';
+	import TemplateEditor from '$lib/components/notifications/TemplateEditor.svelte';
+	import DispatchHistory from '$lib/components/notifications/DispatchHistory.svelte';
+	import { updateChannel, testSendChannel, fetchDispatch } from '$lib/api/channels';
+	import type { Channel, ChannelTemplate, DispatchRow } from '$lib/types/notifications';
+
+	let { data }: { data: { channel: Channel; dispatches: DispatchRow[] } } = $props();
+
+	let name = $state(data.channel.name);
+	let enabled = $state(data.channel.enabled);
+	let subscribedEvents = $state<string[]>([...data.channel.subscribed_events]);
+	let templates = $state<Record<string, ChannelTemplate>>({ ...data.channel.templates });
+
+	let toast = $state<string | null>(null);
+	let testing = $state(false);
+	let saving = $state(false);
+
+	async function save() {
+		saving = true;
+		toast = null;
+		try {
+			await updateChannel(data.channel.id, {
+				name,
+				enabled,
+				subscribed_events: subscribedEvents,
+				templates
+			});
+			toast = 'Saved.';
+		} catch (e) {
+			toast = e instanceof Error ? e.message : 'Save failed';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function runTest() {
+		testing = true;
+		toast = null;
+		try {
+			const { dispatch_id } = await testSendChannel(data.channel.id, 'job.started');
+			// Poll up to 5s (10 * 500ms).
+			for (let i = 0; i < 10; i++) {
+				await new Promise((r) => setTimeout(r, 500));
+				const d = await fetchDispatch(dispatch_id);
+				if (d.status === 'success') {
+					toast = 'Test sent successfully';
+					return;
+				}
+				if (d.status === 'failed') {
+					toast = `Test failed: ${d.last_error ?? 'unknown'}`;
+					return;
+				}
+			}
+			toast = 'Send is still pending — check Recent sends.';
+		} catch (e) {
+			toast = e instanceof Error ? e.message : 'Test failed';
+		} finally {
+			testing = false;
+		}
+	}
+</script>
+
+<section class="channel-edit">
+	<h1>Edit channel</h1>
+	{#if toast}<p class="toast">{toast}</p>{/if}
+
+	<label>Channel name <input aria-label="Channel name" bind:value={name} /></label>
+	<label><input type="checkbox" bind:checked={enabled} /> Enabled</label>
+
+	<EventSubscriptions bind:selected={subscribedEvents} />
+	<details>
+		<summary>Templates</summary>
+		<TemplateEditor {subscribedEvents} bind:templates />
+	</details>
+
+	<div class="actions">
+		<button type="button" disabled={testing} onclick={runTest}>Test</button>
+		<button type="button" onclick={() => goto('/settings/notifications')}>Back</button>
+		<button type="button" disabled={saving} onclick={save}>Save</button>
+	</div>
+
+	<DispatchHistory rows={data.dispatches} />
+</section>

--- a/frontend/src/routes/settings/notifications/[id]/+page.ts
+++ b/frontend/src/routes/settings/notifications/[id]/+page.ts
@@ -1,0 +1,15 @@
+import { fetchChannel, fetchDispatches } from '$lib/api/channels';
+import type { DispatchRow } from '$lib/types/notifications';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params }) => {
+	const id = Number(params.id);
+	const channel = await fetchChannel(id);
+	let dispatches: DispatchRow[] = [];
+	try {
+		dispatches = await fetchDispatches({ channelId: id, limit: 20 });
+	} catch {
+		dispatches = [];
+	}
+	return { channel, dispatches };
+};

--- a/frontend/src/routes/settings/notifications/__tests__/detail.test.ts
+++ b/frontend/src/routes/settings/notifications/__tests__/detail.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, waitFor, cleanup } from '$lib/test-utils';
+import Page from '../[id]/+page.svelte';
+import * as channelsApi from '$lib/api/channels';
+
+vi.mock('$lib/api/channels');
+vi.mock('$app/navigation', () => ({ goto: vi.fn(), invalidateAll: vi.fn() }));
+
+function data() {
+	return {
+		channel: {
+			id: 5, type: 'apprise', name: 'Discord', enabled: true,
+			config: { type: 'apprise', url: 'discord://a/b' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null
+		},
+		dispatches: [
+			{ id: 1, channel_id: 5, event_key: 'job.started', status: 'success', attempts: 1, last_error: null, created_at: '2026-05-20T00:00:00Z', completed_at: '2026-05-20T00:00:01Z' }
+		]
+	};
+}
+
+describe('Channel edit page', () => {
+	beforeEach(() => vi.resetAllMocks());
+	afterEach(() => cleanup());
+
+	it('prefills the channel name', () => {
+		renderComponent(Page, { props: { data: data() } });
+		expect((screen.getByLabelText('Channel name') as HTMLInputElement).value).toBe('Discord');
+	});
+
+	it('shows dispatch history', () => {
+		renderComponent(Page, { props: { data: data() } });
+		expect(screen.getByText('job.started')).toBeTruthy();
+	});
+
+	it('saves changes via updateChannel', async () => {
+		vi.mocked(channelsApi.updateChannel).mockResolvedValue({ id: 5 } as never);
+		renderComponent(Page, { props: { data: data() } });
+		await fireEvent.input(screen.getByLabelText('Channel name'), { target: { value: 'Renamed' } });
+		await fireEvent.click(screen.getByText('Save'));
+		expect(channelsApi.updateChannel).toHaveBeenCalledWith(5, expect.objectContaining({ name: 'Renamed' }));
+	});
+
+	it('test-send polls dispatch status to success', async () => {
+		vi.mocked(channelsApi.testSendChannel).mockResolvedValue({ sent_at: 'now', dispatch_id: 9 });
+		vi.mocked(channelsApi.fetchDispatch).mockResolvedValue({ id: 9, status: 'success', attempts: 1, last_error: null, completed_at: 'now' });
+		renderComponent(Page, { props: { data: data() } });
+		await fireEvent.click(screen.getByText('Test'));
+		await waitFor(() => expect(screen.getByText(/Test sent successfully/i)).toBeTruthy(), { timeout: 3000 });
+	});
+});

--- a/frontend/src/routes/settings/notifications/__tests__/list.test.ts
+++ b/frontend/src/routes/settings/notifications/__tests__/list.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import Page from '../+page.svelte';
+
+vi.mock('$lib/api/channels');
+vi.mock('$app/navigation', () => ({ goto: vi.fn(), invalidateAll: vi.fn() }));
+
+describe('Notifications list page', () => {
+	beforeEach(() => vi.resetAllMocks());
+	afterEach(() => cleanup());
+
+	it('renders a card per channel from data', () => {
+		const data = {
+			channels: [
+				{ id: 1, type: 'apprise', name: 'Discord', enabled: true, config: { type: 'apprise', url: 'd://a/b' }, subscribed_events: ['job.started'], templates: {}, last_fired_at: null, last_success_at: null, last_error: null },
+				{ id: 2, type: 'webhook', name: 'HA', enabled: true, config: { type: 'webhook', url: 'https://x', shared_secret: '<hidden>' }, subscribed_events: ['job.failed'], templates: {}, last_fired_at: null, last_success_at: null, last_error: null }
+			]
+		};
+		renderComponent(Page, { props: { data } });
+		expect(screen.getByText('Discord')).toBeTruthy();
+		expect(screen.getByText('HA')).toBeTruthy();
+	});
+
+	it('renders an empty state with an add link when there are no channels', () => {
+		renderComponent(Page, { props: { data: { channels: [] } } });
+		expect(screen.getByText(/No notification channels/i)).toBeTruthy();
+		expect(screen.getByText('Add channel')).toBeTruthy();
+	});
+});

--- a/frontend/src/routes/settings/notifications/__tests__/new.test.ts
+++ b/frontend/src/routes/settings/notifications/__tests__/new.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, cleanup } from '$lib/test-utils';
+import Page from '../new/+page.svelte';
+import * as channelsApi from '$lib/api/channels';
+
+vi.mock('$lib/api/channels');
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+const catalog = {
+	featured: ['discord'],
+	services: [
+		{
+			id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: true, required: true }],
+			advanced_fields: []
+		}
+	]
+};
+
+describe('Create channel flow', () => {
+	beforeEach(() => vi.resetAllMocks());
+	afterEach(() => cleanup());
+
+	it('starts on the type-picker step', () => {
+		renderComponent(Page, { props: { data: { catalog } } });
+		expect(screen.getByText(/Choose channel type/i)).toBeTruthy();
+	});
+
+	it('webhook type shows URL + secret fields after Next', async () => {
+		renderComponent(Page, { props: { data: { catalog } } });
+		await fireEvent.click(screen.getByLabelText('Webhook'));
+		await fireEvent.click(screen.getByText('Next'));
+		expect(screen.getByLabelText(/Webhook URL/i)).toBeTruthy();
+		expect(screen.getByLabelText(/Shared secret/i)).toBeTruthy();
+	});
+
+	it('bash type shows script path field after Next', async () => {
+		renderComponent(Page, { props: { data: { catalog } } });
+		await fireEvent.click(screen.getByLabelText('Bash script'));
+		await fireEvent.click(screen.getByText('Next'));
+		expect(screen.getByLabelText(/Script path/i)).toBeTruthy();
+	});
+
+	it('apprise webhook save composes URL then creates the channel', async () => {
+		vi.mocked(channelsApi.composeUrl).mockResolvedValue({ url: 'discord://wid' });
+		vi.mocked(channelsApi.createChannel).mockResolvedValue({ id: 7 } as never);
+
+		renderComponent(Page, { props: { data: { catalog } } });
+		// type = apprise (default) -> Next
+		await fireEvent.click(screen.getByText('Next'));
+		// pick discord
+		await fireEvent.click(screen.getByText('Discord'));
+		// fill required field
+		await fireEvent.input(screen.getByLabelText('Webhook ID'), { target: { value: 'wid' } });
+		// name
+		await fireEvent.input(screen.getByLabelText('Channel name'), { target: { value: 'My Discord' } });
+		// save
+		await fireEvent.click(screen.getByText('Save'));
+
+		expect(channelsApi.composeUrl).toHaveBeenCalledWith('discord', { webhook_id: 'wid' }, {});
+		expect(channelsApi.createChannel).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'apprise',
+				name: 'My Discord',
+				config: { type: 'apprise', url: 'discord://wid' }
+			})
+		);
+	});
+});

--- a/frontend/src/routes/settings/notifications/new/+page.svelte
+++ b/frontend/src/routes/settings/notifications/new/+page.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import ServicePicker from '$lib/components/notifications/ServicePicker.svelte';
+	import SchemaField from '$lib/components/notifications/SchemaField.svelte';
+	import EventSubscriptions from '$lib/components/notifications/EventSubscriptions.svelte';
+	import TemplateEditor from '$lib/components/notifications/TemplateEditor.svelte';
+	import { composeUrl, createChannel } from '$lib/api/channels';
+	import type { Catalog, CatalogService, ChannelTemplate } from '$lib/types/notifications';
+
+	let { data }: { data: { catalog: Catalog } } = $props();
+
+	type Step = 'type' | 'service' | 'form';
+	let step = $state<Step>('type');
+	let chanType = $state<'apprise' | 'webhook' | 'bash'>('apprise');
+
+	let service = $state<CatalogService | null>(null);
+	let requiredValues = $state<Record<string, unknown>>({});
+	let advancedValues = $state<Record<string, unknown>>({});
+	let rawUrl = $state('');
+
+	let name = $state('');
+	let enabled = $state(true);
+	let subscribedEvents = $state<string[]>([]);
+	let templates = $state<Record<string, ChannelTemplate>>({});
+
+	// webhook
+	let webhookUrl = $state('');
+	let sharedSecret = $state('');
+	let headersText = $state('');
+
+	// bash
+	let scriptPath = $state('');
+
+	let error = $state<string | null>(null);
+	let saving = $state(false);
+
+	function next() {
+		if (chanType === 'apprise') step = 'service';
+		else step = 'form';
+	}
+
+	function pickService(id: string) {
+		service = data.catalog.services.find((s) => s.id === id) ?? null;
+		requiredValues = {};
+		advancedValues = {};
+		step = 'form';
+	}
+
+	function parseHeaders(text: string): Record<string, string> {
+		const out: Record<string, string> = {};
+		for (const line of text.split('\n')) {
+			const idx = line.indexOf(':');
+			if (idx > 0) {
+				const k = line.slice(0, idx).trim();
+				const v = line.slice(idx + 1).trim();
+				if (k) out[k] = v;
+			}
+		}
+		return out;
+	}
+
+	async function save() {
+		error = null;
+		saving = true;
+		try {
+			let config: Record<string, unknown>;
+			if (chanType === 'apprise') {
+				let url = rawUrl.trim();
+				if (!url && service) {
+					const composed = await composeUrl(service.id, requiredValues, advancedValues);
+					url = composed.url;
+				}
+				config = { type: 'apprise', url };
+			} else if (chanType === 'webhook') {
+				config = {
+					type: 'webhook',
+					url: webhookUrl,
+					shared_secret: sharedSecret || null,
+					headers: headersText.trim() ? parseHeaders(headersText) : null
+				};
+			} else {
+				config = { type: 'bash', script_path: scriptPath };
+			}
+
+			await createChannel({
+				type: chanType,
+				name,
+				enabled,
+				config,
+				subscribed_events: subscribedEvents,
+				templates
+			} as never);
+			await goto('/settings/notifications');
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Save failed';
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<section class="channel-new">
+	<h1>Add channel</h1>
+	{#if error}<p class="error">{error}</p>{/if}
+
+	{#if step === 'type'}
+		<fieldset>
+			<legend>Choose channel type</legend>
+			<label><input type="radio" aria-label="Service (Apprise)" bind:group={chanType} value="apprise" /> Service (Apprise)</label>
+			<label><input type="radio" aria-label="Webhook" bind:group={chanType} value="webhook" /> Webhook</label>
+			<label><input type="radio" aria-label="Bash script" bind:group={chanType} value="bash" /> Bash script</label>
+		</fieldset>
+		<button type="button" onclick={next}>Next</button>
+	{:else if step === 'service'}
+		<ServicePicker catalog={data.catalog} onpick={pickService} />
+	{:else}
+		<label>Channel name <input aria-label="Channel name" bind:value={name} /></label>
+		<label><input type="checkbox" bind:checked={enabled} /> Enabled</label>
+
+		{#if chanType === 'apprise' && service}
+			<h3>{service.name}{#if service.docs_url}<a href={service.docs_url} target="_blank" rel="noreferrer"> docs ↗</a>{/if}</h3>
+			<h4>Required</h4>
+			{#each service.required_fields as f (f.key)}
+				<SchemaField field={f} bind:value={requiredValues[f.key]} />
+			{/each}
+			{#if service.advanced_fields.length}
+				<details>
+					<summary>Advanced</summary>
+					{#each service.advanced_fields as f (f.key)}
+						<SchemaField field={f} bind:value={advancedValues[f.key]} />
+					{/each}
+				</details>
+			{/if}
+			<details>
+				<summary>Or paste a raw Apprise URL</summary>
+				<input aria-label="Raw Apprise URL" bind:value={rawUrl} placeholder="discord://..." />
+			</details>
+		{:else if chanType === 'webhook'}
+			<label>Webhook URL <input aria-label="Webhook URL" bind:value={webhookUrl} /></label>
+			<label>Shared secret (optional, enables HMAC) <input type="password" aria-label="Shared secret" bind:value={sharedSecret} /></label>
+			<label>Custom headers (one per line, Key: value) <textarea aria-label="Custom headers" bind:value={headersText}></textarea></label>
+		{:else}
+			<label>Script path <input aria-label="Script path" bind:value={scriptPath} /></label>
+			<p>Job context is passed as ARM_* environment variables.</p>
+		{/if}
+
+		<EventSubscriptions bind:selected={subscribedEvents} />
+		<details>
+			<summary>Templates</summary>
+			<TemplateEditor subscribedEvents={subscribedEvents} bind:templates />
+		</details>
+
+		<div class="actions">
+			<button type="button" onclick={() => goto('/settings/notifications')}>Cancel</button>
+			<button type="button" disabled={saving} onclick={save}>Save</button>
+		</div>
+	{/if}
+</section>

--- a/frontend/src/routes/settings/notifications/new/+page.ts
+++ b/frontend/src/routes/settings/notifications/new/+page.ts
@@ -1,0 +1,11 @@
+import { fetchServices } from '$lib/api/channels';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+	try {
+		const catalog = await fetchServices();
+		return { catalog };
+	} catch {
+		return { catalog: { featured: [], services: [] } };
+	}
+};

--- a/tests/routers/test_notifications.py
+++ b/tests/routers/test_notifications.py
@@ -102,3 +102,119 @@ async def test_dismiss_notification_failure_no_message(app_client):
         resp = await app_client.patch("/api/notifications/1")
     assert resp.status_code == 502
     assert "Failed to dismiss" in resp.json()["detail"]
+
+
+# --- Channels passthrough ---
+
+async def test_list_channels_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.list_channels",
+        new_callable=AsyncMock, return_value=[{"id": 1, "type": "apprise"}],
+    ):
+        resp = await app_client.get("/api/notifications/channels")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+async def test_list_channels_route_unreachable(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.list_channels",
+        new_callable=AsyncMock, return_value=None,
+    ):
+        resp = await app_client.get("/api/notifications/channels")
+    assert resp.status_code == 503
+
+
+async def test_get_channel_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.get_channel",
+        new_callable=AsyncMock, return_value={"id": 3},
+    ):
+        resp = await app_client.get("/api/notifications/channels/3")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 3
+
+
+async def test_create_channel_route(app_client):
+    body = {"type": "apprise", "name": "x",
+            "config": {"type": "apprise", "url": "discord://a/b"},
+            "subscribed_events": []}
+    with patch(
+        "backend.routers.notifications.arm_client.create_channel",
+        new_callable=AsyncMock, return_value={"id": 9, **body},
+    ):
+        resp = await app_client.post("/api/notifications/channels", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 9
+
+
+async def test_update_channel_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.update_channel",
+        new_callable=AsyncMock, return_value={"id": 9, "name": "renamed"},
+    ):
+        resp = await app_client.patch("/api/notifications/channels/9",
+                                      json={"name": "renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "renamed"
+
+
+async def test_delete_channel_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.delete_channel",
+        new_callable=AsyncMock, return_value={},
+    ):
+        resp = await app_client.delete("/api/notifications/channels/9")
+    assert resp.status_code == 200
+
+
+async def test_test_send_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.test_send_channel",
+        new_callable=AsyncMock, return_value={"dispatch_id": 5, "sent_at": "now"},
+    ):
+        resp = await app_client.post("/api/notifications/channels/2/test",
+                                     json={"event_key": "job.started"})
+    assert resp.status_code == 200
+    assert resp.json()["dispatch_id"] == 5
+
+
+async def test_get_dispatch_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.get_dispatch",
+        new_callable=AsyncMock, return_value={"status": "success"},
+    ):
+        resp = await app_client.get("/api/notifications/dispatch/5")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+
+async def test_list_dispatches_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.list_dispatches",
+        new_callable=AsyncMock, return_value=[{"id": 1, "event_key": "job.started"}],
+    ):
+        resp = await app_client.get("/api/notifications/dispatches?channel_id=2")
+    assert resp.status_code == 200
+    assert resp.json()[0]["event_key"] == "job.started"
+
+
+async def test_get_services_route(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.get_services",
+        new_callable=AsyncMock, return_value={"featured": ["discord"], "services": []},
+    ):
+        resp = await app_client.get("/api/notifications/services")
+    assert resp.status_code == 200
+    assert "discord" in resp.json()["featured"]
+
+
+async def test_compose_url_route(app_client):
+    body = {"required": {"webhook_id": "1"}, "advanced": {}}
+    with patch(
+        "backend.routers.notifications.arm_client.compose_channel_url",
+        new_callable=AsyncMock, return_value={"url": "discord://1"},
+    ):
+        resp = await app_client.post("/api/notifications/services/discord/compose-url", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["url"] == "discord://1"

--- a/tests/services/test_arm_client_channels.py
+++ b/tests/services/test_arm_client_channels.py
@@ -88,3 +88,12 @@ async def test_compose_url_proxies_body():
         out = await arm_client.compose_channel_url("discord", body)
     req.assert_awaited_once_with("POST", "/api/v1/notifications/services/discord/compose-url", json=body)
     assert out["url"] == "discord://1"
+
+
+async def test_compose_url_encodes_service_id():
+    body = {"required": {}, "advanced": {}}
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"url": "x"}) as req:
+        await arm_client.compose_channel_url("weird/id", body)
+    req.assert_awaited_once_with(
+        "POST", "/api/v1/notifications/services/weird%2Fid/compose-url", json=body)

--- a/tests/services/test_arm_client_channels.py
+++ b/tests/services/test_arm_client_channels.py
@@ -1,0 +1,90 @@
+"""Tests for arm_client channel/catalog/dispatch proxy functions."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from backend.services import arm_client
+
+
+async def test_list_channels_proxies_to_neu():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value=[{"id": 1}]) as req:
+        out = await arm_client.list_channels()
+    req.assert_awaited_once_with("GET", "/api/v1/notifications/channels")
+    assert out == [{"id": 1}]
+
+
+async def test_get_channel_proxies():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"id": 3}) as req:
+        out = await arm_client.get_channel(3)
+    req.assert_awaited_once_with("GET", "/api/v1/notifications/channels/3")
+    assert out == {"id": 3}
+
+
+async def test_create_channel_proxies_body():
+    body = {"type": "apprise", "name": "x", "config": {"type": "apprise", "url": "discord://a/b"}, "subscribed_events": []}
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"id": 9}) as req:
+        out = await arm_client.create_channel(body)
+    req.assert_awaited_once_with("POST", "/api/v1/notifications/channels", json=body)
+    assert out == {"id": 9}
+
+
+async def test_update_channel_proxies_body():
+    body = {"name": "renamed"}
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"id": 9, "name": "renamed"}) as req:
+        out = await arm_client.update_channel(9, body)
+    req.assert_awaited_once_with("PATCH", "/api/v1/notifications/channels/9", json=body)
+    assert out["name"] == "renamed"
+
+
+async def test_delete_channel_proxies():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={}) as req:
+        await arm_client.delete_channel(9)
+    req.assert_awaited_once_with("DELETE", "/api/v1/notifications/channels/9")
+
+
+async def test_test_send_channel_proxies():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"dispatch_id": 5}) as req:
+        out = await arm_client.test_send_channel(2, {"event_key": "job.started"})
+    req.assert_awaited_once_with("POST", "/api/v1/notifications/channels/2/test", json={"event_key": "job.started"})
+    assert out["dispatch_id"] == 5
+
+
+async def test_get_dispatch_proxies():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"status": "success"}) as req:
+        out = await arm_client.get_dispatch(5)
+    req.assert_awaited_once_with("GET", "/api/v1/notifications/dispatch/5")
+    assert out["status"] == "success"
+
+
+async def test_list_dispatches_proxies_query():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value=[]) as req:
+        await arm_client.list_dispatches(channel_id=2, status="success", limit=20)
+    req.assert_awaited_once_with(
+        "GET", "/api/v1/notifications/dispatches",
+        params={"channel_id": 2, "status": "success", "limit": 20},
+    )
+
+
+async def test_get_services_proxies():
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"featured": [], "services": []}) as req:
+        out = await arm_client.get_services()
+    req.assert_awaited_once_with("GET", "/api/v1/notifications/services")
+    assert "services" in out
+
+
+async def test_compose_url_proxies_body():
+    body = {"required": {"webhook_id": "1"}, "advanced": {}}
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"url": "discord://1"}) as req:
+        out = await arm_client.compose_channel_url("discord", body)
+    req.assert_awaited_once_with("POST", "/api/v1/notifications/services/discord/compose-url", json=body)
+    assert out["url"] == "discord://1"


### PR DESCRIPTION
## Summary
Sub-spec 3 of 3 for the notification redesign. Adds the arm-ui Notifications page that manages the v4 channels system, and removes the legacy flat-config notification fields.

- BFF passthrough routes for channels CRUD, catalog, compose-url, test-send, dispatch history (added to the existing `notifications.py` router; `arm_client` proxies added).
- Frontend channels API client + hand-written catalog/channel types.
- `/settings/notifications` list view, create flow (apprise/webhook/bash), edit view with dispatch history + test-send polling.
- Schema-driven apprise forms generated from the catalog endpoint.
- Per-event template editor with variable hints.
- Removes the legacy NOTIFY_RIP / NOTIFY_TRANSCODE / NOTIFY_JOBID / PB_KEY / IFTTT_* / PO_* / JSON_URL / APPRISE / BASH_SCRIPT fields from the settings page; the notifications tab now links to the new page.

## Coordination — DO NOT MERGE ALONE
**Must merge together with arm-neu PR #377.** The arm-neu backend drops the legacy Config columns; this PR removes the UI that wrote them. Merging either alone leaves the other inconsistent. Both are intentionally held until joint integration is verified on a live deployment.

Design: arm-ai/arm-ui/docs/superpowers/specs/2026-05-18-notification-integrations-architecture-design.md
Plan: arm-ai/arm-ui/docs/superpowers/plans/2026-05-20-arm-ui-notifications-page.md

## Test plan
- [x] Frontend unit tests: 1008 passing (101 files)
- [x] BFF tests: 693 passing
- [x] svelte-check: 0 errors
- [x] codegen-check in sync
- [x] production build succeeds
- [ ] CI green
- [ ] Joint integration with arm-neu #377 on a live deployment (no live channels backend was reachable in dev — golden-path walk of create/test/edit/delete for all 3 channel types pending the joint deploy)