### PR TITLE
feat(notifications): editable apprise channels via stored service_id

### DIFF
--- a/frontend/src/lib/components/notifications/ChannelEditor.svelte
+++ b/frontend/src/lib/components/notifications/ChannelEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Channel, Catalog, CatalogService, ChannelTemplate } from '$lib/types/notifications';
+	import type { Channel, Catalog, CatalogService, ChannelTemplate, AppriseConfig } from '$lib/types/notifications';
 	import ConfigureSection from './sections/ConfigureSection.svelte';
 	import EventsSection from './sections/EventsSection.svelte';
 	import TemplatesSection from './sections/TemplatesSection.svelte';
@@ -10,6 +10,8 @@
 		config: Record<string, unknown>;
 		subscribed_events: string[];
 		templates: Record<string, ChannelTemplate>;
+		appriseFields: Record<string, unknown>;
+		serviceId: string | null;
 	}
 
 	let {
@@ -34,25 +36,44 @@
 	let events = $state<string[]>([...channel.subscribed_events]);
 	let templates = $state<Record<string, ChannelTemplate>>({ ...channel.templates });
 
-	// Apprise service lookup is best-effort (config carries a composed url, not an id);
-	// fall back to null so ConfigureSection renders generic fields.
-	const service = $derived<CatalogService | null>(null);
+	// Apprise channels store config.service_id, so resolve the service from the
+	// loaded catalog to render the per-service re-entry fields.
+	const serviceId = $derived(
+		channel.type === 'apprise'
+			? ((channel.config as AppriseConfig).service_id ?? null)
+			: null
+	);
+	const service = $derived<CatalogService | null>(
+		serviceId ? catalog.services.find((s) => s.id === serviceId) ?? null : null
+	);
+
+	// Apprise re-entry values live in a separate state from config (which holds the
+	// composed url + service_id). Empty appriseFields = keep current destination.
+	let appriseFields = $state<Record<string, unknown>>({});
+	const appriseTouched = $derived(
+		Object.values(appriseFields).some((v) => v !== undefined && v !== null && String(v).trim() !== '')
+	);
 
 	const dirty = $derived(
 		name !== channel.name ||
 		enabled !== channel.enabled ||
-		JSON.stringify(config) !== JSON.stringify(channel.config) ||
+		(channel.type !== 'apprise' && JSON.stringify(config) !== JSON.stringify(channel.config)) ||
 		JSON.stringify(events) !== JSON.stringify(channel.subscribed_events) ||
-		JSON.stringify(templates) !== JSON.stringify(channel.templates)
+		JSON.stringify(templates) !== JSON.stringify(channel.templates) ||
+		appriseTouched
 	);
 
 	function body(): EditorBody {
-		return { name, enabled, config, subscribed_events: events, templates };
+		return { name, enabled, config, subscribed_events: events, templates, appriseFields, serviceId };
 	}
 </script>
 
 <div class="space-y-4 border-t border-primary/20 px-4 py-4 dark:border-primary/20">
-	<ConfigureSection type={channel.type} bind:name bind:enabled bind:config {service} />
+	{#if channel.type === 'apprise'}
+		<ConfigureSection type="apprise" bind:name bind:enabled bind:config={appriseFields} {service} preserveExisting />
+	{:else}
+		<ConfigureSection type={channel.type} bind:name bind:enabled bind:config {service} />
+	{/if}
 	<EventsSection bind:selected={events} />
 	<TemplatesSection subscribedEvents={events} bind:templates />
 

--- a/frontend/src/lib/components/notifications/ChannelEditor.svelte
+++ b/frontend/src/lib/components/notifications/ChannelEditor.svelte
@@ -46,6 +46,9 @@
 	const service = $derived<CatalogService | null>(
 		serviceId ? catalog.services.find((s) => s.id === serviceId) ?? null : null
 	);
+	const unknownService = $derived(
+		channel.type === 'apprise' && serviceId !== null && service === null
+	);
 
 	// Apprise re-entry values live in a separate state from config (which holds the
 	// composed url + service_id). Empty appriseFields = keep current destination.
@@ -70,6 +73,11 @@
 
 <div class="space-y-4 border-t border-primary/20 px-4 py-4 dark:border-primary/20">
 	{#if channel.type === 'apprise'}
+		{#if unknownService}
+			<p class="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-500/40 dark:bg-amber-900/20 dark:text-amber-300">
+				Unknown service '{serviceId}' — recreate this channel to edit its destination.
+			</p>
+		{/if}
 		<ConfigureSection type="apprise" bind:name bind:enabled bind:config={appriseFields} {service} preserveExisting />
 	{:else}
 		<ConfigureSection type={channel.type} bind:name bind:enabled bind:config {service} />

--- a/frontend/src/lib/components/notifications/NotificationsTab.svelte
+++ b/frontend/src/lib/components/notifications/NotificationsTab.svelte
@@ -96,11 +96,25 @@
 
 	async function handleEditorSave(c: Channel, body: EditorBody) {
 		try {
-			const updated = await updateChannel(c.id, {
-				name: body.name, enabled: body.enabled,
-				config: body.config as unknown as Channel['config'],
-				subscribed_events: body.subscribed_events, templates: body.templates
-			});
+			const patch: Record<string, unknown> = {
+				name: body.name,
+				enabled: body.enabled,
+				subscribed_events: body.subscribed_events,
+				templates: body.templates
+			};
+			if (c.type === 'apprise') {
+				const filled = Object.values(body.appriseFields).some(
+					(v) => v !== undefined && v !== null && String(v).trim() !== ''
+				);
+				if (filled && body.serviceId) {
+					const { url } = await composeUrl(body.serviceId, body.appriseFields, {});
+					patch.config = { type: 'apprise', url, service_id: body.serviceId };
+				}
+				// blank -> leave patch.config unset -> backend keeps current url
+			} else {
+				patch.config = body.config as unknown as Channel['config'];
+			}
+			const updated = await updateChannel(c.id, patch as Parameters<typeof updateChannel>[1]);
 			channels = channels.map((x) => (x.id === c.id ? updated : x));
 			addToast({ tone: 'success', title: 'Saved.' });
 		} catch (e) {

--- a/frontend/src/lib/components/notifications/NotificationsTab.svelte
+++ b/frontend/src/lib/components/notifications/NotificationsTab.svelte
@@ -59,7 +59,7 @@
 	async function toConfig(body: { type: string; config: Record<string, unknown>; serviceId: string | null }) {
 		if (body.type === 'apprise' && body.serviceId) {
 			const { url } = await composeUrl(body.serviceId, body.config, {});
-			return { type: 'apprise', url };
+			return { type: 'apprise', url, service_id: body.serviceId };
 		}
 		return { type: body.type, ...body.config };
 	}

--- a/frontend/src/lib/components/notifications/NotificationsTab.svelte
+++ b/frontend/src/lib/components/notifications/NotificationsTab.svelte
@@ -145,30 +145,44 @@
 		}
 	}
 
+	// Test an unsaved/edited config and toast the result. Shared by the add-form
+	// and the inline editor so the success/error toast handling lives in one place.
+	async function testConfigAndToast(type: string, config: Record<string, unknown>, eventKey: string) {
+		const res = await testConfig({ type, config, event_key: eventKey });
+		if (res.ok) addToast({ tone: 'success', title: 'Test delivered' });
+		else addToast({ tone: 'error', title: 'Test failed', body: res.error ?? '' });
+	}
+
 	async function handleTestUnsaved(body: AddChannelBody) {
 		try {
 			const config = await toConfig(body);
-			const res = await testConfig({ type: body.type, config, event_key: body.subscribed_events[0] ?? 'job.started' });
-			if (res.ok) addToast({ tone: 'success', title: 'Test delivered' });
-			else addToast({ tone: 'error', title: 'Test failed', body: res.error ?? '' });
+			await testConfigAndToast(body.type, config, body.subscribed_events[0] ?? 'job.started');
 		} catch (e) {
 			addToast({ tone: 'error', title: 'Test failed', body: e instanceof Error ? e.message : '' });
 		}
 	}
 
 	async function handleEditorTest(c: Channel, body: EditorBody) {
+		const eventKey = body.subscribed_events[0] ?? 'job.started';
 		try {
-			// The editor's config is already in the channel's stored shape
-			// (no apprise URL composition needed — it carries the saved/edited
-			// config directly). Test it via the unsaved-config endpoint so the
-			// user tests their current edits, not the last-saved state.
-			const res = await testConfig({
-				type: c.type,
-				config: body.config,
-				event_key: body.subscribed_events[0] ?? 'job.started'
-			});
-			if (res.ok) addToast({ tone: 'success', title: 'Test delivered' });
-			else addToast({ tone: 'error', title: 'Test failed', body: res.error ?? '' });
+			if (c.type === 'apprise') {
+				const filled = Object.values(body.appriseFields).some(
+					(v) => v !== undefined && v !== null && String(v).trim() !== ''
+				);
+				if (filled && body.serviceId) {
+					// User re-entered fields: compose the new url and test that.
+					const { url } = await composeUrl(body.serviceId, body.appriseFields, {});
+					await testConfigAndToast('apprise', { type: 'apprise', url }, eventKey);
+					return;
+				}
+				// Untouched apprise: fields are blank (config holds only the composed
+				// url + service_id), so test the SAVED channel instead.
+				await handleTestSaved(c);
+				return;
+			}
+			// Webhook/bash: test the edited config directly via the unsaved-config
+			// endpoint so the user tests their current edits, not the last-saved state.
+			await testConfigAndToast(c.type, body.config, eventKey);
 		} catch (e) {
 			addToast({ tone: 'error', title: 'Test failed', body: e instanceof Error ? e.message : '' });
 		}

--- a/frontend/src/lib/components/notifications/__tests__/ChannelEditor.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ChannelEditor.svelte.test.ts
@@ -27,4 +27,64 @@ describe('ChannelEditor', () => {
 		await fireEvent.click(screen.getByRole('button', { name: /delete/i }));
 		expect(ondelete).toHaveBeenCalled();
 	});
+
+	it('apprise editor renders the service fields resolved from service_id', async () => {
+		const catalog = { featured: ['discord'], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] }
+		] };
+		const ch = {
+			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null
+		};
+		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave: () => {}, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
+		const wid = await screen.findByLabelText(/Webhook ID/i) as HTMLInputElement;
+		expect(wid).toBeInTheDocument();
+		expect(wid.value).toBe('');
+	});
+
+	it('apprise editor save with blank fields reports empty appriseFields (keep current)', async () => {
+		const onsave = vi.fn();
+		const catalog = { featured: [], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] }
+		] };
+		const ch = {
+			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null
+		};
+		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
+		await fireEvent.input(screen.getByLabelText('Channel Label'), { target: { value: 'D2' } });
+		await waitFor(() => expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled());
+		await fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+		expect(onsave).toHaveBeenCalledWith(expect.objectContaining({ name: 'D2', serviceId: 'discord' }));
+		const arg = onsave.mock.calls[0][0];
+		expect(Object.values(arg.appriseFields).filter((v) => v && String(v).trim() !== '')).toEqual([]);
+	});
+
+	it('apprise editor save with filled fields reports them in appriseFields', async () => {
+		const onsave = vi.fn();
+		const catalog = { featured: [], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] }
+		] };
+		const ch = {
+			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null
+		};
+		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
+		await fireEvent.input(await screen.findByLabelText(/Webhook ID/i), { target: { value: '99' } });
+		await waitFor(() => expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled());
+		await fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+		expect(onsave.mock.calls[0][0].appriseFields).toEqual(expect.objectContaining({ webhook_id: '99' }));
+	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/ChannelEditor.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ChannelEditor.svelte.test.ts
@@ -2,14 +2,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderComponent, screen, fireEvent, waitFor, cleanup } from '$lib/test-utils';
 import ChannelEditor from '../ChannelEditor.svelte';
 import type { Channel, Catalog } from '$lib/types/notifications';
