### PR TITLE
feat(notifications): move Channel Label/Enabled above the service picker

### DIFF
--- a/frontend/src/lib/components/notifications/AddChannelForm.svelte
+++ b/frontend/src/lib/components/notifications/AddChannelForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Catalog, CatalogService, ChannelType, ChannelTemplate } from '$lib/types/notifications';
 	import ConfigureSection from './sections/ConfigureSection.svelte';
+	import LabelEnabledRow from './sections/LabelEnabledRow.svelte';
 	import EventsSection from './sections/EventsSection.svelte';
 	import TemplatesSection from './sections/TemplatesSection.svelte';
 	import ServiceDropdown from './ServiceDropdown.svelte';
@@ -81,13 +82,15 @@
 			{/each}
 		</fieldset>
 
+		<LabelEnabledRow bind:name bind:enabled />
+
 		{#if type === 'apprise'}
 			<div class="rounded-lg border border-primary/15 bg-page p-4 dark:border-primary/20 dark:bg-primary/5">
 				<ServiceDropdown {catalog} selectedId={serviceId} onpick={pickService} />
 			</div>
 		{/if}
 
-		<ConfigureSection {type} bind:name bind:enabled bind:config {service} />
+		<ConfigureSection {type} bind:name bind:enabled bind:config {service} showLabelRow={false} />
 		<EventsSection bind:selected={events} />
 		<TemplatesSection subscribedEvents={events} bind:templates />
 	</div>

--- a/frontend/src/lib/components/notifications/sections/ConfigureSection.svelte
+++ b/frontend/src/lib/components/notifications/sections/ConfigureSection.svelte
@@ -1,22 +1,23 @@
 <script lang="ts">
 	import type { CatalogService, ChannelType, CatalogField } from '$lib/types/notifications';
-	import { FIELD_INPUT_CLASS } from '$lib/types/notifications';
 	import SchemaField from '../SchemaField.svelte';
 	import ServiceGlyph from '../ServiceGlyph.svelte';
-	import Toggle from '../Toggle.svelte';
+	import LabelEnabledRow from './LabelEnabledRow.svelte';
 
 	let {
 		type,
 		name = $bindable(),
 		enabled = $bindable(),
 		config = $bindable(),
-		service
+		service,
+		showLabelRow = true
 	}: {
 		type: ChannelType;
 		name: string;
 		enabled: boolean;
 		config: Record<string, unknown>;
 		service: CatalogService | null;
+		showLabelRow?: boolean;
 	} = $props();
 
 	const webhookFields: CatalogField[] = [
@@ -37,16 +38,9 @@
 </script>
 
 <div class="space-y-4">
-	<div class="grid grid-cols-[1fr_auto] items-end gap-4">
-		<label class="flex flex-col gap-1">
-			<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Channel Label *</span>
-			<input class={FIELD_INPUT_CLASS} aria-label="Channel Label" bind:value={name} required />
-		</label>
-		<div class="flex items-center gap-2 pb-2">
-			<Toggle checked={enabled} label="Enabled" onchange={(v) => (enabled = v)} />
-			<span class="text-sm text-gray-700 dark:text-gray-300">Enabled</span>
-		</div>
-	</div>
+	{#if showLabelRow}
+		<LabelEnabledRow bind:name bind:enabled />
+	{/if}
 
 	{#if fields.length}
 		<div class="rounded-lg border border-primary/15 bg-page p-4 dark:border-primary/20 dark:bg-primary/5">

--- a/frontend/src/lib/components/notifications/sections/LabelEnabledRow.svelte
+++ b/frontend/src/lib/components/notifications/sections/LabelEnabledRow.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { FIELD_INPUT_CLASS } from '$lib/types/notifications';
+	import Toggle from '../Toggle.svelte';
+
+	let {
+		name = $bindable(),
+		enabled = $bindable()
+	}: { name: string; enabled: boolean } = $props();
+</script>
+
+<div class="grid grid-cols-[1fr_auto] items-end gap-4">
+	<label class="flex flex-col gap-1">
+		<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Channel Label *</span>
+		<input class={FIELD_INPUT_CLASS} aria-label="Channel Label" bind:value={name} required />
+	</label>
+	<div class="flex items-center gap-2 pb-2">
+		<Toggle checked={enabled} label="Enabled" onchange={(v) => (enabled = v)} />
+		<span class="text-sm text-gray-700 dark:text-gray-300">Enabled</span>
+	</div>
+</div>


### PR DESCRIPTION
## Summary
- In the Add-channel form, the Channel Label + Enabled toggle now render **above** the delivery configuration — so for apprise channels the label/enabled row sits above the service-picker dropdown (and above the webhook/bash fields).
- Extracted the row into a shared `LabelEnabledRow.svelte`; `ConfigureSection` gained a `showLabelRow` prop (default `true`) so the inline channel editor is unchanged.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npx vitest run src/lib/components/notifications/` — 56/56 passing
- [x] Browser-verified: apprise Add form shows label/enabled directly above the service dropdown
- [ ] CI green