### PR TITLE
feat(notifications): searchable service dropdown, form polish, Test button

### DIFF
--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -113,3 +113,11 @@ async def compose_channel_url(service_id: str, body: dict[str, Any]) -> Any:
     if resp is None:
         raise HTTPException(status_code=503, detail=_UNREACHABLE)
     return resp
+
+
+@router.post("/notifications/test")
+async def test_channel_config(body: dict[str, Any]) -> Any:
+    resp = await arm_client.test_channel_config(body)
+    if resp is None:
+        raise HTTPException(status_code=503, detail=_UNREACHABLE)
+    return resp

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -806,6 +806,11 @@ async def compose_channel_url(service_id: str, body: dict[str, Any]) -> dict[str
     )
 
 
+async def test_channel_config(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Test-send to an unsaved channel config. Returns None if unreachable."""
+    return await _request("POST", "/api/v1/notifications/test", json=body)
+
+
 # --- Health ---
 
 

--- a/frontend/src/lib/__tests__/channels-api.test.ts
+++ b/frontend/src/lib/__tests__/channels-api.test.ts
@@ -3,7 +3,7 @@ import * as client from '$lib/api/client';
 import {
 	fetchChannels, fetchChannel, createChannel, updateChannel,
 	deleteChannel, testSendChannel, fetchDispatch, fetchDispatches,
-	fetchServices, composeUrl
+	fetchServices, composeUrl, testConfig
 } from '$lib/api/channels';
 
 describe('channels api', () => {
@@ -76,6 +76,15 @@ describe('channels api', () => {
 		await composeUrl('discord', { webhook_id: '1' }, { tts: true });
 		expect(spy).toHaveBeenCalledWith('/api/notifications/services/discord/compose-url', {
 			method: 'POST', body: JSON.stringify({ required: { webhook_id: '1' }, advanced: { tts: true } })
+		});
+	});
+
+	it('testConfig POSTs the config to /test', async () => {
+		const spy = vi.spyOn(client, 'apiFetch').mockResolvedValue({ ok: true, error: null } as never);
+		const body = { type: 'apprise', config: { type: 'apprise', url: 'discord://a/b' }, event_key: 'job.started' };
+		await testConfig(body);
+		expect(spy).toHaveBeenCalledWith('/api/notifications/test', {
+			method: 'POST', body: JSON.stringify(body)
 		});
 	});
 });

--- a/frontend/src/lib/api/channels.ts
+++ b/frontend/src/lib/api/channels.ts
@@ -68,3 +68,14 @@ export function composeUrl(
 		body: JSON.stringify({ required, advanced })
 	});
 }
+
+export function testConfig(body: {
+	type: string;
+	config: Record<string, unknown>;
+	event_key?: string;
+}): Promise<{ ok: boolean; error: string | null }> {
+	return apiFetch<{ ok: boolean; error: string | null }>('/api/notifications/test', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	});
+}

--- a/frontend/src/lib/components/notifications/SchemaField.svelte
+++ b/frontend/src/lib/components/notifications/SchemaField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { CatalogField } from '$lib/types/notifications';
+	import { FIELD_INPUT_CLASS } from '$lib/types/notifications';
 
 	let { field, value = $bindable() }: { field: CatalogField; value: unknown } = $props();
 
@@ -27,7 +28,7 @@
 				aria-label={field.label}
 				bind:value
 				required={field.required}
-				class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+				class={FIELD_INPUT_CLASS}
 			>
 				{#each field.values ?? [] as opt}
 					<option value={opt}>{opt}</option>
@@ -40,7 +41,7 @@
 				step={field.type === 'float' ? 'any' : '1'}
 				bind:value
 				required={field.required}
-				class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+				class={FIELD_INPUT_CLASS}
 			/>
 		{:else}
 			<input
@@ -48,7 +49,7 @@
 				aria-label={field.label}
 				bind:value
 				required={field.required}
-				class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+				class={FIELD_INPUT_CLASS}
 			/>
 		{/if}
 	</label>

--- a/frontend/src/lib/components/notifications/ServicePicker.svelte
+++ b/frontend/src/lib/components/notifications/ServicePicker.svelte
@@ -3,8 +3,10 @@
 
 	let { catalog, onpick }: { catalog: Catalog; onpick: (id: string) => void } = $props();
 
+	let open = $state(false);
 	let search = $state('');
-	let showAll = $state(false);
+	let highlighted = $state(0);
+	let rootEl: HTMLDivElement | undefined = $state();
 
 	const byId = $derived(new Map(catalog.services.map((s) => [s.id, s])));
 
@@ -12,54 +14,123 @@
 		catalog.featured.map((id) => byId.get(id)).filter((s): s is CatalogService => !!s)
 	);
 
-	const filtered = $derived(
+	// When searching, match across all services; otherwise show featured first.
+	const options = $derived(
 		search.trim()
-			? catalog.services.filter((s) => s.name.toLowerCase().includes(search.trim().toLowerCase()))
-			: showAll
-				? catalog.services
-				: featuredServices
+			? catalog.services.filter((s) =>
+					s.name.toLowerCase().includes(search.trim().toLowerCase())
+				)
+			: featuredServices
 	);
+
+	function choose(id: string) {
+		onpick(id);
+		open = false;
+		search = '';
+	}
+
+	function toggle() {
+		open = !open;
+		if (open) {
+			search = '';
+			highlighted = 0;
+		}
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (!open) {
+			if (e.key === 'Enter' || e.key === 'ArrowDown' || e.key === ' ') {
+				e.preventDefault();
+				toggle();
+			}
+			return;
+		}
+		if (e.key === 'Escape') {
+			open = false;
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			highlighted = Math.min(highlighted + 1, options.length - 1);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			highlighted = Math.max(highlighted - 1, 0);
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			const opt = options[highlighted];
+			if (opt) choose(opt.id);
+		}
+	}
+
+	$effect(() => {
+		if (!open) return;
+		function onDocClick(ev: MouseEvent) {
+			if (rootEl && !rootEl.contains(ev.target as Node)) open = false;
+		}
+		document.addEventListener('click', onDocClick, true);
+		return () => document.removeEventListener('click', onDocClick, true);
+	});
+
+	// Keep the highlighted index in range as the filtered list changes.
+	$effect(() => {
+		if (highlighted > options.length - 1) highlighted = 0;
+	});
 </script>
 
-<div class="space-y-3">
-	<input
-		type="search"
-		placeholder="Search services"
-		bind:value={search}
-		class="w-full rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
-	/>
+<div class="relative" bind:this={rootEl}>
+	<button
+		type="button"
+		onclick={toggle}
+		onkeydown={onKeydown}
+		aria-haspopup="listbox"
+		aria-expanded={open}
+		class="flex w-full items-center justify-between rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-left text-sm text-gray-700 hover:border-primary focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-gray-200"
+	>
+		<span>Select a service…</span>
+		<svg
+			class="h-4 w-4 transform transition-transform {open ? 'rotate-180' : ''}"
+			fill="none" stroke="currentColor" viewBox="0 0 24 24"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
+	</button>
 
-	{#if filtered.length === 0}
-		<p class="text-sm text-gray-500 dark:text-gray-400">No services match "{search}".</p>
-	{:else}
-		<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
-			{#each filtered as svc (svc.id)}
-				<button
-					type="button"
-					onclick={() => onpick(svc.id)}
-					class="rounded-md border border-primary/25 bg-surface px-3 py-2 text-sm text-gray-800 hover:border-primary hover:bg-primary/10 dark:border-primary/30 dark:bg-surface-dark dark:text-gray-200 dark:hover:bg-primary/15"
-				>
-					{svc.name}
-				</button>
-			{/each}
+	{#if open}
+		<div
+			class="absolute z-20 mt-1 w-full overflow-hidden rounded-md border border-primary/25 bg-surface shadow-lg dark:border-primary/30 dark:bg-surface-dark"
+		>
+			<div class="p-2">
+				<!-- svelte-ignore a11y_autofocus -->
+				<input
+					type="search"
+					placeholder="Search services"
+					bind:value={search}
+					onkeydown={onKeydown}
+					autofocus
+					class="w-full rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+				/>
+			</div>
+			<ul role="listbox" class="max-h-60 overflow-y-auto py-1">
+				{#if options.length === 0}
+					<li class="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No services match "{search}".</li>
+				{:else}
+					{#each options as svc, i (svc.id)}
+						<li role="option" aria-selected={i === highlighted}>
+							<button
+								type="button"
+								onclick={() => choose(svc.id)}
+								onmouseenter={() => (highlighted = i)}
+								class="block w-full px-3 py-2 text-left text-sm text-gray-800 hover:bg-primary/10 dark:text-gray-200 dark:hover:bg-primary/15 {i === highlighted ? 'bg-primary/10 dark:bg-primary/15' : ''}"
+							>
+								{svc.name}
+							</button>
+						</li>
+					{/each}
+				{/if}
+			</ul>
+			{#if !search.trim()}
+				<p class="border-t border-primary/15 px-3 py-1.5 text-xs text-gray-500 dark:border-primary/20 dark:text-gray-400">
+					Showing {featuredServices.length} featured — type to search all {catalog.services.length}.
+				</p>
+			{/if}
 		</div>
-	{/if}
-
-	{#if !search.trim() && !showAll}
-		<button
-			type="button"
-			onclick={() => (showAll = true)}
-			class="text-sm font-medium text-primary hover:text-primary-hover hover:underline"
-		>
-			Show all ({catalog.services.length})
-		</button>
-	{:else if !search.trim() && showAll}
-		<button
-			type="button"
-			onclick={() => (showAll = false)}
-			class="text-sm font-medium text-primary hover:text-primary-hover hover:underline"
-		>
-			Show featured only
-		</button>
 	{/if}
 </div>

--- a/frontend/src/lib/components/notifications/ServicePicker.svelte
+++ b/frontend/src/lib/components/notifications/ServicePicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Catalog, CatalogService } from '$lib/types/notifications';
+	import { FIELD_INPUT_CLASS } from '$lib/types/notifications';
 
 	let { catalog, onpick }: { catalog: Catalog; onpick: (id: string) => void } = $props();
 
@@ -114,7 +115,7 @@
 					bind:value={search}
 					onkeydown={onKeydown}
 					autofocus
-					class="w-full rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+					class="w-full {FIELD_INPUT_CLASS}"
 				/>
 			</div>
 			<ul role="listbox" class="max-h-60 overflow-y-auto py-1">

--- a/frontend/src/lib/components/notifications/ServicePicker.svelte
+++ b/frontend/src/lib/components/notifications/ServicePicker.svelte
@@ -14,13 +14,22 @@
 		catalog.featured.map((id) => byId.get(id)).filter((s): s is CatalogService => !!s)
 	);
 
-	// When searching, match across all services; otherwise show featured first.
+	// All services, featured first (for discoverability) then the rest A→Z.
+	const allOrdered = $derived.by(() => {
+		const featuredIds = new Set(catalog.featured);
+		const rest = catalog.services
+			.filter((s) => !featuredIds.has(s.id))
+			.sort((a, b) => a.name.localeCompare(b.name));
+		return [...featuredServices, ...rest];
+	});
+
+	// Show every service by default; filter across all when searching.
 	const options = $derived(
 		search.trim()
 			? catalog.services.filter((s) =>
 					s.name.toLowerCase().includes(search.trim().toLowerCase())
 				)
-			: featuredServices
+			: allOrdered
 	);
 
 	function choose(id: string) {
@@ -128,7 +137,7 @@
 			</ul>
 			{#if !search.trim()}
 				<p class="border-t border-primary/15 px-3 py-1.5 text-xs text-gray-500 dark:border-primary/20 dark:text-gray-400">
-					Showing {featuredServices.length} featured — type to search all {catalog.services.length}.
+					{catalog.services.length} services — type to filter.
 				</p>
 			{/if}
 		</div>

--- a/frontend/src/lib/components/notifications/TemplateEditor.svelte
+++ b/frontend/src/lib/components/notifications/TemplateEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { EVENT_VARIABLES, EVENT_LABELS, type EventKey } from '$lib/types/notifications';
+	import { EVENT_VARIABLES, EVENT_LABELS, type EventKey, FIELD_INPUT_CLASS } from '$lib/types/notifications';
 	import type { ChannelTemplate } from '$lib/types/notifications';
 
 	let {
@@ -30,7 +30,7 @@
 					aria-label={`${key} title`}
 					value={templates[key]?.title ?? ''}
 					oninput={(e) => (ensure(key).title = (e.currentTarget as HTMLInputElement).value || null)}
-					class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+					class={FIELD_INPUT_CLASS}
 				/>
 			</label>
 			<label class="flex flex-col gap-1">
@@ -40,7 +40,7 @@
 					rows="2"
 					value={templates[key]?.body ?? ''}
 					oninput={(e) => (ensure(key).body = (e.currentTarget as HTMLTextAreaElement).value || null)}
-					class="rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white"
+					class={FIELD_INPUT_CLASS}
 				></textarea>
 			</label>
 			<p class="text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/lib/components/notifications/TemplateEditor.svelte
+++ b/frontend/src/lib/components/notifications/TemplateEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { EVENT_VARIABLES, EVENT_LABELS, type EventKey, FIELD_INPUT_CLASS } from '$lib/types/notifications';
+	import { EVENT_VARIABLES, EVENT_LABELS, EVENT_DEFAULT_TEMPLATES, type EventKey, FIELD_INPUT_CLASS } from '$lib/types/notifications';
 	import type { ChannelTemplate } from '$lib/types/notifications';
 
 	let {
@@ -15,6 +15,10 @@
 	function varsFor(key: string): string[] {
 		return EVENT_VARIABLES[key as EventKey] ?? [];
 	}
+
+	function defaultsFor(key: string): { title: string; body: string } {
+		return EVENT_DEFAULT_TEMPLATES[key as EventKey] ?? { title: '', body: '' };
+	}
 </script>
 
 <div class="space-y-4">
@@ -28,6 +32,7 @@
 				<span class="text-xs font-medium text-gray-600 dark:text-gray-400">Title</span>
 				<input
 					aria-label={`${key} title`}
+					placeholder={defaultsFor(key).title}
 					value={templates[key]?.title ?? ''}
 					oninput={(e) => (ensure(key).title = (e.currentTarget as HTMLInputElement).value || null)}
 					class={FIELD_INPUT_CLASS}
@@ -38,11 +43,15 @@
 				<textarea
 					aria-label={`${key} body`}
 					rows="2"
+					placeholder={defaultsFor(key).body}
 					value={templates[key]?.body ?? ''}
 					oninput={(e) => (ensure(key).body = (e.currentTarget as HTMLTextAreaElement).value || null)}
 					class={FIELD_INPUT_CLASS}
 				></textarea>
 			</label>
+			<p class="text-xs text-gray-500 dark:text-gray-400">
+				Leave blank to send the default shown above.
+			</p>
 			<p class="text-xs text-gray-500 dark:text-gray-400">
 				Available variables:
 				{#each varsFor(key) as v}

--- a/frontend/src/lib/components/notifications/TemplateEditor.svelte
+++ b/frontend/src/lib/components/notifications/TemplateEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { EVENT_VARIABLES, EVENT_LABELS, EVENT_DEFAULT_TEMPLATES, type EventKey, FIELD_INPUT_CLASS } from '$lib/types/notifications';
 	import type { ChannelTemplate } from '$lib/types/notifications';
 
@@ -6,6 +7,19 @@
 		subscribedEvents,
 		templates = $bindable()
 	}: { subscribedEvents: string[]; templates: Record<string, ChannelTemplate> } = $props();
+
+	type FieldName = 'title' | 'body';
+	type FocusTarget = {
+		key: string;
+		field: FieldName;
+		el: HTMLInputElement | HTMLTextAreaElement;
+		start: number;
+		end: number;
+	};
+
+	// The most recently focused template field + its caret/selection, so a
+	// variable-chip click knows where to insert. Captured per event row.
+	let active: FocusTarget | null = $state(null);
 
 	function ensure(key: string): ChannelTemplate {
 		if (!templates[key]) templates[key] = { title: null, body: null };
@@ -18,6 +32,54 @@
 
 	function defaultsFor(key: string): { title: string; body: string } {
 		return EVENT_DEFAULT_TEMPLATES[key as EventKey] ?? { title: '', body: '' };
+	}
+
+	// Remember the focused field and current caret so a later chip click can
+	// insert there even though clicking the chip moves DOM focus.
+	function rememberCaret(key: string, field: FieldName, el: HTMLInputElement | HTMLTextAreaElement) {
+		active = {
+			key,
+			field,
+			el,
+			start: el.selectionStart ?? el.value.length,
+			end: el.selectionEnd ?? el.value.length
+		};
+	}
+
+	// Insert `{varName}` into the last-focused field for `key` at the caret.
+	// If no field for this row is focused, append to the title.
+	async function insertVariable(key: string, varName: string) {
+		const token = `{${varName}}`;
+		const tmpl: ChannelTemplate = templates[key] ?? { title: null, body: null };
+		const target =
+			active && active.key === key
+				? active
+				: { key, field: 'title' as FieldName, el: null, start: (tmpl.title ?? '').length, end: (tmpl.title ?? '').length };
+
+		const current = (target.field === 'title' ? tmpl.title : tmpl.body) ?? '';
+		const start = Math.min(target.start, current.length);
+		const end = Math.min(target.end, current.length);
+		const next = current.slice(0, start) + token + current.slice(end);
+
+		// Reassign through the bindable so both new keys and nested-field
+		// updates trigger reactivity reliably.
+		templates = {
+			...templates,
+			[key]: {
+				title: target.field === 'title' ? next || null : tmpl.title ?? null,
+				body: target.field === 'body' ? next || null : tmpl.body ?? null
+			}
+		};
+
+		// Restore focus + place the caret right after the inserted token,
+		// once Svelte has flushed the new value to the DOM.
+		const caret = start + token.length;
+		await tick();
+		if (target.el) {
+			target.el.focus();
+			target.el.setSelectionRange(caret, caret);
+			active = { ...target, start: caret, end: caret };
+		}
 	}
 </script>
 
@@ -34,7 +96,13 @@
 					aria-label={`${key} title`}
 					placeholder={defaultsFor(key).title}
 					value={templates[key]?.title ?? ''}
-					oninput={(e) => (ensure(key).title = (e.currentTarget as HTMLInputElement).value || null)}
+					oninput={(e) => {
+						ensure(key).title = (e.currentTarget as HTMLInputElement).value || null;
+						rememberCaret(key, 'title', e.currentTarget as HTMLInputElement);
+					}}
+					onfocus={(e) => rememberCaret(key, 'title', e.currentTarget as HTMLInputElement)}
+					onkeyup={(e) => rememberCaret(key, 'title', e.currentTarget as HTMLInputElement)}
+					onclick={(e) => rememberCaret(key, 'title', e.currentTarget as HTMLInputElement)}
 					class={FIELD_INPUT_CLASS}
 				/>
 			</label>
@@ -45,7 +113,13 @@
 					rows="2"
 					placeholder={defaultsFor(key).body}
 					value={templates[key]?.body ?? ''}
-					oninput={(e) => (ensure(key).body = (e.currentTarget as HTMLTextAreaElement).value || null)}
+					oninput={(e) => {
+						ensure(key).body = (e.currentTarget as HTMLTextAreaElement).value || null;
+						rememberCaret(key, 'body', e.currentTarget as HTMLTextAreaElement);
+					}}
+					onfocus={(e) => rememberCaret(key, 'body', e.currentTarget as HTMLTextAreaElement)}
+					onkeyup={(e) => rememberCaret(key, 'body', e.currentTarget as HTMLTextAreaElement)}
+					onclick={(e) => rememberCaret(key, 'body', e.currentTarget as HTMLTextAreaElement)}
 					class={FIELD_INPUT_CLASS}
 				></textarea>
 			</label>
@@ -53,11 +127,18 @@
 				Leave blank to send the default shown above.
 			</p>
 			<p class="text-xs text-gray-500 dark:text-gray-400">
-				Available variables:
-				{#each varsFor(key) as v}
-					<code class="mr-1 rounded bg-primary/10 px-1 py-0.5 text-primary dark:bg-primary/15">{`{${v}}`}</code>
-				{/each}
+				Click a variable to insert it{active?.key === key ? ` into the ${active.field}` : ''}:
 			</p>
+			<div class="flex flex-wrap gap-1">
+				{#each varsFor(key) as v}
+					<button
+						type="button"
+						aria-label={`Insert {${v}}`}
+						onclick={() => insertVariable(key, v)}
+						class="rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary hover:bg-primary/20 dark:bg-primary/15 dark:hover:bg-primary/25"
+					><code>{`{${v}}`}</code></button>
+				{/each}
+			</div>
 		</div>
 	{/each}
 </div>

--- a/frontend/src/lib/components/notifications/__tests__/ServicePicker.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ServicePicker.test.ts
@@ -15,23 +15,46 @@ const catalog: Catalog = {
 describe('ServicePicker', () => {
 	afterEach(() => cleanup());
 
-	it('renders featured services', () => {
+	it('shows a closed dropdown trigger by default', () => {
 		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
-		expect(screen.getByText('Discord')).toBeTruthy();
-		expect(screen.getByText('Slack')).toBeTruthy();
+		const trigger = screen.getByRole('button', { name: /select a service/i });
+		expect(trigger).toBeTruthy();
+		expect(trigger.getAttribute('aria-expanded')).toBe('false');
+		// Options are not rendered until opened.
+		expect(screen.queryByText('Discord')).toBeNull();
 	});
 
-	it('filters by search substring', async () => {
+	it('reveals featured services when opened', async () => {
 		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
+		await fireEvent.click(screen.getByRole('button', { name: /select a service/i }));
+		expect(screen.getByText('Discord')).toBeTruthy();
+		expect(screen.getByText('Slack')).toBeTruthy();
+		// Non-featured services are hidden until searched.
+		expect(screen.queryByText('Telegram')).toBeNull();
+	});
+
+	it('filters across all services by search substring', async () => {
+		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
+		await fireEvent.click(screen.getByRole('button', { name: /select a service/i }));
 		await fireEvent.input(screen.getByPlaceholderText('Search services'), { target: { value: 'tele' } });
 		expect(screen.queryByText('Telegram')).toBeTruthy();
 		expect(screen.queryByText('Discord')).toBeNull();
 	});
 
-	it('calls onpick with the service id', async () => {
+	it('calls onpick with the service id and closes', async () => {
 		let picked = '';
 		renderComponent(ServicePicker, { props: { catalog, onpick: (id: string) => (picked = id) } });
+		await fireEvent.click(screen.getByRole('button', { name: /select a service/i }));
 		await fireEvent.click(screen.getByText('Discord'));
 		expect(picked).toBe('discord');
+		// Dropdown closed after selection.
+		expect(screen.queryByText('Slack')).toBeNull();
+	});
+
+	it('shows an empty state when nothing matches', async () => {
+		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
+		await fireEvent.click(screen.getByRole('button', { name: /select a service/i }));
+		await fireEvent.input(screen.getByPlaceholderText('Search services'), { target: { value: 'zzz' } });
+		expect(screen.getByText(/No services match/i)).toBeTruthy();
 	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/ServicePicker.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ServicePicker.test.ts
@@ -24,13 +24,14 @@ describe('ServicePicker', () => {
 		expect(screen.queryByText('Discord')).toBeNull();
 	});
 
-	it('reveals featured services when opened', async () => {
+	it('reveals all services when opened, featured first', async () => {
 		renderComponent(ServicePicker, { props: { catalog, onpick: () => {} } });
 		await fireEvent.click(screen.getByRole('button', { name: /select a service/i }));
+		// Featured services...
 		expect(screen.getByText('Discord')).toBeTruthy();
 		expect(screen.getByText('Slack')).toBeTruthy();
-		// Non-featured services are hidden until searched.
-		expect(screen.queryByText('Telegram')).toBeNull();
+		// ...and non-featured services are all shown by default now.
+		expect(screen.getByText('Telegram')).toBeTruthy();
 	});
 
 	it('filters across all services by search substring', async () => {

--- a/frontend/src/lib/components/notifications/__tests__/TemplateEditor.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/TemplateEditor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { renderComponent, screen, cleanup } from '$lib/test-utils';
+import { renderComponent, screen, cleanup, fireEvent, waitFor } from '$lib/test-utils';
 import TemplateEditor from '../TemplateEditor.svelte';
 
 describe('TemplateEditor', () => {
@@ -35,5 +35,32 @@ describe('TemplateEditor', () => {
 		expect((screen.getByLabelText('job.started body') as HTMLTextAreaElement).placeholder)
 			.toBe('Job {job_id} started ripping {job_title} ({job_disc_type}).');
 		expect(screen.getByText(/Leave blank to send the default/i)).toBeTruthy();
+	});
+
+	it('inserts a variable token at the caret of the focused field', async () => {
+		renderComponent(TemplateEditor, { props: { subscribedEvents: ['job.started'], templates: {} } });
+		const title = screen.getByLabelText('job.started title') as HTMLInputElement;
+
+		// Type some text, place the caret in the middle, then click a chip.
+		await fireEvent.input(title, { target: { value: 'hi  there' } });
+		title.focus();
+		title.setSelectionRange(3, 3); // after "hi "
+		await fireEvent.click(title); // captures caret position
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Insert {job_title}' }));
+
+		await waitFor(() => {
+			expect((screen.getByLabelText('job.started title') as HTMLInputElement).value)
+				.toBe('hi {job_title} there');
+		});
+	});
+
+	it('appends a variable to the title when no field is focused', async () => {
+		renderComponent(TemplateEditor, { props: { subscribedEvents: ['job.started'], templates: {} } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Insert {job_id}' }));
+		await waitFor(() => {
+			expect((screen.getByLabelText('job.started title') as HTMLInputElement).value)
+				.toBe('{job_id}');
+		});
 	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/TemplateEditor.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/TemplateEditor.test.ts
@@ -27,4 +27,13 @@ describe('TemplateEditor', () => {
 		});
 		expect((screen.getByLabelText('job.started title') as HTMLInputElement).value).toBe('Hi {job_title}');
 	});
+
+	it('shows the built-in default as a placeholder when a field is blank', () => {
+		renderComponent(TemplateEditor, { props: { subscribedEvents: ['job.started'], templates: {} } });
+		expect((screen.getByLabelText('job.started title') as HTMLInputElement).placeholder)
+			.toBe('ARM started: {job_title}');
+		expect((screen.getByLabelText('job.started body') as HTMLTextAreaElement).placeholder)
+			.toBe('Job {job_id} started ripping {job_title} ({job_disc_type}).');
+		expect(screen.getByText(/Leave blank to send the default/i)).toBeTruthy();
+	});
 });

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -7262,31 +7262,3 @@ export type GetPatternTokensApiPatternsTokensGetResponses = {
 };
 
 export type GetPatternTokensApiPatternsTokensGetResponse = GetPatternTokensApiPatternsTokensGetResponses[keyof GetPatternTokensApiPatternsTokensGetResponses];
-
-export type RootStaticOrSpaFilenameGetData = {
-    body?: never;
-    path: {
-        /**
-         * Filename
-         */
-        filename: string;
-    };
-    query?: never;
-    url: '/{filename}';
-};
-
-export type RootStaticOrSpaFilenameGetErrors = {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-};
-
-export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
-
-export type RootStaticOrSpaFilenameGetResponses = {
-    /**
-     * Successful Response
-     */
-    200: unknown;
-};

--- a/frontend/src/lib/types/api.gen.ts
+++ b/frontend/src/lib/types/api.gen.ts
@@ -6277,6 +6277,36 @@ export type ComposeChannelUrlApiNotificationsServicesServiceIdComposeUrlPostResp
     200: unknown;
 };
 
+export type TestChannelConfigApiNotificationsTestPostData = {
+    /**
+     * Body
+     */
+    body: {
+        [key: string]: unknown;
+    };
+    path?: never;
+    query?: never;
+    url: '/api/notifications/test';
+};
+
+export type TestChannelConfigApiNotificationsTestPostErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type TestChannelConfigApiNotificationsTestPostError = TestChannelConfigApiNotificationsTestPostErrors[keyof TestChannelConfigApiNotificationsTestPostErrors];
+
+export type TestChannelConfigApiNotificationsTestPostResponses = {
+    /**
+     * Response Test Channel Config Api Notifications Test Post
+     *
+     * Successful Response
+     */
+    200: unknown;
+};
+
 export type ListThemesApiThemesGetData = {
     body?: never;
     path?: never;
@@ -7232,3 +7262,31 @@ export type GetPatternTokensApiPatternsTokensGetResponses = {
 };
 
 export type GetPatternTokensApiPatternsTokensGetResponse = GetPatternTokensApiPatternsTokensGetResponses[keyof GetPatternTokensApiPatternsTokensGetResponses];
+
+export type RootStaticOrSpaFilenameGetData = {
+    body?: never;
+    path: {
+        /**
+         * Filename
+         */
+        filename: string;
+    };
+    query?: never;
+    url: '/{filename}';
+};
+
+export type RootStaticOrSpaFilenameGetErrors = {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+};
+
+export type RootStaticOrSpaFilenameGetError = RootStaticOrSpaFilenameGetErrors[keyof RootStaticOrSpaFilenameGetErrors];
+
+export type RootStaticOrSpaFilenameGetResponses = {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+};

--- a/frontend/src/lib/types/notifications.ts
+++ b/frontend/src/lib/types/notifications.ts
@@ -143,6 +143,36 @@ export const EVENT_LABELS: Record<EventKey, string> = {
 	'job.duplicate_detected': 'Duplicate detected'
 };
 
+// Built-in title/body used when a channel leaves a template field blank.
+// Mirror of arm-neu arm/notifications/templates.py _DEFAULTS — surfaced as
+// placeholders so "optional" templates show what will be sent by default.
+export const EVENT_DEFAULT_TEMPLATES: Record<EventKey, { title: string; body: string }> = {
+	'job.started': {
+		title: 'ARM started: {job_title}',
+		body: 'Job {job_id} started ripping {job_title} ({job_disc_type}).'
+	},
+	'job.rip_complete': {
+		title: 'Rip complete: {job_title}',
+		body: 'Job {job_id} rip finished in {rip_duration_seconds}s, {track_count} tracks.'
+	},
+	'job.transcode_complete': {
+		title: 'Transcode complete: {job_title}',
+		body: 'Job {job_id} transcode finished in {transcode_duration_seconds}s. Output: {output_path}'
+	},
+	'job.failed': {
+		title: 'ARM job failed: {job_title}',
+		body: 'Job {job_id} failed during {phase}: {error_message}'
+	},
+	'job.manual_wait_required': {
+		title: 'ARM waiting: {job_title}',
+		body: 'Job {job_id} is waiting for manual input ({reason}). {wait_minutes_remaining} minutes remaining.'
+	},
+	'job.duplicate_detected': {
+		title: 'Duplicate detected: {job_title}',
+		body: 'Job {job_id} duplicates existing job {existing_job_id}.'
+	}
+};
+
 export function isCatalogField(v: unknown): v is CatalogField {
 	if (typeof v !== 'object' || v === null) return false;
 	const f = v as Record<string, unknown>;

--- a/frontend/src/lib/types/notifications.ts
+++ b/frontend/src/lib/types/notifications.ts
@@ -148,3 +148,9 @@ export function isCatalogField(v: unknown): v is CatalogField {
 	const f = v as Record<string, unknown>;
 	return typeof f.key === 'string' && typeof f.label === 'string' && typeof f.type === 'string';
 }
+
+// Shared input styling for the notification form fields, so the long
+// Tailwind class string lives in one place (components can't reach the
+// settings page's local inputClass constant).
+export const FIELD_INPUT_CLASS =
+	'rounded-md border border-primary/25 bg-primary/5 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary dark:border-primary/30 dark:bg-primary/10 dark:text-white';

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -558,7 +558,7 @@
 		const entry = editState[id];
 		if (!entry) return;
 		if (!entry.name.trim()) {
-			entry.toast = 'Channel name is required.';
+			entry.toast = 'Channel label is required.';
 			return;
 		}
 		entry.saving = true;
@@ -661,7 +661,7 @@
 		// Required-field validation (inputs aren't in a <form>, so the
 		// browser's required attribute never fires — validate explicitly).
 		if (!addName.trim()) {
-			addError = 'Channel name is required.';
+			addError = 'Channel label is required.';
 			return;
 		}
 		addSaving = true;
@@ -2275,8 +2275,8 @@
 
 										<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 											<label class="block">
-												<span class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Channel name *</span>
-												<input class={inputClass} aria-label="Channel name" aria-required="true" required bind:value={entry.name} />
+												<span class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Channel Label *</span>
+												<input class={inputClass} aria-label="Channel Label" aria-required="true" required bind:value={entry.name} />
 											</label>
 											<label class="flex items-end gap-2 pb-2">
 												<input type="checkbox" bind:checked={entry.enabled} />
@@ -2286,12 +2286,15 @@
 
 										<EventSubscriptions bind:selected={entry.subscribedEvents} />
 
-										<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5">
-											<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Templates</summary>
-											<div class="mt-3">
-												<TemplateEditor subscribedEvents={entry.subscribedEvents} bind:templates={entry.templates} />
-											</div>
-										</details>
+										{#if entry.subscribedEvents.length > 0}
+											<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5" open>
+												<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Message templates (optional)</summary>
+												<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Customize the title and body sent for each subscribed event. Leave blank to use the built-in defaults.</p>
+												<div class="mt-3">
+													<TemplateEditor subscribedEvents={entry.subscribedEvents} bind:templates={entry.templates} />
+												</div>
+											</details>
+										{/if}
 
 										<div class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5">
 											<h3 class="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Recent sends</h3>
@@ -2355,6 +2358,17 @@
 										<p class="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-900/20 dark:text-red-300">{addError}</p>
 									{/if}
 
+									<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+										<label class="block">
+											<span class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Channel Label *</span>
+											<input class={inputClass} aria-label="New channel label" aria-required="true" required bind:value={addName} />
+										</label>
+										<label class="flex items-end gap-2 pb-2">
+											<input type="checkbox" bind:checked={addEnabled} />
+											<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Enabled</span>
+										</label>
+									</div>
+
 									<fieldset class="space-y-2">
 										<legend class="text-sm font-medium text-gray-700 dark:text-gray-300">Channel type</legend>
 										<div class="flex flex-wrap gap-4">
@@ -2369,17 +2383,6 @@
 											</label>
 										</div>
 									</fieldset>
-
-									<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-										<label class="block">
-											<span class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Channel name *</span>
-											<input class={inputClass} aria-label="New channel name" aria-required="true" required bind:value={addName} />
-										</label>
-										<label class="flex items-end gap-2 pb-2">
-											<input type="checkbox" bind:checked={addEnabled} />
-											<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Enabled</span>
-										</label>
-									</div>
 
 									{#if addType === 'apprise'}
 										{#if !addService}
@@ -2442,12 +2445,15 @@
 
 									<EventSubscriptions bind:selected={addSubscribedEvents} />
 
-									<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5">
-										<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Templates</summary>
-										<div class="mt-3">
-											<TemplateEditor subscribedEvents={addSubscribedEvents} bind:templates={addTemplates} />
-										</div>
-									</details>
+									{#if addSubscribedEvents.length > 0}
+										<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5" open>
+											<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Message templates (optional)</summary>
+											<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Customize the title and body sent for each subscribed event. Leave blank to use the built-in defaults.</p>
+											<div class="mt-3">
+												<TemplateEditor subscribedEvents={addSubscribedEvents} bind:templates={addTemplates} />
+											</div>
+										</details>
+									{/if}
 
 									<div class="flex flex-wrap items-center gap-2">
 										<button

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1554,6 +1554,35 @@
 	</div>
 {/snippet}
 
+<!-- Message-templates section, shared by the edit and add channel forms.
+     The TemplateEditor is passed as children so each call site keeps its
+     own bind:templates. -->
+{#snippet templatesSection(subscribedEvents: string[], children: import('svelte').Snippet)}
+	{#if subscribedEvents.length > 0}
+		<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5" open>
+			<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Message templates (optional)</summary>
+			<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Customize the title and body sent for each subscribed event. Leave blank to use the built-in defaults.</p>
+			<div class="mt-3">{@render children()}</div>
+		</details>
+	{/if}
+{/snippet}
+
+<!-- Save + Test button pair, shared by the edit and add channel forms. -->
+{#snippet channelActionButtons(saving: boolean, onSave: () => void, testing: boolean, onTest: () => void)}
+	<button
+		type="button"
+		disabled={saving}
+		onclick={onSave}
+		class="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-hover disabled:opacity-50 dark:bg-primary dark:hover:bg-primary-hover"
+	>{saving ? 'Saving…' : 'Save'}</button>
+	<button
+		type="button"
+		disabled={testing}
+		onclick={onTest}
+		class="rounded-md border border-primary/25 px-4 py-2 text-sm font-medium text-primary-text hover:bg-primary/10 disabled:opacity-50 dark:border-primary/30 dark:text-primary-text-dark dark:hover:bg-primary/15"
+	>{testing ? 'Testing…' : 'Test'}</button>
+{/snippet}
+
 <!-- Reusable snippet for GPU support cards.
      Filters to the detected vendor's group(s); falls back to showing all
      groups when nothing is detected so the user can see what's missing. -->
@@ -2312,15 +2341,10 @@
 
 										<EventSubscriptions bind:selected={entry.subscribedEvents} />
 
-										{#if entry.subscribedEvents.length > 0}
-											<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5" open>
-												<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Message templates (optional)</summary>
-												<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Customize the title and body sent for each subscribed event. Leave blank to use the built-in defaults.</p>
-												<div class="mt-3">
-													<TemplateEditor subscribedEvents={entry.subscribedEvents} bind:templates={entry.templates} />
-												</div>
-											</details>
-										{/if}
+										{#snippet editTemplateEditor()}
+											<TemplateEditor subscribedEvents={entry.subscribedEvents} bind:templates={entry.templates} />
+										{/snippet}
+										{@render templatesSection(entry.subscribedEvents, editTemplateEditor)}
 
 										<div class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5">
 											<h3 class="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Recent sends</h3>
@@ -2332,18 +2356,7 @@
 										</div>
 
 										<div class="flex flex-wrap items-center gap-2">
-											<button
-												type="button"
-												disabled={entry.saving}
-												onclick={() => saveChannel(ch.id)}
-												class="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-hover disabled:opacity-50 dark:bg-primary dark:hover:bg-primary-hover"
-											>{entry.saving ? 'Saving…' : 'Save'}</button>
-											<button
-												type="button"
-												disabled={entry.testing}
-												onclick={() => testChannel(ch.id)}
-												class="rounded-md border border-primary/25 px-4 py-2 text-sm font-medium text-primary-text hover:bg-primary/10 disabled:opacity-50 dark:border-primary/30 dark:text-primary-text-dark dark:hover:bg-primary/15"
-											>{entry.testing ? 'Testing…' : 'Test'}</button>
+											{@render channelActionButtons(entry.saving, () => saveChannel(ch.id), entry.testing, () => testChannel(ch.id))}
 											<button
 												type="button"
 												onclick={() => removeChannel(ch)}
@@ -2466,29 +2479,13 @@
 
 									<EventSubscriptions bind:selected={addSubscribedEvents} />
 
-									{#if addSubscribedEvents.length > 0}
-										<details class="rounded-md border border-primary/15 bg-page p-3 dark:border-primary/20 dark:bg-primary/5" open>
-											<summary class="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">Message templates (optional)</summary>
-											<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Customize the title and body sent for each subscribed event. Leave blank to use the built-in defaults.</p>
-											<div class="mt-3">
-												<TemplateEditor subscribedEvents={addSubscribedEvents} bind:templates={addTemplates} />
-											</div>
-										</details>
-									{/if}
+									{#snippet addTemplateEditor()}
+										<TemplateEditor subscribedEvents={addSubscribedEvents} bind:templates={addTemplates} />
+									{/snippet}
+									{@render templatesSection(addSubscribedEvents, addTemplateEditor)}
 
 									<div class="flex flex-wrap items-center gap-2">
-										<button
-											type="button"
-											disabled={addSaving}
-											onclick={saveNewChannel}
-											class="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-hover disabled:opacity-50 dark:bg-primary dark:hover:bg-primary-hover"
-										>{addSaving ? 'Saving…' : 'Save'}</button>
-										<button
-											type="button"
-											disabled={addTesting}
-											onclick={testNewChannel}
-											class="rounded-md border border-primary/25 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 disabled:opacity-50 dark:border-primary/30 dark:hover:bg-primary/15"
-										>{addTesting ? 'Testing…' : 'Test'}</button>
+										{@render channelActionButtons(addSaving, saveNewChannel, addTesting, testNewChannel)}
 										<button
 											type="button"
 											onclick={() => { resetAddForm(); addPanelOpen = false; }}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -32,7 +32,7 @@
 	import DispatchHistory from '$lib/components/notifications/DispatchHistory.svelte';
 	import {
 		fetchChannels, fetchServices, createChannel, updateChannel,
-		deleteChannel, testSendChannel, fetchDispatch, fetchDispatches, composeUrl
+		deleteChannel, testSendChannel, fetchDispatch, fetchDispatches, composeUrl, testConfig
 	} from '$lib/api/channels';
 	import type {
 		Channel, Catalog, CatalogService, ChannelTemplate, ChannelConfig, DispatchRow
@@ -479,6 +479,8 @@
 	let addScriptPath = $state('');
 	let addSaving = $state(false);
 	let addError = $state<string | null>(null);
+	let addTesting = $state(false);
+	let addTestResult = $state<{ ok: boolean; msg: string } | null>(null);
 
 	async function loadNotifications() {
 		if (channelsLoaded || channelsLoading) return;
@@ -654,58 +656,59 @@
 		addHeadersText = '';
 		addScriptPath = '';
 		addError = null;
+		addTestResult = null;
+	}
+
+	// Validate the add-form fields and assemble the ChannelConfig. Throws
+	// an Error with a user-facing message on any validation failure.
+	// Shared by saveNewChannel and testNewChannel so the rules stay in one
+	// place. (Inputs aren't in a <form>, so the browser's required
+	// attribute never fires — validate explicitly.)
+	async function buildAddConfig(): Promise<ChannelConfig> {
+		if (addType === 'apprise') {
+			let url = addRawUrl.trim();
+			if (!url && addService) {
+				const missing = addService.required_fields
+					.filter((f) => {
+						const v = addRequired[f.key];
+						return v === undefined || v === null || String(v).trim() === '';
+					})
+					.map((f) => f.label);
+				if (missing.length > 0) {
+					throw new Error(`Required field${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}.`);
+				}
+				const composed = await composeUrl(
+					addService.id,
+					$state.snapshot(addRequired),
+					$state.snapshot(addAdvanced)
+				);
+				url = composed.url;
+			}
+			if (!url) throw new Error('Pick a service or paste a raw Apprise URL.');
+			return { type: 'apprise', url };
+		}
+		if (addType === 'webhook') {
+			if (!addWebhookUrl.trim()) throw new Error('Webhook URL is required.');
+			return {
+				type: 'webhook',
+				url: addWebhookUrl.trim(),
+				shared_secret: addSharedSecret || null,
+				headers: addHeadersText.trim() ? parseHeaders(addHeadersText) : null
+			};
+		}
+		if (!addScriptPath.trim()) throw new Error('Script path is required.');
+		return { type: 'bash', script_path: addScriptPath.trim() };
 	}
 
 	async function saveNewChannel() {
 		addError = null;
-		// Required-field validation (inputs aren't in a <form>, so the
-		// browser's required attribute never fires — validate explicitly).
 		if (!addName.trim()) {
 			addError = 'Channel label is required.';
 			return;
 		}
 		addSaving = true;
 		try {
-			let config: ChannelConfig;
-			if (addType === 'apprise') {
-				let url = addRawUrl.trim();
-				if (!url && addService) {
-					// Every required service field must be filled before composing.
-					const missing = addService.required_fields
-						.filter((f) => {
-							const v = addRequired[f.key];
-							return v === undefined || v === null || String(v).trim() === '';
-						})
-						.map((f) => f.label);
-					if (missing.length > 0) {
-						throw new Error(`Required field${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}.`);
-					}
-					const composed = await composeUrl(
-						addService.id,
-						$state.snapshot(addRequired),
-						$state.snapshot(addAdvanced)
-					);
-					url = composed.url;
-				}
-				if (!url) throw new Error('Pick a service or paste a raw Apprise URL.');
-				config = { type: 'apprise', url };
-			} else if (addType === 'webhook') {
-				if (!addWebhookUrl.trim()) {
-					throw new Error('Webhook URL is required.');
-				}
-				config = {
-					type: 'webhook',
-					url: addWebhookUrl.trim(),
-					shared_secret: addSharedSecret || null,
-					headers: addHeadersText.trim() ? parseHeaders(addHeadersText) : null
-				};
-			} else {
-				if (!addScriptPath.trim()) {
-					throw new Error('Script path is required.');
-				}
-				config = { type: 'bash', script_path: addScriptPath.trim() };
-			}
-
+			const config = await buildAddConfig();
 			await createChannel({
 				type: addType,
 				name: addName,
@@ -721,6 +724,29 @@
 			addError = e instanceof Error ? e.message : 'Save failed';
 		} finally {
 			addSaving = false;
+		}
+	}
+
+	// Test-send the in-progress add-form config without saving the channel.
+	async function testNewChannel() {
+		addError = null;
+		addTestResult = null;
+		addTesting = true;
+		try {
+			const config = await buildAddConfig();
+			const evt = addSubscribedEvents[0] ?? 'job.started';
+			const result = await testConfig({
+				type: addType,
+				config: config as unknown as Record<string, unknown>,
+				event_key: evt
+			});
+			addTestResult = result.ok
+				? { ok: true, msg: 'Test sent successfully.' }
+				: { ok: false, msg: `Test failed: ${result.error ?? 'unknown error'}` };
+		} catch (e) {
+			addTestResult = { ok: false, msg: e instanceof Error ? e.message : 'Test failed' };
+		} finally {
+			addTesting = false;
 		}
 	}
 
@@ -2464,10 +2490,19 @@
 										>{addSaving ? 'Saving…' : 'Save'}</button>
 										<button
 											type="button"
+											disabled={addTesting}
+											onclick={testNewChannel}
+											class="rounded-md border border-primary/25 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 disabled:opacity-50 dark:border-primary/30 dark:hover:bg-primary/15"
+										>{addTesting ? 'Testing…' : 'Test'}</button>
+										<button
+											type="button"
 											onclick={() => { resetAddForm(); addPanelOpen = false; }}
 											class="rounded-md border border-primary/25 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-primary/10 dark:border-primary/30 dark:text-gray-400 dark:hover:bg-primary/15"
 										>Cancel</button>
 									</div>
+									{#if addTestResult}
+										<p class="text-sm {addTestResult.ok ? 'text-status-success' : 'text-status-error'}">{addTestResult.msg}</p>
+									{/if}
 								</div>
 							{/if}
 						</div>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2361,25 +2361,20 @@
 							</p>
 						{/if}
 
-						<!-- Add channel panel -->
-						<div class="rounded-lg border border-dashed border-primary/40 bg-surface dark:border-primary/40 dark:bg-surface-dark">
+						<!-- Add channel: a button that stays below the list; the form
+						     is hidden until the button is clicked, then shown inline. -->
+						{#if !addPanelOpen}
 							<button
 								type="button"
-								onclick={() => (addPanelOpen = !addPanelOpen)}
-								class="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-semibold text-primary-text hover:bg-page dark:text-primary-text-dark dark:hover:bg-primary/10"
-								aria-expanded={addPanelOpen}
+								onclick={() => (addPanelOpen = true)}
+								class="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-hover dark:bg-primary dark:hover:bg-primary-hover"
 							>
-								<span>+ Add channel</span>
-								<svg
-									class="h-4 w-4 transform transition-transform {addPanelOpen ? 'rotate-180' : ''}"
-									fill="none" stroke="currentColor" viewBox="0 0 24 24"
-								>
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-								</svg>
+								+ Add channel
 							</button>
-
-							{#if addPanelOpen}
-								<div class="space-y-4 border-t border-primary/20 px-4 py-4 dark:border-primary/20">
+						{:else}
+							<div class="rounded-lg border border-dashed border-primary/40 bg-surface dark:border-primary/40 dark:bg-surface-dark">
+								<div class="space-y-4 px-4 py-4">
+									<h3 class="text-sm font-semibold text-primary-text dark:text-primary-text-dark">Add channel</h3>
 									{#if addError}
 										<p class="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-900/20 dark:text-red-300">{addError}</p>
 									{/if}
@@ -2504,8 +2499,8 @@
 										<p class="text-sm {addTestResult.ok ? 'text-status-success' : 'text-status-error'}">{addTestResult.msg}</p>
 									{/if}
 								</div>
-							{/if}
-						</div>
+							</div>
+						{/if}
 					</div>
 				{/if}
 			</section>

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -472,7 +472,7 @@ describe('Settings Page', () => {
 		// scoped queries. Optionally set the new channel's name.
 		async function openAddPanel(name?: string): Promise<HTMLElement> {
 			await fireEvent.click(screen.getByText('+ Add channel'));
-			const addName = await waitFor(() => screen.getByLabelText('New channel name'));
+			const addName = await waitFor(() => screen.getByLabelText('New channel label'));
 			if (name !== undefined) {
 				await fireEvent.input(addName, { target: { value: name } });
 			}
@@ -601,7 +601,7 @@ describe('Settings Page', () => {
 			await fireEvent.click(screen.getByLabelText('Webhook'));
 			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
 			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
-			await expectAddBlocked(card, /Channel name is required/i);
+			await expectAddBlocked(card, /Channel label is required/i);
 		});
 
 		it('blocks add of a webhook channel with a blank URL', async () => {
@@ -621,11 +621,11 @@ describe('Settings Page', () => {
 		it('blocks edit save when the channel name is cleared', async () => {
 			await gotoNotifications();
 			const panel = await expandFamilyDiscord();
-			const nameInput = within(panel).getByLabelText('Channel name') as HTMLInputElement;
+			const nameInput = within(panel).getByLabelText('Channel Label') as HTMLInputElement;
 			await fireEvent.input(nameInput, { target: { value: '' } });
 			await fireEvent.click(within(panel).getByText('Save'));
 			await waitFor(() => {
-				expect(within(panel).getByText(/Channel name is required/i)).toBeInTheDocument();
+				expect(within(panel).getByText(/Channel label is required/i)).toBeInTheDocument();
 			});
 			expect(vi.mocked(channelsApi.updateChannel)).not.toHaveBeenCalled();
 		});

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -143,6 +143,29 @@ vi.mock('$lib/stores/dashboard', () => ({ dashboard: mockDashboard }));
 describe('Settings Page', () => {
 	afterEach(() => cleanup());
 
+	// Render the page and wait for the tab bar to settle (the 'Music' tab is
+	// the readiness signal used throughout these tests).
+	async function renderAndWait() {
+		renderComponent(SettingsPage);
+		await waitFor(() => {
+			expect(screen.getByText('Music')).toBeInTheDocument();
+		});
+	}
+
+	// Render, then switch to a top-level tab by its label.
+	async function renderAndOpenTab(tab: string) {
+		await renderAndWait();
+		await fireEvent.click(screen.getAllByText(tab)[0]);
+	}
+
+	// Open the System tab and wait for its Versions card to render.
+	async function openSystemVersions() {
+		await renderAndOpenTab('System');
+		await waitFor(() => {
+			expect(screen.getByText('Versions')).toBeInTheDocument();
+		});
+	}
+
 	describe('rendering', () => {
 		it('renders page title', () => {
 			renderComponent(SettingsPage);
@@ -150,10 +173,7 @@ describe('Settings Page', () => {
 		});
 
 		it('renders all tab buttons after settings load', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
+			await renderAndWait();
 			const allTabs = ['Ripping', 'Music', 'Transcoding', 'Notifications', 'Drives', 'Appearance'];
 			for (const tab of allTabs) {
 				const matches = screen.getAllByText(tab);
@@ -206,22 +226,13 @@ describe('Settings Page', () => {
 		});
 
 		it('shows Appearance tab', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
+			await renderAndWait();
 			const matches = screen.getAllByText('Appearance');
 			expect(matches.length).toBeGreaterThanOrEqual(1);
 		});
 
 		it('image cache section loads when Appearance tab active', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			// Click Appearance tab
-			const appearanceTab = screen.getAllByText('Appearance');
-			await fireEvent.click(appearanceTab[0]);
+			await renderAndOpenTab('Appearance');
 			await waitFor(() => {
 				expect(screen.getByText('Image Cache')).toBeInTheDocument();
 			});
@@ -235,12 +246,7 @@ describe('Settings Page', () => {
 		});
 
 		it('shows cache feedback after clearing image cache', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const appearanceTab = screen.getAllByText('Appearance');
-			await fireEvent.click(appearanceTab[0]);
+			await renderAndOpenTab('Appearance');
 			await waitFor(() => {
 				expect(screen.getByText('Clear Cache')).toBeInTheDocument();
 			});
@@ -259,12 +265,7 @@ describe('Settings Page', () => {
 		});
 
 		it('shows dark mode toggle when scheme does not lock mode', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const appearanceTab = screen.getAllByText('Appearance');
-			await fireEvent.click(appearanceTab[0]);
+			await renderAndOpenTab('Appearance');
 			await waitFor(() => {
 				expect(screen.getByText('Dark Mode')).toBeInTheDocument();
 			});
@@ -274,12 +275,7 @@ describe('Settings Page', () => {
 
 		it('calls toggleTheme when dark mode switch is clicked', async () => {
 			const { toggleTheme } = await import('$lib/stores/theme');
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const appearanceTab = screen.getAllByText('Appearance');
-			await fireEvent.click(appearanceTab[0]);
+			await renderAndOpenTab('Appearance');
 			await waitFor(() => {
 				expect(screen.getByLabelText('Dark mode')).toBeInTheDocument();
 			});
@@ -293,12 +289,7 @@ describe('Settings Page', () => {
 			const locked = writable(true);
 			Object.assign(schemeLocksMode, { set: locked.set, subscribe: locked.subscribe, update: locked.update });
 
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const appearanceTab = screen.getAllByText('Appearance');
-			await fireEvent.click(appearanceTab[0]);
+			await renderAndOpenTab('Appearance');
 			await waitFor(() => {
 				expect(screen.getByText('Locked by theme')).toBeInTheDocument();
 			});
@@ -306,13 +297,7 @@ describe('Settings Page', () => {
 		});
 
 		it('notifications tab renders inline channel panels and drops legacy fields', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			// Switch to the notifications tab
-			const notificationsTab = screen.getAllByText('Notifications');
-			await fireEvent.click(notificationsTab[0]);
+			await renderAndOpenTab('Notifications');
 			// The inline channel panel for the mocked channel loads
 			await waitFor(() => {
 				expect(screen.getByText('Family Discord')).toBeTruthy();
@@ -329,13 +314,7 @@ describe('Settings Page', () => {
 		});
 
 		it('renders drives tab with collapsible diagnostics toggle', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			// Switch to drives tab
-			const drivesTab = screen.getAllByText('Drives');
-			await fireEvent.click(drivesTab[0]);
+			await renderAndOpenTab('Drives');
 			await waitFor(() => {
 				expect(screen.getByText('Udev & Drive Diagnostics')).toBeInTheDocument();
 			});
@@ -347,15 +326,7 @@ describe('Settings Page', () => {
 			mockDashboard.set({
 				transcoder_system_stats: { gpu: { vendor: 'nvidia' } }
 			});
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const systemTab = screen.getAllByText('System');
-			await fireEvent.click(systemTab[0]);
-			await waitFor(() => {
-				expect(screen.getByText('Versions')).toBeInTheDocument();
-			});
+			await openSystemVersions();
 			// Vendor subtitle renders as visible text alongside the version
 			expect(screen.getByText('nvidia')).toBeInTheDocument();
 		});
@@ -364,15 +335,7 @@ describe('Settings Page', () => {
 			mockDashboard.set({
 				transcoder_system_stats: { gpu: null }
 			});
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const systemTab = screen.getAllByText('System');
-			await fireEvent.click(systemTab[0]);
-			await waitFor(() => {
-				expect(screen.getByText('Versions')).toBeInTheDocument();
-			});
+			await openSystemVersions();
 			expect(screen.queryByText('nvidia')).not.toBeInTheDocument();
 			expect(screen.queryByText('intel')).not.toBeInTheDocument();
 			expect(screen.queryByText('amd')).not.toBeInTheDocument();
@@ -380,15 +343,7 @@ describe('Settings Page', () => {
 
 		it('omits GPU vendor subtitle when transcoder is offline (no stats)', async () => {
 			mockDashboard.set({ transcoder_system_stats: null });
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const systemTab = screen.getAllByText('System');
-			await fireEvent.click(systemTab[0]);
-			await waitFor(() => {
-				expect(screen.getByText('Versions')).toBeInTheDocument();
-			});
+			await openSystemVersions();
 			expect(screen.queryByText('nvidia')).not.toBeInTheDocument();
 		});
 
@@ -401,29 +356,13 @@ describe('Settings Page', () => {
 				database: { path: '/db/arm.db', size_bytes: 0, available: true, migration_current: 'a', migration_head: 'a', up_to_date: true },
 				drives: []
 			});
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const systemTab = screen.getAllByText('System');
-			await fireEvent.click(systemTab[0]);
-			await waitFor(() => {
-				expect(screen.getByText('Versions')).toBeInTheDocument();
-			});
+			await openSystemVersions();
 			const grid = screen.getByText('Versions').parentElement?.querySelector('div.grid');
 			expect(grid?.className).toContain('md:grid-cols-4');
 		});
 
 		it('uses md:grid-cols-3 when Versions card has 3 entries (e.g. transcoder disabled)', async () => {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
-			const systemTab = screen.getAllByText('System');
-			await fireEvent.click(systemTab[0]);
-			await waitFor(() => {
-				expect(screen.getByText('Versions')).toBeInTheDocument();
-			});
+			await openSystemVersions();
 			// Default mock has 3 versions: arm, transcoder, ui
 			const grid = screen.getByText('Versions').parentElement?.querySelector('div.grid');
 			expect(grid?.className).toContain('md:grid-cols-3');
@@ -446,10 +385,7 @@ describe('Settings Page', () => {
 		// Open the Notifications tab and wait for the mocked "Family Discord"
 		// channel panel to render.
 		async function gotoNotifications() {
-			renderComponent(SettingsPage);
-			await waitFor(() => {
-				expect(screen.getByText('Music')).toBeInTheDocument();
-			});
+			await renderAndWait();
 			await fireEvent.click(screen.getAllByText('Notifications')[0]);
 			await waitFor(() => {
 				expect(screen.getByText('Family Discord')).toBeInTheDocument();

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -551,8 +551,10 @@ describe('Settings Page', () => {
 
 		it('creates an apprise channel via composeUrl + createChannel', async () => {
 			await gotoNotifications();
-			// Type defaults to apprise → ServicePicker offers the featured Discord.
+			// Type defaults to apprise → ServicePicker dropdown offers featured Discord.
 			const addCard = await openAddPanel('New Discord');
+			// Open the service dropdown, then pick Discord from the list.
+			await fireEvent.click(await waitFor(() => screen.getByRole('button', { name: /select a service/i })));
 			const discordBtn = await waitFor(() => screen.getByRole('button', { name: 'Discord' }));
 			await fireEvent.click(discordBtn);
 			// Discord has no required_fields in the mock catalog, so we can save

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -109,7 +109,8 @@ vi.mock('$lib/api/channels', () => ({
 	updateChannel: vi.fn(() => Promise.resolve({ id: 1 })),
 	deleteChannel: vi.fn(() => Promise.resolve({})),
 	testSendChannel: vi.fn(() => Promise.resolve({ sent_at: 'now', dispatch_id: 1 })),
-	composeUrl: vi.fn(() => Promise.resolve({ url: 'discord://a/b' }))
+	composeUrl: vi.fn(() => Promise.resolve({ url: 'discord://a/b' })),
+	testConfig: vi.fn(() => Promise.resolve({ ok: true, error: null }))
 }));
 
 vi.mock('$lib/stores/polling', async () => {
@@ -589,6 +590,44 @@ describe('Settings Page', () => {
 						config: expect.objectContaining({ type: 'webhook', url: 'https://hooks.example/x' })
 					})
 				);
+			});
+		});
+
+		// --- Test (unsaved config) ---
+
+		it('test-sends the in-progress webhook config without saving', async () => {
+			await gotoNotifications();
+			const addCard = await openAddPanel('Hook To Test');
+			await fireEvent.click(screen.getByLabelText('Webhook'));
+			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
+			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
+			await fireEvent.click(within(addCard).getByText('Test'));
+			await waitFor(() => {
+				expect(vi.mocked(channelsApi.testConfig)).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'webhook',
+						config: expect.objectContaining({ type: 'webhook', url: 'https://hooks.example/x' })
+					})
+				);
+			});
+			// Did not save.
+			expect(vi.mocked(channelsApi.createChannel)).not.toHaveBeenCalled();
+			// Success message shown.
+			await waitFor(() => {
+				expect(within(addCard).getByText(/Test sent successfully/i)).toBeInTheDocument();
+			});
+		});
+
+		it('shows the failure message when a test config send fails', async () => {
+			vi.mocked(channelsApi.testConfig).mockResolvedValueOnce({ ok: false, error: 'http 500' });
+			await gotoNotifications();
+			const addCard = await openAddPanel('Bad Hook');
+			await fireEvent.click(screen.getByLabelText('Webhook'));
+			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
+			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
+			await fireEvent.click(within(addCard).getByText('Test'));
+			await waitFor(() => {
+				expect(within(addCard).getByText(/Test failed: http 500/i)).toBeInTheDocument();
 			});
 		});
 

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -427,12 +427,14 @@ describe('Settings Page', () => {
 			);
 		}
 
+		const WEBHOOK_URL = 'https://hooks.example/x';
+
 		// Open the add panel, switch it to the Webhook type, and fill the
 		// Webhook URL. Returns the add card for scoped queries. Pass url=null
 		// to leave the URL blank (for validation tests).
 		async function setupWebhookAdd(
 			name?: string,
-			url: string | null = 'https://hooks.example/x'
+			url: string | null = WEBHOOK_URL
 		): Promise<HTMLElement> {
 			await gotoNotifications();
 			const card = await openAddPanel(name);
@@ -442,6 +444,17 @@ describe('Settings Page', () => {
 				await fireEvent.input(webhookUrl, { target: { value: url } });
 			}
 			return card;
+		}
+
+		// Matcher for a webhook create/test payload (optionally asserting the
+		// channel name). Shared by the create + test webhook expectations.
+		function webhookPayloadMatching(name?: string) {
+			const shape: Record<string, unknown> = {
+				type: 'webhook',
+				config: expect.objectContaining({ type: 'webhook', url: WEBHOOK_URL })
+			};
+			if (name !== undefined) shape.name = name;
+			return expect.objectContaining(shape);
 		}
 
 		// Save the add panel and assert the given error message is shown and
@@ -537,11 +550,7 @@ describe('Settings Page', () => {
 			await fireEvent.click(within(addCard).getByText('Save'));
 			await waitFor(() => {
 				expect(vi.mocked(channelsApi.createChannel)).toHaveBeenCalledWith(
-					expect.objectContaining({
-						type: 'webhook',
-						name: 'My Webhook',
-						config: expect.objectContaining({ type: 'webhook', url: 'https://hooks.example/x' })
-					})
+					webhookPayloadMatching('My Webhook')
 				);
 			});
 		});
@@ -553,10 +562,7 @@ describe('Settings Page', () => {
 			await fireEvent.click(within(addCard).getByText('Test'));
 			await waitFor(() => {
 				expect(vi.mocked(channelsApi.testConfig)).toHaveBeenCalledWith(
-					expect.objectContaining({
-						type: 'webhook',
-						config: expect.objectContaining({ type: 'webhook', url: 'https://hooks.example/x' })
-					})
+					webhookPayloadMatching()
 				);
 			});
 			// Did not save.

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -382,6 +382,14 @@ describe('Settings Page', () => {
 			vi.mocked(channelsApi.composeUrl).mockClear();
 		});
 
+		// window.confirm is spied per-test by clickDeleteWithConfirm; restore
+		// the global afterwards so other suites see the real implementation.
+		let confirmSpy: ReturnType<typeof vi.spyOn> | null = null;
+		afterEach(() => {
+			confirmSpy?.mockRestore();
+			confirmSpy = null;
+		});
+
 		// Open the Notifications tab and wait for the mocked "Family Discord"
 		// channel panel to render.
 		async function gotoNotifications() {
@@ -475,32 +483,28 @@ describe('Settings Page', () => {
 			);
 		});
 
+		// Expand Family Discord and click its Delete button with window.confirm
+		// stubbed to the given response. The spy stays active (restored in
+		// afterEach) so the caller can await the delete outcome and assert.
+		async function clickDeleteWithConfirm(confirmReturns: boolean) {
+			confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(confirmReturns);
+			await gotoNotifications();
+			const card = await expandFamilyDiscord();
+			await fireEvent.click(within(card).getByText('Delete'));
+		}
+
 		it('deletes a channel after confirm via deleteChannel', async () => {
-			const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-			try {
-				await gotoNotifications();
-				const card = await expandFamilyDiscord();
-				await fireEvent.click(within(card).getByText('Delete'));
-				await waitFor(() => {
-					expect(vi.mocked(channelsApi.deleteChannel)).toHaveBeenCalledWith(1);
-				});
-				expect(confirmSpy).toHaveBeenCalled();
-			} finally {
-				confirmSpy.mockRestore();
-			}
+			await clickDeleteWithConfirm(true);
+			await waitFor(() => {
+				expect(vi.mocked(channelsApi.deleteChannel)).toHaveBeenCalledWith(1);
+			});
+			expect(confirmSpy).toHaveBeenCalled();
 		});
 
 		it('does not delete when confirm is dismissed', async () => {
-			const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
-			try {
-				await gotoNotifications();
-				const card = await expandFamilyDiscord();
-				await fireEvent.click(within(card).getByText('Delete'));
-				expect(confirmSpy).toHaveBeenCalled();
-				expect(vi.mocked(channelsApi.deleteChannel)).not.toHaveBeenCalled();
-			} finally {
-				confirmSpy.mockRestore();
-			}
+			await clickDeleteWithConfirm(false);
+			expect(confirmSpy).toHaveBeenCalled();
+			expect(vi.mocked(channelsApi.deleteChannel)).not.toHaveBeenCalled();
 		});
 
 		it('creates an apprise channel via composeUrl + createChannel', async () => {

--- a/frontend/src/routes/settings/__tests__/settings-page.test.ts
+++ b/frontend/src/routes/settings/__tests__/settings-page.test.ts
@@ -419,6 +419,23 @@ describe('Settings Page', () => {
 			);
 		}
 
+		// Open the add panel, switch it to the Webhook type, and fill the
+		// Webhook URL. Returns the add card for scoped queries. Pass url=null
+		// to leave the URL blank (for validation tests).
+		async function setupWebhookAdd(
+			name?: string,
+			url: string | null = 'https://hooks.example/x'
+		): Promise<HTMLElement> {
+			await gotoNotifications();
+			const card = await openAddPanel(name);
+			await fireEvent.click(screen.getByLabelText('Webhook'));
+			if (url !== null) {
+				const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
+				await fireEvent.input(webhookUrl, { target: { value: url } });
+			}
+			return card;
+		}
+
 		// Save the add panel and assert the given error message is shown and
 		// createChannel was not called.
 		async function expectAddBlocked(card: HTMLElement, message: RegExp) {
@@ -512,11 +529,7 @@ describe('Settings Page', () => {
 		});
 
 		it('creates a webhook channel via createChannel without composeUrl', async () => {
-			await gotoNotifications();
-			const addCard = await openAddPanel('My Webhook');
-			await fireEvent.click(screen.getByLabelText('Webhook'));
-			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
-			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
+			const addCard = await setupWebhookAdd('My Webhook');
 			await fireEvent.click(within(addCard).getByText('Save'));
 			await waitFor(() => {
 				expect(vi.mocked(channelsApi.createChannel)).toHaveBeenCalledWith(
@@ -532,11 +545,7 @@ describe('Settings Page', () => {
 		// --- Test (unsaved config) ---
 
 		it('test-sends the in-progress webhook config without saving', async () => {
-			await gotoNotifications();
-			const addCard = await openAddPanel('Hook To Test');
-			await fireEvent.click(screen.getByLabelText('Webhook'));
-			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
-			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
+			const addCard = await setupWebhookAdd('Hook To Test');
 			await fireEvent.click(within(addCard).getByText('Test'));
 			await waitFor(() => {
 				expect(vi.mocked(channelsApi.testConfig)).toHaveBeenCalledWith(
@@ -556,11 +565,7 @@ describe('Settings Page', () => {
 
 		it('shows the failure message when a test config send fails', async () => {
 			vi.mocked(channelsApi.testConfig).mockResolvedValueOnce({ ok: false, error: 'http 500' });
-			await gotoNotifications();
-			const addCard = await openAddPanel('Bad Hook');
-			await fireEvent.click(screen.getByLabelText('Webhook'));
-			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
-			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
+			const addCard = await setupWebhookAdd('Bad Hook');
 			await fireEvent.click(within(addCard).getByText('Test'));
 			await waitFor(() => {
 				expect(within(addCard).getByText(/Test failed: http 500/i)).toBeInTheDocument();
@@ -570,19 +575,13 @@ describe('Settings Page', () => {
 		// --- Required-field validation ---
 
 		it('blocks add with a blank channel name and does not call createChannel', async () => {
-			await gotoNotifications();
 			// Name left blank; webhook + URL filled so only the name is missing.
-			const card = await openAddPanel();
-			await fireEvent.click(screen.getByLabelText('Webhook'));
-			const webhookUrl = await waitFor(() => screen.getByLabelText('Webhook URL'));
-			await fireEvent.input(webhookUrl, { target: { value: 'https://hooks.example/x' } });
+			const card = await setupWebhookAdd();
 			await expectAddBlocked(card, /Channel label is required/i);
 		});
 
 		it('blocks add of a webhook channel with a blank URL', async () => {
-			await gotoNotifications();
-			const card = await openAddPanel('No URL Hook');
-			await fireEvent.click(screen.getByLabelText('Webhook')); // URL left blank
+			const card = await setupWebhookAdd('No URL Hook', null);
 			await expectAddBlocked(card, /Webhook URL is required/i);
 		});
 

--- a/tests/routers/test_notifications.py
+++ b/tests/routers/test_notifications.py
@@ -218,3 +218,23 @@ async def test_compose_url_route(app_client):
         resp = await app_client.post("/api/notifications/services/discord/compose-url", json=body)
     assert resp.status_code == 200
     assert resp.json()["url"] == "discord://1"
+
+
+async def test_test_config_route(app_client):
+    body = {"type": "apprise", "config": {"type": "apprise", "url": "discord://a/b"}}
+    with patch(
+        "backend.routers.notifications.arm_client.test_channel_config",
+        new_callable=AsyncMock, return_value={"ok": True, "error": None},
+    ):
+        resp = await app_client.post("/api/notifications/test", json=body)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "error": None}
+
+
+async def test_test_config_route_unreachable(app_client):
+    with patch(
+        "backend.routers.notifications.arm_client.test_channel_config",
+        new_callable=AsyncMock, return_value=None,
+    ):
+        resp = await app_client.post("/api/notifications/test", json={"type": "apprise", "config": {}})
+    assert resp.status_code == 503

--- a/tests/services/test_arm_client_channels.py
+++ b/tests/services/test_arm_client_channels.py
@@ -97,3 +97,12 @@ async def test_compose_url_encodes_service_id():
         await arm_client.compose_channel_url("weird/id", body)
     req.assert_awaited_once_with(
         "POST", "/api/v1/notifications/services/weird%2Fid/compose-url", json=body)
+
+
+async def test_test_channel_config_proxies_body():
+    body = {"type": "apprise", "config": {"type": "apprise", "url": "discord://a/b"}, "event_key": "job.started"}
+    with patch.object(arm_client, "_request", new_callable=AsyncMock,
+                      return_value={"ok": True, "error": None}) as req:
+        out = await arm_client.test_channel_config(body)
+    req.assert_awaited_once_with("POST", "/api/v1/notifications/test", json=body)
+    assert out == {"ok": True, "error": None}


### PR DESCRIPTION
## Summary
Follow-up UX work on the inline notifications UI (settings → Notifications tab).

- **Searchable service dropdown** replaces the button grid: shows all services (featured first), type to filter, keyboard nav, click-outside close.
- **Form polish**: rename "Channel name" → "Channel Label" and move it to the first field; templates section only renders once an event is subscribed, auto-opens, with a clearer "Message templates (optional)" label + helper text (no more dead-end "subscribe to an event" prompt).
- **Test button on the Add-channel form**: verify an unsaved config before saving. BFF passthrough `POST /api/notifications/test` → arm-neu `/api/v1/notifications/test`; frontend `testConfig` client; builds the same config as Save (composing the apprise URL when needed); shows pass/fail.

## Coordination
The **Test button depends on arm-neu PR #382** (the `/api/v1/notifications/test` endpoint). Merge #382 first (or together). Until then the Test button returns 503 — graceful, not a crash.

## Test plan
- [x] 1008 frontend tests, 699 BFF tests; svelte-check 0 errors; build succeeds; codegen synced
- [x] Browser-verified: dropdown search/select, label reorder, templates auto-reveal, Test button (success + failure paths) against a mock backend
- [ ] CI green
- [ ] Joint browser test against a live arm-neu carrying #382