+import { discordCatalog, appriseChannel, webhookChannel } from './apprise-fixtures';
 
 const catalog: Catalog = { featured: [], services: [] };
-const ch: Channel = {
-	id: 3, type: 'webhook', name: 'Hook', enabled: true,
-	config: { type: 'webhook', url: 'https://x' },
-	subscribed_events: ['job.started'], templates: {},
-	last_fired_at: null, last_success_at: null, last_error: null
-};
+const ch: Channel = webhookChannel({ id: 3 });
 
 describe('ChannelEditor', () => {
 	afterEach(() => cleanup());
@@ -29,17 +25,8 @@ describe('ChannelEditor', () => {
 	});
 
 	it('apprise editor renders the service fields resolved from service_id', async () => {
-		const catalog = { featured: ['discord'], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] }
-		] };
-		const ch = {
-			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null
-		};
+		const catalog = discordCatalog;
+		const ch = appriseChannel({ id: 7 });
 		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave: () => {}, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
 		const wid = await screen.findByLabelText(/Webhook ID/i) as HTMLInputElement;
 		expect(wid).toBeInTheDocument();
@@ -48,17 +35,8 @@ describe('ChannelEditor', () => {
 
 	it('apprise editor save with blank fields reports empty appriseFields (keep current)', async () => {
 		const onsave = vi.fn();
-		const catalog = { featured: [], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] }
-		] };
-		const ch = {
-			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null
-		};
+		const catalog = discordCatalog;
+		const ch = appriseChannel({ id: 7 });
 		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
 		await fireEvent.input(screen.getByLabelText('Channel Label'), { target: { value: 'D2' } });
 		await waitFor(() => expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled());
@@ -70,17 +48,8 @@ describe('ChannelEditor', () => {
 
 	it('apprise editor save with filled fields reports them in appriseFields', async () => {
 		const onsave = vi.fn();
-		const catalog = { featured: [], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] }
-		] };
-		const ch = {
-			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null
-		};
+		const catalog = discordCatalog;
+		const ch = appriseChannel({ id: 7 });
 		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
 		await fireEvent.input(await screen.findByLabelText(/Webhook ID/i), { target: { value: '99' } });
 		await waitFor(() => expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled());
@@ -90,12 +59,7 @@ describe('ChannelEditor', () => {
 
 	it('shows a notice when service_id is not in the catalog', async () => {
 		const catalog = { featured: [], services: [] };  // discord absent
-		const ch = {
-			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null
-		};
+		const ch = appriseChannel({ id: 7 });
 		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave: () => {}, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
 		expect(await screen.findByText(/Unknown service 'discord'/i)).toBeInTheDocument();
 	});

--- a/frontend/src/lib/components/notifications/__tests__/ChannelEditor.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/ChannelEditor.svelte.test.ts
@@ -87,4 +87,16 @@ describe('ChannelEditor', () => {
 		await fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
 		expect(onsave.mock.calls[0][0].appriseFields).toEqual(expect.objectContaining({ webhook_id: '99' }));
 	});
+
+	it('shows a notice when service_id is not in the catalog', async () => {
+		const catalog = { featured: [], services: [] };  // discord absent
+		const ch = {
+			id: 7, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null
+		};
+		renderComponent(ChannelEditor, { props: { channel: ch, catalog, onsave: () => {}, ontest: () => {}, onclose: () => {}, ondelete: () => {} } });
+		expect(await screen.findByText(/Unknown service 'discord'/i)).toBeInTheDocument();
+	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
@@ -85,4 +85,37 @@ describe('NotificationsTab', () => {
 		));
 		expect(testSend).not.toHaveBeenCalled();
 	});
+
+	it('add: includes service_id in the apprise config it creates', async () => {
+		vi.spyOn(api, 'fetchServices').mockResolvedValue({
+			featured: ['discord'],
+			services: [{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+				required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+				advanced_fields: [] }]
+		});
+		const compose = vi.spyOn(api, 'composeUrl').mockResolvedValue({ url: 'discord://x/y' });
+		const create = vi.spyOn(api, 'createChannel').mockResolvedValue({
+			id: 5, type: 'apprise', name: 'New', enabled: true,
+			config: { type: 'apprise', url: 'discord://x/y', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null
+		});
+		renderComponent(NotificationsTab);
+		await screen.findByText('Hook');
+		await fireEvent.click(screen.getByRole('button', { name: /add channel/i }));
+		await fireEvent.input(screen.getByLabelText('Channel Label'), { target: { value: 'New' } });
+		await fireEvent.click(await screen.findByRole('button', { name: /select a service/i }));
+		await fireEvent.click(await screen.findByRole('button', { name: /Discord/ }));
+		await fireEvent.input(screen.getByLabelText(/Webhook ID/i), { target: { value: '123' } });
+		await fireEvent.click(screen.getByLabelText('Job started'));
+		await fireEvent.click(screen.getByRole('button', { name: /save channel/i }));
+
+		await waitFor(() => expect(compose).toHaveBeenCalledWith('discord', expect.objectContaining({ webhook_id: '123' }), expect.any(Object)));
+		await waitFor(() => expect(create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'apprise',
+				config: expect.objectContaining({ type: 'apprise', url: 'discord://x/y', service_id: 'discord' })
+			})
+		));
+	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
@@ -118,4 +118,49 @@ describe('NotificationsTab', () => {
 			})
 		));
 	});
+
+	it('editor save with apprise fields recomposes url and patches config', async () => {
+		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null };
+		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
+		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] } ] });
+		const compose = vi.spyOn(api, 'composeUrl').mockResolvedValue({ url: 'discord://9/9' });
+		const update = vi.spyOn(api, 'updateChannel').mockResolvedValue({ ...ch, config: { type: 'apprise', url: 'discord://9/9', service_id: 'discord' } });
+		renderComponent(NotificationsTab);
+		await screen.findByText('D');
+		await fireEvent.click(screen.getByText('D'));  // expand the row
+		await fireEvent.input(await screen.findByLabelText(/Webhook ID/i), { target: { value: '9' } });
+		await fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+		await waitFor(() => expect(compose).toHaveBeenCalledWith('discord', expect.objectContaining({ webhook_id: '9' }), expect.any(Object)));
+		await waitFor(() => expect(update).toHaveBeenCalledWith(1, expect.objectContaining({
+			config: expect.objectContaining({ type: 'apprise', url: 'discord://9/9', service_id: 'discord' })
+		})));
+	});
+
+	it('editor save with blank apprise fields omits config', async () => {
+		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null };
+		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
+		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] } ] });
+		const compose = vi.spyOn(api, 'composeUrl');
+		const update = vi.spyOn(api, 'updateChannel').mockResolvedValue({ ...ch, name: 'D2' });
+		renderComponent(NotificationsTab);
+		await screen.findByText('D');
+		await fireEvent.click(screen.getByText('D'));
+		await fireEvent.input(screen.getByLabelText('Channel Label'), { target: { value: 'D2' } });
+		await fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+		await waitFor(() => expect(update).toHaveBeenCalled());
+		expect(compose).not.toHaveBeenCalled();
+		expect(update.mock.calls[0][1]).not.toHaveProperty('config');
+	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
@@ -4,13 +4,9 @@ import NotificationsTab from '../NotificationsTab.svelte';
 import * as api from '$lib/api/channels';
 import { toasts, dismissToast } from '$lib/stores/toast.svelte';
 import type { Channel } from '$lib/types/notifications';
