### PR TITLE
fix(sidebar+settings): debounce offline flag; stop double-scroll on tab click

### DIFF
--- a/frontend/src/lib/stores/__tests__/dashboard.test.ts
+++ b/frontend/src/lib/stores/__tests__/dashboard.test.ts
@@ -86,14 +86,54 @@ describe('dashboard store sticky merge', () => {
 		expect(get(dashboard).notification_count).toBe(0);
 	});
 
-	it('does not stick non-sticky fields like transcoder_online', async () => {
+	it('debounces a single transcoder_online=false blip (two-strike)', async () => {
+		// First poll online; second blips to false (transient backend timeout);
+		// store masks it as still true to absorb the blip. Third poll still
+		// false → store flips to false (real outage).
 		fetchDashboardMock
 			.mockResolvedValueOnce(fullPayload({ transcoder_online: true }))
+			.mockResolvedValueOnce(fullPayload({ transcoder_online: false }))
 			.mockResolvedValueOnce(fullPayload({ transcoder_online: false }));
 
 		const { dashboard } = await import('../dashboard');
 		await dashboard.refresh();
 		await dashboard.refresh();
-		expect(get(dashboard).transcoder_online).toBe(false);
+		expect(get(dashboard).transcoder_online).toBe(true);  // blip absorbed
+		await dashboard.refresh();
+		expect(get(dashboard).transcoder_online).toBe(false); // real outage
+	});
+
+	it('debounces a single arm_online=false blip (two-strike)', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ arm_online: true }))
+			.mockResolvedValueOnce(fullPayload({ arm_online: false }))
+			.mockResolvedValueOnce(fullPayload({ arm_online: false }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		await dashboard.refresh();
+		expect(get(dashboard).arm_online).toBe(true);
+		await dashboard.refresh();
+		expect(get(dashboard).arm_online).toBe(false);
+	});
+
+	it('two-strike counter resets when a true poll lands between false polls', async () => {
+		fetchDashboardMock
+			.mockResolvedValueOnce(fullPayload({ arm_online: true }))
+			.mockResolvedValueOnce(fullPayload({ arm_online: false }))
+			.mockResolvedValueOnce(fullPayload({ arm_online: true }))
+			.mockResolvedValueOnce(fullPayload({ arm_online: false }))
+			.mockResolvedValueOnce(fullPayload({ arm_online: false }));
+
+		const { dashboard } = await import('../dashboard');
+		await dashboard.refresh();
+		await dashboard.refresh();
+		expect(get(dashboard).arm_online).toBe(true);
+		await dashboard.refresh();
+		expect(get(dashboard).arm_online).toBe(true);
+		await dashboard.refresh();
+		expect(get(dashboard).arm_online).toBe(true);
+		await dashboard.refresh();
+		expect(get(dashboard).arm_online).toBe(false);
 	});
 });

--- a/frontend/src/lib/stores/dashboard.ts
+++ b/frontend/src/lib/stores/dashboard.ts
@@ -31,7 +31,17 @@ const STICKY_FIELDS = [
 	'ripping_enabled'
 ] as const satisfies readonly (keyof DashboardData)[];
 
+// Booleans that flip to `false` on a single backend blip (RemoteProtocolError,
+// timeout, etc). Don't pop the sidebar to "Cannot reach …" until we've seen
+// two consecutive `false` polls — one stale reading absorbs transient blips
+// while real outages still surface within ~10s.
+const TWO_STRIKE_FIELDS = ['arm_online', 'transcoder_online'] as const satisfies readonly (keyof DashboardData)[];
+
 let lastGood: DashboardData = emptyDashboard;
+const consecutiveFalse: Record<(typeof TWO_STRIKE_FIELDS)[number], number> = {
+	arm_online: 0,
+	transcoder_online: 0
+};
 
 async function fetchDashboardSticky(): Promise<DashboardData> {
 	const fresh = (await fetchDashboard()) as DashboardData & Partial<Record<(typeof STICKY_FIELDS)[number], unknown>>;
@@ -39,6 +49,19 @@ async function fetchDashboardSticky(): Promise<DashboardData> {
 	for (const key of STICKY_FIELDS) {
 		if (fresh[key] === null || fresh[key] === undefined) {
 			(merged[key] as unknown) = lastGood[key];
+		}
+	}
+	for (const key of TWO_STRIKE_FIELDS) {
+		if (fresh[key] === false) {
+			consecutiveFalse[key]++;
+			// First `false` after a `true` — keep showing online (debounce
+			// a single-poll blip). A second consecutive `false` surfaces
+			// the real outage on the next poll, ~5s later.
+			if (consecutiveFalse[key] < 2) {
+				(merged[key] as unknown) = true;
+			}
+		} else {
+			consecutiveFalse[key] = 0;
 		}
 	}
 	lastGood = merged;

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -426,9 +426,15 @@
 		}
 	}
 
+	// Set to true while we are mutating window.location.hash ourselves,
+	// so the hashchange listener can skip the work setTab already did
+	// (otherwise tab clicks scroll twice — once here, once in the listener).
+	let programmaticHashChange = false;
+
 	function setTab(tab: Tab) {
 		activeTab = tab;
 		pendingPanel = null;
+		programmaticHashChange = true;
 		window.location.hash = tab;
 		if (tab === 'music') loadAbcdeConfig();
 		if (tab === 'system') loadSystemInfo();
@@ -475,6 +481,10 @@
 		if (activeTab === 'system') loadSystemInfo();
 		if (activeTab === 'appearance') loadCacheStats();
 		function onHashChange() {
+			if (programmaticHashChange) {
+				programmaticHashChange = false;
+				return;
+			}
 			const { tab, panel } = parseHash();
 			activeTab = tab;
 			if (tab === 'music') loadAbcdeConfig();


### PR DESCRIPTION
## Summary

Two unrelated UI bugs observed on the v19.0.0-rc deployment.

**Sidebar offline flash.** The httpx keepalive fix from PR #360 reduced the rate but didn't eliminate it — any single failed poll (timeout, RemoteProtocolError, network blip) still pops 'Cannot reach the ARM ripping service' for one ~5s poll cycle before recovering. Added a two-strike debounce in the dashboard store: the first \`arm_online: false\` / \`transcoder_online: false\` is masked (UI keeps showing online); only a second consecutive false flips the flag. Real outages still surface within ~10s. Counter resets on any \`true\` poll.

**Settings tab double-scroll.** Clicking a tab in Settings scrolled the viewport twice. \`setTab()\` mutates \`window.location.hash\`, which fires the \`hashchange\` listener that does the same scroll work again. Added a \`programmaticHashChange\` flag so the listener no-ops when \`setTab\` triggered the change itself.

## Test plan

- [x] \`npx vitest run src/lib/stores/__tests__/dashboard.test.ts\` — 7 pass including 3 new debounce tests
- [x] \`npm run check\` — 0 errors
- [ ] CI green
- [ ] Browser smoke on RC: refresh hifi UI for several minutes — no sidebar flash; click between Settings tabs — single smooth scroll, not double