### PR TITLE
fix(notifications): stop double scrollbar when channel editor is expanded

### DIFF
--- a/frontend/src/lib/components/notifications/AddChannelForm.svelte
+++ b/frontend/src/lib/components/notifications/AddChannelForm.svelte
@@ -71,7 +71,7 @@
 	</div>
 
 	<div class="space-y-5 p-5">
-		<fieldset class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+		<fieldset class="relative grid grid-cols-1 gap-3 sm:grid-cols-3">
 			<legend class="sr-only">Delivery type</legend>
 			{#each types as t}
 				<label class="relative flex cursor-pointer flex-col gap-1 rounded-lg border p-4 {type === t.key ? 'border-primary bg-primary/10' : 'border-primary/20 bg-page dark:bg-primary/5'}">

--- a/frontend/src/lib/components/notifications/EventSubscriptions.svelte
+++ b/frontend/src/lib/components/notifications/EventSubscriptions.svelte
@@ -12,7 +12,7 @@
 	}
 </script>
 
-<fieldset class="space-y-2">
+<fieldset class="relative space-y-2">
 	<legend class="sr-only">Events</legend>
 	<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
 		{#each EVENT_KEYS as key}


### PR DESCRIPTION
## Summary
- Add `relative` to two `<fieldset>` elements that wrap `<legend class="sr-only">` so the absolute legend stays anchored to the fieldset and doesn't extend `<html>.scrollHeight` past the viewport when its in-flow Y is deep inside the scrolled `<main>`.

## Root cause
Tailwind's `sr-only` sets `position: absolute` with no `top`/`left`. When the containing fieldset is `position: static`, the absolute legend's containing block falls back to the initial containing block (the viewport). The legend therefore renders at its in-flow Y from document top — which, with the channel editor expanded, was ~872px and pushed `<html>.scrollHeight` past the viewport, producing a second scrollbar beside the legitimate `<main>` one.

## Test plan
- [x] `npm test` — 1059/1059 pass
- [x] `npm run check` — 0 errors
- [x] Repro'd in Playwright on hifi (`html.scrollH=872, viewport=800`) and confirmed fix locally (`html.scrollH=800`)
- [ ] Smoke test on staging after merge: expand a notification channel and confirm only one scrollbar