+import { discordCatalog, appriseChannel, webhookChannel } from './apprise-fixtures';
 
-const ch: Channel = {
-	id: 1, type: 'webhook', name: 'Hook', enabled: true,
-	config: { type: 'webhook', url: 'https://x' },
-	subscribed_events: ['job.started'], templates: {},
-	last_fired_at: null, last_success_at: null, last_error: null
-};
+const ch: Channel = webhookChannel();
 
 describe('NotificationsTab', () => {
 	beforeEach(() => {
@@ -87,12 +83,7 @@ describe('NotificationsTab', () => {
 	});
 
 	it('add: includes service_id in the apprise config it creates', async () => {
-		vi.spyOn(api, 'fetchServices').mockResolvedValue({
-			featured: ['discord'],
-			services: [{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-				required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-				advanced_fields: [] }]
-		});
+		vi.spyOn(api, 'fetchServices').mockResolvedValue(discordCatalog);
 		const compose = vi.spyOn(api, 'composeUrl').mockResolvedValue({ url: 'discord://x/y' });
 		const create = vi.spyOn(api, 'createChannel').mockResolvedValue({
 			id: 5, type: 'apprise', name: 'New', enabled: true,
@@ -120,15 +111,9 @@ describe('NotificationsTab', () => {
 	});
 
 	it('editor save with apprise fields recomposes url and patches config', async () => {
-		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null };
+		const ch = appriseChannel();
 		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
-		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] } ] });
+		vi.spyOn(api, 'fetchServices').mockResolvedValue(discordCatalog);
 		const compose = vi.spyOn(api, 'composeUrl').mockResolvedValue({ url: 'discord://9/9' });
 		const update = vi.spyOn(api, 'updateChannel').mockResolvedValue({ ...ch, config: { type: 'apprise', url: 'discord://9/9', service_id: 'discord' } });
 		renderComponent(NotificationsTab);
@@ -143,15 +128,9 @@ describe('NotificationsTab', () => {
 	});
 
 	it('editor save with blank apprise fields omits config', async () => {
-		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null };
+		const ch = appriseChannel();
 		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
-		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] } ] });
+		vi.spyOn(api, 'fetchServices').mockResolvedValue(discordCatalog);
 		const compose = vi.spyOn(api, 'composeUrl');
 		const update = vi.spyOn(api, 'updateChannel').mockResolvedValue({ ...ch, name: 'D2' });
 		renderComponent(NotificationsTab);
