### PR TITLE
fix(bff): handle empty 204 body in _request

### DIFF
--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -64,6 +64,12 @@ async def _request(
     try:
         resp = await get_client().request(method, url, **kwargs)
         if resp.is_success:
+            # 204 No Content (e.g. channel DELETE) or any empty success body
+            # has no JSON to parse. Return {} — a truthy-enough success marker
+            # that is NOT None, so callers that treat None as "ARM unreachable"
+            # do not misfire a 503.
+            if resp.status_code == 204 or not resp.content:
+                return {}
             return resp.json()
         return _parse_error_response(resp)
     except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError, httpx.ReadError, RuntimeError, OSError) as exc:

--- a/tests/services/test_arm_client.py
+++ b/tests/services/test_arm_client.py
@@ -69,6 +69,44 @@ async def test_abandon_job_connect_error(mock_client):
     assert await arm_client.abandon_job(42) is None
 
 
+# --- _request empty-body handling (204 No Content) ---
+
+
+async def test_request_handles_204_empty_body():
+    """A 204 with an empty body returns {} (not None, no JSONDecodeError).
+
+    arm-neu's DELETE /notifications/channels/{id} returns 204 No Content.
+    Calling resp.json() on the empty body would raise JSONDecodeError and
+    crash the BFF with HTTP 500. Returning {} keeps the None=unreachable
+    sentinel intact while signalling success.
+    """
+    resp = MagicMock()
+    resp.is_success = True
+    resp.status_code = 204
+    resp.content = b""
+    fake_client = MagicMock()
+    fake_client.request = AsyncMock(return_value=resp)
+    with patch.object(arm_client, "get_client", return_value=fake_client):
+        out = await arm_client._request(
+            "DELETE", "/api/v1/notifications/channels/1"
+        )
+    assert out == {}
+
+
+async def test_request_parses_json_on_200():
+    """A normal 200 with a JSON body is still parsed and returned."""
+    resp = MagicMock()
+    resp.is_success = True
+    resp.status_code = 200
+    resp.content = b'{"ok": true}'
+    resp.json = MagicMock(return_value={"ok": True})
+    fake_client = MagicMock()
+    fake_client.request = AsyncMock(return_value=resp)
+    with patch.object(arm_client, "get_client", return_value=fake_client):
+        out = await arm_client._request("GET", "/x")
+    assert out == {"ok": True}
+
+
 # --- skip_and_finalize ---
 
 


### PR DESCRIPTION
## Bug (found during 19.0.0-rc production deploy)

Deleting a notification channel returned **HTTP 500** even though the channel was actually deleted in arm-neu.

arm-neu's `DELETE /api/v1/notifications/channels/{id}` returns **204 No Content** with an empty body (`arm/api/v1/notifications.py`, `status_code=204`). The BFF's shared `_request` helper in `backend/services/arm_client.py` unconditionally called `resp.json()` on every success response, which raised `json.decoder.JSONDecodeError: Expecting value` on the empty 204 body and bubbled up as a 500.

```
File "backend/routers/notifications.py", in delete_channel
File "backend/services/arm_client.py", in delete_channel -> _request
    return resp.json()   # crashes on empty 204 body
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Fix

In `_request`, the success branch now tolerates an empty body:

```python
if resp.is_success:
    if resp.status_code == 204 or not resp.content:
        return {}
    return resp.json()
```

It returns `{}` (not `None`) for empty success bodies. `None` is the "ARM unreachable" sentinel used by routers to raise 503 — returning `{}` keeps that contract intact so a successful 204 is not mistaken for an outage. The DELETE route now returns `{}` with HTTP 200.

## Scope

A scan of arm-neu confirms the channel DELETE is the **only** endpoint returning 204. The 201 endpoints (`POST /jobs/folder`, `POST /notifications/channels`, `POST /jobs/iso`) all return JSON bodies and are unaffected; the `not resp.content` guard would protect them regardless.

Note: this branch is cut from `main`. The `_request` helper (and thus the bug) already lives on `main`; the channel routes that exercise it land with the `feat/notifications-page` merge, so the fix is in place ahead of/independent of that.

## Tests (TDD)

- `test_request_handles_204_empty_body` — 204 + empty content returns `{}` (failed before the fix, passes after).
- `test_request_parses_json_on_200` — normal JSON 200 still parsed.
- Full `tests/services/ + tests/routers/test_notifications.py`: 299 passed.