### PR TITLE
fix(notifications): align channel-list column headers + style Close button

### DIFF
--- a/frontend/src/lib/components/notifications/ChannelEditor.svelte
+++ b/frontend/src/lib/components/notifications/ChannelEditor.svelte
@@ -100,7 +100,7 @@
 	<div class="flex flex-wrap items-center gap-2">
 		<button type="button" disabled={!dirty} onclick={() => onsave(body())} class="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-hover disabled:opacity-40">Save changes</button>
 		<button type="button" onclick={() => ontest(body())} class="rounded-md border border-primary/25 px-4 py-2 text-sm text-primary-text hover:bg-primary/10 dark:border-primary/30 dark:text-primary-text-dark">Send test</button>
-		<button type="button" onclick={onclose} class="rounded-md px-4 py-2 text-sm text-gray-600 hover:bg-primary/10 dark:text-gray-300">Close</button>
+		<button type="button" onclick={onclose} class="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-primary/10 dark:border-gray-600 dark:text-gray-300">Close</button>
 		<button type="button" onclick={ondelete} class="ml-auto rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-500/40 dark:text-red-400 dark:hover:bg-red-900/20">Delete</button>
 	</div>
 </div>

--- a/frontend/src/lib/components/notifications/ChannelList.svelte
+++ b/frontend/src/lib/components/notifications/ChannelList.svelte
@@ -30,8 +30,8 @@
 </script>
 
 <div class="overflow-hidden rounded-xl border border-primary/20 bg-surface dark:border-primary/20 dark:bg-surface-dark">
-	<div class="grid grid-cols-[auto_1fr_auto_auto_auto] gap-4 border-b border-primary/20 bg-page px-4 py-2 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-gray-500 dark:bg-primary/5 dark:text-gray-400">
-		<span></span><span>Channel</span><span class="hidden text-right md:block">Last delivery</span><span>Enabled</span><span>Actions</span>
+	<div class="grid grid-cols-[44px_1fr_110px_64px_64px] gap-4 border-b border-primary/20 bg-page px-4 py-2 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-gray-500 dark:bg-primary/5 dark:text-gray-400">
+		<span></span><span>Channel</span><span class="hidden whitespace-nowrap text-right md:block">Last delivery</span><span class="text-center">Enabled</span><span class="text-center">Actions</span>
 	</div>
 	{#each channels as c (c.id)}
 		<div class="border-b border-primary/15 last:border-0 dark:border-primary/20">

--- a/frontend/src/lib/components/notifications/ChannelRow.svelte
+++ b/frontend/src/lib/components/notifications/ChannelRow.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div
-	class="grid cursor-pointer grid-cols-[auto_1fr_auto_auto_auto] items-center gap-4 px-4 py-3 hover:bg-primary/5"
+	class="grid cursor-pointer grid-cols-[44px_1fr_110px_64px_64px] items-center gap-4 px-4 py-3 hover:bg-primary/5"
 	role="button"
 	tabindex="0"
 	onclick={() => onexpand?.()}
@@ -55,11 +55,11 @@
 		<p class="font-mono text-xs text-gray-600 dark:text-gray-300">{relativeTime(channel.last_fired_at)}</p>
 	</div>
 
-	<div onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()} role="presentation">
+	<div class="flex justify-center" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()} role="presentation">
 		<Toggle checked={channel.enabled} label="Enabled" onchange={() => ontoggle?.()} />
 	</div>
 
-	<div class="flex items-center gap-1">
+	<div class="flex items-center justify-center gap-1">
 		<button
 			type="button"
 			aria-label="Send test"


### PR DESCRIPTION
## Summary
- **Align column headers with row values.** ChannelList header and ChannelRow used independent `grid-cols-[auto_…_auto]` containers, so their auto-sized tracks computed different widths. Pin both to `[44px 1fr 110px 64px 64px]` so \`LAST DELIVERY\`/\`ENABLED\`/\`ACTIONS\` headers sit above their values.
- **Style the Close button.** Add a gray border matching the secondary-button pattern so it doesn't look unstyled next to Save / Send test / Delete.

## Test plan
- [x] \`npm test\` — 1059/1059 pass
- [x] \`npm run check\` — 0 errors
- [x] Local Playwright verification: header + first row column widths match exactly (`[44, 610, 110, 64, 64]`).
- [ ] Smoke test on staging after merge: confirm headers line up and Close button has a visible border.