@@ -165,15 +144,9 @@ describe('NotificationsTab', () => {
 	});
 
 	it('editor test with blank apprise fields tests the saved channel', async () => {
-		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null };
+		const ch = appriseChannel();
 		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
-		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] } ] });
+		vi.spyOn(api, 'fetchServices').mockResolvedValue(discordCatalog);
 		const testSend = vi.spyOn(api, 'testSendChannel').mockResolvedValue({ sent_at: 'now', dispatch_id: 1 });
 		vi.spyOn(api, 'fetchDispatch').mockResolvedValue({ id: 1, status: 'success', attempts: 1, last_error: null, completed_at: 'now' });
 		const testCfg = vi.spyOn(api, 'testConfig');
@@ -189,15 +162,9 @@ describe('NotificationsTab', () => {
 	});
 
 	it('editor test with filled apprise fields composes + tests the new url', async () => {
-		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
-			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
-			subscribed_events: ['job.started'], templates: {},
-			last_fired_at: null, last_success_at: null, last_error: null };
+		const ch = appriseChannel();
 		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
-		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
-			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
-			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
-			  advanced_fields: [] } ] });
+		vi.spyOn(api, 'fetchServices').mockResolvedValue(discordCatalog);
 		const compose = vi.spyOn(api, 'composeUrl').mockResolvedValue({ url: 'discord://9/9' });
 		const testCfg = vi.spyOn(api, 'testConfig').mockResolvedValue({ ok: true, error: null });
 		const testSend = vi.spyOn(api, 'testSendChannel');

--- a/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/NotificationsTab.svelte.test.ts
@@ -163,4 +163,53 @@ describe('NotificationsTab', () => {
 		expect(compose).not.toHaveBeenCalled();
 		expect(update.mock.calls[0][1]).not.toHaveProperty('config');
 	});
+
+	it('editor test with blank apprise fields tests the saved channel', async () => {
+		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null };
+		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
+		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] } ] });
+		const testSend = vi.spyOn(api, 'testSendChannel').mockResolvedValue({ sent_at: 'now', dispatch_id: 1 });
+		vi.spyOn(api, 'fetchDispatch').mockResolvedValue({ id: 1, status: 'success', attempts: 1, last_error: null, completed_at: 'now' });
+		const testCfg = vi.spyOn(api, 'testConfig');
+		renderComponent(NotificationsTab);
+		await screen.findByText('D');
+		await fireEvent.click(screen.getByText('D'));
+		// editor "Send test" with blank apprise fields
+		const sendTestBtns = await screen.findAllByRole('button', { name: /send test/i });
+		const editorBtn = sendTestBtns.find((b) => b.textContent?.toLowerCase().includes('send test'));
+		await fireEvent.click(editorBtn!);
+		await waitFor(() => expect(testSend).toHaveBeenCalledWith(1, 'job.started'));
+		expect(testCfg).not.toHaveBeenCalled();
+	});
+
+	it('editor test with filled apprise fields composes + tests the new url', async () => {
+		const ch = { id: 1, type: 'apprise' as const, name: 'D', enabled: true,
+			config: { type: 'apprise' as const, url: 'discord://1/2', service_id: 'discord' },
+			subscribed_events: ['job.started'], templates: {},
+			last_fired_at: null, last_success_at: null, last_error: null };
+		vi.spyOn(api, 'fetchChannels').mockResolvedValue([ch]);
+		vi.spyOn(api, 'fetchServices').mockResolvedValue({ featured: [], services: [
+			{ id: 'discord', name: 'Discord', docs_url: '', url_scheme: 'discord',
+			  required_fields: [{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }],
+			  advanced_fields: [] } ] });
+		const compose = vi.spyOn(api, 'composeUrl').mockResolvedValue({ url: 'discord://9/9' });
+		const testCfg = vi.spyOn(api, 'testConfig').mockResolvedValue({ ok: true, error: null });
+		const testSend = vi.spyOn(api, 'testSendChannel');
+		renderComponent(NotificationsTab);
+		await screen.findByText('D');
+		await fireEvent.click(screen.getByText('D'));
+		await fireEvent.input(await screen.findByLabelText(/Webhook ID/i), { target: { value: '9' } });
+		const sendTestBtns = await screen.findAllByRole('button', { name: /send test/i });
+		const editorBtn = sendTestBtns.find((b) => b.textContent?.toLowerCase().includes('send test'));
+		await fireEvent.click(editorBtn!);
+		await waitFor(() => expect(compose).toHaveBeenCalledWith('discord', expect.objectContaining({ webhook_id: '9' }), expect.any(Object)));
+		await waitFor(() => expect(testCfg).toHaveBeenCalledWith(expect.objectContaining({ type: 'apprise', config: expect.objectContaining({ url: 'discord://9/9' }) })));
+		expect(testSend).not.toHaveBeenCalled();
+	});
 });

--- a/frontend/src/lib/components/notifications/__tests__/apprise-fixtures.ts
+++ b/frontend/src/lib/components/notifications/__tests__/apprise-fixtures.ts
@@ -1,0 +1,51 @@
+import type { Catalog, Channel } from '$lib/types/notifications';
+
+/** Shared apprise/discord test fixtures (deduped to satisfy SonarCloud). */
+
+export const discordCatalog: Catalog = {
+	featured: ['discord'],
+	services: [
+		{
+			id: 'discord',
+			name: 'Discord',
+			docs_url: '',
+			url_scheme: 'discord',
+			required_fields: [
+				{ key: 'webhook_id', label: 'Webhook ID', type: 'string', private: false, required: true }
+			],
+			advanced_fields: []
+		}
+	]
+};
+
+export function webhookChannel(overrides: Partial<Channel> = {}): Channel {
+	return {
+		id: 1,
+		type: 'webhook',
+		name: 'Hook',
+		enabled: true,
+		config: { type: 'webhook', url: 'https://x' },
+		subscribed_events: ['job.started'],
+		templates: {},
+		last_fired_at: null,
+		last_success_at: null,
+		last_error: null,
+		...overrides
+	};
+}
+
+export function appriseChannel(overrides: Partial<Channel> = {}): Channel {
+	return {
+		id: 1,
+		type: 'apprise',
+		name: 'D',
+		enabled: true,
+		config: { type: 'apprise', url: 'discord://1/2', service_id: 'discord' },
+		subscribed_events: ['job.started'],
+		templates: {},
+		last_fired_at: null,
+		last_success_at: null,
+		last_error: null,
+		...overrides
+	};
+}

--- a/frontend/src/lib/components/notifications/__tests__/sections.svelte.test.ts
+++ b/frontend/src/lib/components/notifications/__tests__/sections.svelte.test.ts
@@ -37,4 +37,25 @@ describe('ConfigureSection', () => {
 		renderComponent(ConfigureSection, { props });
 		expect(screen.getByLabelText(/webhook url/i)).toBeInTheDocument();
 	});
+
+	it('preserveExisting makes config fields optional and shows the keep-current hint', () => {
+		const props = $state({
+			type: 'webhook' as const, name: 'x', enabled: true,
+			config: {} as Record<string, unknown>, service: null, preserveExisting: true
+		});
+		renderComponent(ConfigureSection, { props });
+		const url = screen.getByLabelText(/webhook url/i) as HTMLInputElement;
+		expect(url.required).toBe(false);
+		expect(screen.getByText(/leave blank to keep/i)).toBeInTheDocument();
+	});
+
+	it('without preserveExisting, required fields stay required', () => {
+		const props = $state({
+			type: 'webhook' as const, name: 'x', enabled: true,
+			config: {} as Record<string, unknown>, service: null
+		});
+		renderComponent(ConfigureSection, { props });
+		const url = screen.getByLabelText(/webhook url/i) as HTMLInputElement;
+		expect(url.required).toBe(true);
+	});
 });

--- a/frontend/src/lib/components/notifications/sections/ConfigureSection.svelte
+++ b/frontend/src/lib/components/notifications/sections/ConfigureSection.svelte
@@ -10,7 +10,8 @@
 		enabled = $bindable(),
 		config = $bindable(),
 		service,
-		showLabelRow = true
+		showLabelRow = true,
+		preserveExisting = false
 	}: {
 		type: ChannelType;
 		name: string;
@@ -18,6 +19,7 @@
 		config: Record<string, unknown>;
 		service: CatalogService | null;
 		showLabelRow?: boolean;
+		preserveExisting?: boolean;
 	} = $props();
 
 	const webhookFields: CatalogField[] = [
@@ -28,12 +30,15 @@
 		{ key: 'script_path', label: 'Script Path', type: 'string', private: false, required: true }
 	];
 
-	const fields = $derived(
+	const rawFields = $derived(
 		type === 'apprise'
 			? [...(service?.required_fields ?? []), ...(service?.advanced_fields ?? [])]
 			: type === 'webhook'
 				? webhookFields
 				: bashFields
+	);
+	const fields = $derived(
+		preserveExisting ? rawFields.map((f) => ({ ...f, required: false })) : rawFields
 	);
 </script>
 
@@ -51,6 +56,9 @@
 					<span class="ml-1 font-mono text-[11px] normal-case tracking-normal text-gray-500">{service.url_scheme}://…</span>
 				{:else if type === 'webhook'}Webhook configuration{:else}Bash script configuration{/if}
 			</div>
+			{#if preserveExisting}
+				<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">Re-enter credentials to change the destination. Leave blank to keep the current settings.</p>
+			{/if}
 			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
 				{#each fields as f (f.key)}
 					<div class={f.key === 'url' || f.key === 'script_path' ? 'sm:col-span-2' : ''}>

--- a/frontend/src/lib/types/notifications.ts
+++ b/frontend/src/lib/types/notifications.ts
@@ -18,6 +18,7 @@ export type ChannelType = 'apprise' | 'webhook' | 'bash';
 export interface AppriseConfig {
 	type: 'apprise';
 	url: string;
+	service_id?: string | null;
 }
 
 export interface WebhookConfig {


### PR DESCRIPTION
## Summary
- Apprise channels can now be **edited** in the inline channel editor. Previously the editor showed no destination fields for apprise (it couldn't recover the service from the composed URL).
- Stores `service_id` in the created apprise config (`toConfig`); the editor resolves the service from the catalog via `service_id` and reuses `ConfigureSection` to render the same per-service inputs as the Add form.
- New `preserveExisting` flag on `ConfigureSection`: edit fields are optional with a "leave blank to keep current" hint. **Blank fields keep the current destination** (PATCH omits config); **filled fields recompose** the URL via `composeUrl` on save. The stored credential is never re-displayed.
- Editor "Send test": re-entered fields → test the composed URL; untouched → test the saved channel. Unknown `service_id` → inline notice (no crash).
- Bumps `components/contracts` submodule for the new field; adds `service_id?` to the `AppriseConfig` TS type.

Part 3 of a 3-repo change (contracts → neu → ui). Spec/plan in `arm-ai/arm-neu/docs/superpowers/{specs,plans}/2026-05-25-editable-apprise-channels*`.

## Test plan
- [x] `npx vitest run` — 1048/1048 pass
- [x] `npm run check` — 0 errors
- [x] jscpd — 0 duplication clones in new notifications code
- [ ] CI: lockstep, CodeQL, SonarCloud, codecov, builds
- [ ] Browser smoke: edit an apprise channel — fields render empty w/ keep-current hint; save name-only keeps url; re-enter creds → url recomposed; test-send both paths