### PR TITLE
feat(demo): add ARM_UI_DEMO_MODE for isolated UI with seed data

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     transcoder_enabled: bool = True
     transcoder_webhook_secret: str = ""
     port: int = 8888
+    demo_mode: bool = False
 
     model_config = {"env_prefix": "ARM_UI_"}
 

--- a/backend/demo/__init__.py
+++ b/backend/demo/__init__.py
@@ -1,0 +1,3 @@
+"""Demo mode: in-memory seed data served via a custom httpx transport."""
+from backend.demo.data import build_demo_store  # noqa: F401
+from backend.demo.store import DemoStore  # noqa: F401

--- a/backend/demo/data.py
+++ b/backend/demo/data.py
@@ -1,0 +1,555 @@
+"""Single source of truth for demo/test entity builders.
+
+These builders return plain dicts matching the JSON shapes ARM-neu and the
+Transcoder return, so the data flows through the real router Pydantic
+validation unchanged. Deterministic: fixed ids/titles/timestamps, no
+datetime.now()/random.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from backend.demo.store import DemoStore
+
+
+_JOB_DEFAULTS: dict = {
+    "job_id": 1,
+    "arm_version": "2.8.0",
+    "crc_id": "abc123",
+    "logfile": "job_1.log",
+    "start_time": datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+    "stop_time": None,
+    "job_length": "01:30:00",
+    "status": "active",
+    "stage": "rip",
+    "no_of_titles": 5,
+    "title": "Test Movie",
+    "title_auto": "Test Movie",
+    "title_manual": None,
+    "year": "2024",
+    "year_auto": "2024",
+    "year_manual": None,
+    "video_type": "movie",
+    "video_type_auto": "movie",
+    "video_type_manual": None,
+    "imdb_id": "tt1234567",
+    "poster_url": None,
+    "devpath": "/dev/sr0",
+    "mountpoint": "/mnt/dev/sr0",
+    "hasnicetitle": True,
+    "errors": None,
+    "disctype": "dvd",
+    "label": "TEST_MOVIE",
+    "path": "/home/arm/media/Test Movie (2024)",
+    "raw_path": "/home/arm/raw/Test Movie (2024)",
+    "transcode_path": "/home/arm/transcode",
+    "source_type": None,
+    "source_path": None,
+    "ejected": False,
+    "disc_number": None,
+    "disc_total": None,
+    "pid": 12345,
+    "artist": None,
+    "artist_auto": None,
+    "artist_manual": None,
+    "album": None,
+    "album_auto": None,
+    "album_manual": None,
+    "season": None,
+    "season_auto": None,
+    "season_manual": None,
+    "episode": None,
+    "episode_auto": None,
+    "episode_manual": None,
+}
+
+
+def make_job_dict(**overrides) -> dict:
+    """Return a plain dict matching the Job-columns dict the ripper API returns.
+
+    Used by router tests that mock ``arm_client.get_jobs_paginated`` /
+    ``get_active_jobs`` / ``get_job_detail``. Includes a default
+    ``track_counts`` so JobSchema's nested-counts field is populated.
+    """
+    defaults = {
+        **_JOB_DEFAULTS,
+        "track_counts": {"total": 5, "ripped": 0},
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_track_dict(**overrides) -> dict:
+    d = {
+        "track_id": 1,
+        "job_id": 1,
+        "track_number": "1",
+        "length": 3600,
+        "filename": "title_t00.mkv",
+        "orig_filename": "title_t00.mkv",
+        "basename": "title_t00.mkv",
+        "ripped": False,
+        "main_feature": False,
+        "source": "makemkv",
+    }
+    d.update(overrides)
+    return d
+
+
+def make_drive_dict(**overrides) -> dict:
+    d = {
+        "drive_id": 1,
+        "name": "DVD-RW",
+        "mount": "/dev/sr0",
+        "job_id_current": None,
+        "job_id_previous": None,
+        "description": "Primary drive",
+        "drive_mode": "auto",
+        "maker": "Plextor",
+        "model": "PX-891SA",
+        "serial": "ABC123",
+        "connection": "SATA",
+        "capabilities": ["dvd-r", "dvd-rw", "bd-r"],
+        "firmware": "1.04",
+        "location": "/dev/sr0",
+        "stale": False,
+        "mdisc": 0,
+        "serial_id": "PLEXTOR_ABC123",
+        "uhd_capable": False,
+        "current_job": None,
+    }
+    d.update(overrides)
+    return d
+
+
+def make_notification_dict(**overrides) -> dict:
+    d = {
+        "id": 1,
+        "title": "Job Complete",
+        "message": "Test Movie finished ripping",
+        "trigger_time": "2024-01-15T10:30:00Z",
+        "seen": False,
+        "cleared": False,
+    }
+    d.update(overrides)
+    return d
+
+
+def make_channel_dict(**overrides) -> dict:
+    d = {
+        "id": 1,
+        "type": "apprise",
+        "name": "Family Discord",
+        "enabled": True,
+        "config": {"type": "apprise", "url": "discord://x/y"},
+        "subscribed_events": ["job.started", "job.completed"],
+        "templates": {},
+    }
+    d.update(overrides)
+    return d
+
+
+def make_dispatch_dict(**overrides) -> dict:
+    d = {
+        "id": 1,
+        "channel_id": 1,
+        "event_key": "job.completed",
+        "status": "success",
+        "attempts": 1,
+        "error": None,
+        "created_at": "2024-01-15T10:30:00Z",
+        "completed_at": "2024-01-15T10:30:01Z",
+    }
+    d.update(overrides)
+    return d
+
+
+def make_transcode_job_dict(**overrides) -> dict:
+    d = {
+        "id": 1,
+        "title": "Test Movie",
+        "source_path": "/mnt/raw/job_1/title_t00.mkv",
+        "status": "processing",
+        "progress": 42.0,
+        "current_fps": 120.5,
+        "error": None,
+        "logfile": "transcode_1.log",
+        "video_type": "movie",
+        "year": "2024",
+        "disctype": "dvd",
+        "output_path": "/mnt/library/Test Movie (2024)/title_t00.mkv",
+        "total_tracks": 5,
+        "poster_url": None,
+        "config_overrides": {"preset_slug": "h264-fast", "delete_source": True},
+        "created_at": "2024-01-15T10:00:00Z",
+        "started_at": "2024-01-15T10:05:00Z",
+        "completed_at": None,
+    }
+    d.update(overrides)
+    return d
+
+
+def make_preset_dict(**overrides) -> dict:
+    d = {
+        "slug": "h264-fast",
+        "name": "H.264 Fast",
+        "scheme": "tiered-quality",
+        "description": "Fast hardware-accelerated H.264",
+        "builtin": True,
+        "shared": {"container": "mkv"},
+        "tiers": {"sd": {"crf": 28}, "hd": {"crf": 23}, "uhd": {"crf": 20}},
+        "parent_slug": None,
+        "unavailable": False,
+        "reason": None,
+    }
+    d.update(overrides)
+    return d
+
+
+def make_log_entry_dict(**overrides) -> dict:
+    d = {
+        "timestamp": "2024-01-15T10:30:00Z",
+        "level": "INFO",
+        "logger": "arm.ripper",
+        "event": "Ripping track 1",
+        "job_id": 1,
+        "label": "TEST_MOVIE",
+        "raw": "2024-01-15 10:30:00 INFO arm.ripper Ripping track 1",
+    }
+    d.update(overrides)
+    return d
+
+
+def make_file_entry_dict(**overrides) -> dict:
+    """Return a plain dict matching the FileEntry JSON shape."""
+    d: dict = {
+        "name": "unknown",
+        "type": "file",
+        "size": 0,
+        "modified": "2024-01-15T11:00:00Z",
+        "extension": "",
+        "category": "",
+        "permissions": None,
+        "owner": None,
+        "group": None,
+    }
+    d.update(overrides)
+    return d
+
+
+def build_demo_store() -> DemoStore:
+    """Assemble one deterministic dataset covering every UI state."""
+    jobs = [
+        make_job_dict(job_id=1, title="Blade Runner 2049", year="2017",
+                      title_auto="Blade Runner 2049",
+                      imdb_id="tt1856101",
+                      path="/home/arm/media/Blade Runner 2049 (2017)",
+                      raw_path="/home/arm/raw/Blade Runner 2049 (2017)",
+                      status="active", stage="rip", disctype="bluray",
+                      track_counts={"total": 3, "ripped": 1},
+                      poster_url="https://image.tmdb.org/t/p/w500/gajva2L0rPYkEWjzgFlBXCAVBE5.jpg"),
+        make_job_dict(job_id=2, title="Dune: Part Two", year="2024",
+                      title_auto="Dune: Part Two",
+                      imdb_id="tt15239678",
+                      path="/home/arm/media/Dune Part Two (2024)",
+                      raw_path="/home/arm/raw/Dune Part Two (2024)",
+                      status="active", stage="transcode", disctype="bluray",
+                      track_counts={"total": 1, "ripped": 1},
+                      poster_url="https://image.tmdb.org/t/p/w500/1pdfLvkbY9ohJlCjQH2CZjjYVvJ.jpg"),
+        make_job_dict(job_id=3, title="The Office S03", year="2006",
+                      title_auto="The Office S03",
+                      imdb_id="tt0386676",
+                      path="/home/arm/media/The Office S03 (2006)",
+                      raw_path="/home/arm/raw/The Office S03 (2006)",
+                      status="waiting", stage="rip", disctype="dvd",
+                      video_type="tv", season="3",
+                      no_of_titles=8, track_counts={"total": 8, "ripped": 0},
+                      poster_url="https://image.tmdb.org/t/p/w500/7DJKHzAi83BmQrWLrYYOqcoKfhR.jpg"),
+        make_job_dict(job_id=4, title="Abbey Road", year="1969",
+                      title_auto="Abbey Road",
+                      imdb_id=None,
+                      path="/home/arm/media/Abbey Road (1969)",
+                      raw_path="/home/arm/raw/Abbey Road (1969)",
+                      status="success", stage="rip", disctype="music",
+                      video_type="music", artist="The Beatles",
+                      album="Abbey Road", stop_time="2024-01-15T11:00:00Z",
+                      track_counts={"total": 17, "ripped": 17},
+                      poster_url="https://coverartarchive.org/release-group/9162580e-5df4-32de-80cc-f45a8d8a9b1d/front-500"),
+        make_job_dict(job_id=5, title="Corrupt Disc", year=None,
+                      title_auto="Corrupt Disc",
+                      imdb_id=None,
+                      path="/home/arm/media/Corrupt Disc",
+                      raw_path="/home/arm/raw/Corrupt Disc",
+                      status="fail", stage="rip", disctype="dvd",
+                      errors="MakeMKV read error on title 2",
+                      track_counts={"total": 0, "ripped": 0},
+                      poster_url=None),
+        make_job_dict(job_id=6, title="Planet Earth II", year="2016",
+                      title_auto="Planet Earth II",
+                      imdb_id="tt5491994",
+                      path="/home/arm/media/Planet Earth II (2016)",
+                      raw_path="/home/arm/raw/Planet Earth II (2016)",
+                      status="success", stage="transcode", disctype="bluray",
+                      video_type="tv", season="1", disc_number=1, disc_total=2,
+                      track_counts={"total": 6, "ripped": 6},
+                      poster_url="https://image.tmdb.org/t/p/w500/5maYKYzWpE68ycxGh1luu4P2LOS.jpg"),
+    ]
+    tracks = {
+        1: [make_track_dict(track_id=10 + i, job_id=1, track_number=str(i + 1),
+                            filename=f"title_t0{i}.mkv", ripped=(i == 0),
+                            main_feature=(i == 0), length=8400 - i * 60)
+            for i in range(3)],
+        5: [],
+    }
+    drives = [
+        make_drive_dict(drive_id=1, name="Blu-ray", mount="/dev/sr0",
+                        job_id_current=1, uhd_capable=True,
+                        current_job={"job_id": 1, "title": "Blade Runner 2049",
+                                     "status": "active", "disctype": "bluray"}),
+        make_drive_dict(drive_id=2, name="DVD-RW", mount="/dev/sr1",
+                        serial="DEF456", serial_id="HLDS_DEF456"),
+        make_drive_dict(drive_id=3, name="Stale Drive", mount="/dev/sr2",
+                        stale=True, description="Unplugged"),
+    ]
+    notifications = [
+        make_notification_dict(id=1, title="Rip complete",
+                               message="Abbey Road finished", seen=False),
+        make_notification_dict(id=2, title="Transcode started",
+                               message="Dune: Part Two", seen=False),
+        make_notification_dict(id=3, title="Job failed",
+                               message="Corrupt Disc", seen=True),
+    ]
+    channels = [
+        make_channel_dict(id=1, type="apprise", name="Family Discord"),
+        make_channel_dict(id=2, type="webhook", name="Home Assistant",
+                          config={"type": "webhook",
+                                  "url": "https://hass.local/hook"}),
+        make_channel_dict(id=3, type="bash", name="Notify Script",
+                          config={"type": "bash",
+                                  "script_path": "/opt/arm/scripts/notify.sh"}),
+    ]
+    dispatches = [
+        make_dispatch_dict(id=1, channel_id=1, status="success"),
+        make_dispatch_dict(id=2, channel_id=2, status="failed",
+                           error="connection refused", attempts=3),
+    ]
+    transcode_jobs = [
+        make_transcode_job_dict(id=1, title="Dune: Part Two", status="processing",
+                                progress=63.0,
+                                poster_url="https://image.tmdb.org/t/p/w500/1pdfLvkbY9ohJlCjQH2CZjjYVvJ.jpg"),
+        make_transcode_job_dict(id=2, title="Planet Earth II", status="pending",
+                                progress=0.0, started_at=None,
+                                poster_url="https://image.tmdb.org/t/p/w500/5maYKYzWpE68ycxGh1luu4P2LOS.jpg"),
+        make_transcode_job_dict(id=3, title="Blade Runner 2049",
+                                status="completed", progress=100.0,
+                                completed_at="2024-01-15T10:45:00Z",
+                                poster_url="https://image.tmdb.org/t/p/w500/gajva2L0rPYkEWjzgFlBXCAVBE5.jpg"),
+    ]
+    presets = [
+        make_preset_dict(slug="h264-fast", name="H.264 Fast"),
+        make_preset_dict(slug="h265-quality", name="H.265 Quality",
+                         scheme="tiered-quality", builtin=False),
+    ]
+    log_files = [
+        {"filename": "job_1.log", "size": 20480, "modified": "2024-01-15T11:00:00Z"},
+        {"filename": "job_4.log", "size": 8192, "modified": "2024-01-15T11:05:00Z"},
+    ]
+    file_roots = [
+        {"label": "Raw", "path": "/mnt/raw", "key": "raw"},
+        {"label": "Library", "path": "/mnt/library", "key": "library",
+         "readonly": True},
+    ]
+    file_tree: dict = {
+        "/mnt/raw": [
+            make_file_entry_dict(name="Blade Runner 2049 (2017)", type="directory",
+                                 modified="2024-01-15T10:00:00Z"),
+            make_file_entry_dict(name="The Office S03 (2006)", type="directory",
+                                 modified="2024-01-15T10:30:00Z"),
+        ],
+        "/mnt/raw/Blade Runner 2049 (2017)": [
+            make_file_entry_dict(name="title_t00.mkv", type="file",
+                                 size=42000000000, extension="mkv",
+                                 category="video",
+                                 modified="2024-01-15T10:15:00Z"),
+        ],
+        "/mnt/raw/The Office S03 (2006)": [
+            make_file_entry_dict(name="title_t00.mkv", type="file",
+                                 size=1500000000, extension="mkv",
+                                 category="video",
+                                 modified="2024-01-15T10:35:00Z"),
+            make_file_entry_dict(name="title_t01.mkv", type="file",
+                                 size=1480000000, extension="mkv",
+                                 category="video",
+                                 modified="2024-01-15T10:36:00Z"),
+        ],
+        "/mnt/library": [
+            make_file_entry_dict(name="Movies", type="directory",
+                                 modified="2024-01-15T11:00:00Z"),
+        ],
+        "/mnt/library/Movies": [
+            make_file_entry_dict(name="Blade Runner 2049 (2017).mkv", type="file",
+                                 size=38000000000, extension="mkv",
+                                 category="video",
+                                 modified="2024-01-15T10:50:00Z"),
+        ],
+    }
+    log_entries = [
+        make_log_entry_dict(),
+        make_log_entry_dict(level="DEBUG", event="Scanning disc",
+                            raw="2024-01-15 10:29:00 DEBUG arm.ripper Scanning disc"),
+        make_log_entry_dict(level="WARNING", logger="arm.transcode",
+                            event="Low disk space",
+                            raw="2024-01-15 10:31:00 WARNING arm.transcode Low disk space"),
+        make_log_entry_dict(level="ERROR", logger="arm.makemkv",
+                            event="Read retry on title 2",
+                            raw="2024-01-15 10:32:00 ERROR arm.makemkv Read retry on title 2"),
+    ]
+    return DemoStore(
+        jobs=jobs,
+        tracks=tracks,
+        job_config={"RIPMETHOD": "mkv", "MAINFEATURE": True, "MINLENGTH": 120,
+                    "MAXLENGTH": 9000, "AUDIO_FORMAT": "aac",
+                    "SKIP_TRANSCODE": False},
+        drives=drives,
+        notifications=notifications,
+        channels=channels,
+        dispatches=dispatches,
+        transcode_jobs=transcode_jobs,
+        presets=presets,
+        config={"RIPMETHOD": "mkv", "MAINFEATURE": "False", "MINLENGTH": "60",
+                "MAXLENGTH": "9999", "AUDIO_FORMAT": "aac", "SKIP_TRANSCODE": "False",
+                "RAW_PATH": "/mnt/raw", "LIBRARY_PATH": "/mnt/library",
+                "TV_TITLE_PATTERN": "{title} - S{season}E{episode}",
+                "MOVIE_TITLE_PATTERN": "{title} ({year})"},
+        system_info={"id": 1, "name": "ARM Demo Server",
+                     "cpu": "Intel Core i7-9700K",
+                     "description": "Demo data", "mem_total": 32.0},
+        system_stats={"cpu_percent": 22.5, "cpu_temp": 51.0,
+                      "memory": {"total_gb": 32.0, "used_gb": 12.0,
+                                 "free_gb": 20.0, "percent": 37.5},
+                      "storage": [
+                          {"name": "Raw", "path": "/mnt/raw", "total_gb": 2000.0,
+                           "used_gb": 900.0, "free_gb": 1100.0, "percent": 45.0},
+                          {"name": "Library", "path": "/mnt/library",
+                           "total_gb": 8000.0, "used_gb": 7400.0,
+                           "free_gb": 600.0, "percent": 92.5}],
+                      "gpu": {"vendor": "nvidia", "utilization_percent": 48.0,
+                              "memory_used_mb": 2048.0, "memory_total_mb": 8192.0,
+                              "temperature_c": 58.0, "encoder_percent": 40.0,
+                              "power_draw_w": 160.0, "power_limit_w": 250.0,
+                              "clock_core_mhz": 1900.0, "clock_memory_mhz": 7000.0}},
+        job_stats={"total": 6, "active": 2, "waiting": 1, "success": 2, "fail": 1},
+        setup_status={"db_exists": True, "db_initialized": True, "db_current": True,
+                      "db_version": "2.8.0", "db_head": "demo", "first_run": False,
+                      "arm_version": "2.8.0"},
+        ripping_enabled={"enabled": True, "makemkv_key_valid": True,
+                         "makemkv_key_checked_at": "2024-01-15T09:00:00Z"},
+        transcoder_health={"status": "online",
+                           "gpu_support": {"h264": True, "h265": True, "av1": False},
+                           "worker_running": True, "queue_size": 1,
+                           "require_api_auth": False,
+                           "webhook_secret_configured": True},
+        transcoder_stats={"pending": 1, "processing": 1, "completed": 12,
+                          "failed": 0, "cancelled": 0, "worker_running": True,
+                          "current_job": "1", "active_count": 1,
+                          "max_concurrent": 4},
+        transcoder_config={"config": {"default_encoder": "h264",
+                                      "output_container": "mkv",
+                                      "audio_codec": "aac"},
+                           "updatable_keys": ["default_encoder", "output_container"],
+                           "paths": {"source": "/mnt/raw", "output": "/mnt/library",
+                                     "logs": "/logs"},
+                           "valid_video_encoders": ["h264", "h265", "vp9"],
+                           "valid_audio_encoders": ["aac", "mp3", "opus"],
+                           "valid_subtitle_modes": ["auto", "forced", "all"],
+                           "valid_log_levels": ["debug", "info", "warning", "error"],
+                           "valid_preset_files": ["builtin.json"],
+                           "presets_by_file": {"builtin.json": ["h264-fast"]}},
+        handbrake_presets={"General": ["Fast 1080p30", "HQ 1080p30"],
+                           "Matroska": ["H.265 MKV 1080p30"]},
+        log_files=log_files,
+        log_entries=log_entries,
+        file_roots=file_roots,
+        file_tree=file_tree,
+        movie_search=[
+            {
+                "title": "Blade Runner 2049",
+                "year": "2017",
+                "imdb_id": "tt1856101",
+                "media_type": "movie",
+                "poster_url": "https://image.tmdb.org/t/p/w500/gajva2L0rPYkEWjzgFlBXCAVBE5.jpg",
+            },
+            {
+                "title": "Dune: Part Two",
+                "year": "2024",
+                "imdb_id": "tt15239678",
+                "media_type": "movie",
+                "poster_url": "https://image.tmdb.org/t/p/w500/1pdfLvkbY9ohJlCjQH2CZjjYVvJ.jpg",
+            },
+        ],
+        media_detail={
+            "title": "Blade Runner 2049",
+            "year": "2017",
+            "imdb_id": "tt1856101",
+            "media_type": "movie",
+            "poster_url": "https://image.tmdb.org/t/p/w500/gajva2L0rPYkEWjzgFlBXCAVBE5.jpg",
+            "plot": "A young blade runner discovers a long-buried secret that leads him to track down former blade runner Rick Deckard.",
+            "background_url": None,
+        },
+        music_search=[
+            {
+                "title": "Abbey Road",
+                "artist": "The Beatles",
+                "year": "1969",
+                "release_id": "abbey-road-1",
+                "media_type": "music",
+                "poster_url": "https://coverartarchive.org/release-group/9162580e-5df4-32de-80cc-f45a8d8a9b1d/front-500",
+                "track_count": 17,
+                "country": "GB",
+                "release_type": "Album",
+                "format": "CD",
+                "label": "Apple Records",
+            },
+            {
+                "title": "Abbey Road (Remaster)",
+                "artist": "The Beatles",
+                "year": "2019",
+                "release_id": "abbey-road-2",
+                "media_type": "music",
+                "poster_url": "https://coverartarchive.org/release-group/9162580e-5df4-32de-80cc-f45a8d8a9b1d/front-500",
+                "track_count": 17,
+                "country": "GB",
+                "release_type": "Album",
+                "format": "CD",
+                "label": "Apple Records",
+            },
+        ],
+        music_detail={
+            "title": "Abbey Road",
+            "artist": "The Beatles",
+            "year": "1969",
+            "release_id": "abbey-road-1",
+            "media_type": "music",
+            "poster_url": "https://coverartarchive.org/release-group/9162580e-5df4-32de-80cc-f45a8d8a9b1d/front-500",
+            "track_count": 17,
+            "country": "GB",
+            "release_type": "Album",
+            "format": "CD",
+            "label": "Apple Records",
+            "catalog_number": "PCS 7088",
+            "barcode": None,
+            "status": "Official",
+            "disc_count": 1,
+            "tracks": [
+                {"number": "1", "title": "Come Together", "length_ms": 259000, "disc_number": 1},
+                {"number": "2", "title": "Something", "length_ms": 182000, "disc_number": 1},
+                {"number": "3", "title": "Maxwell's Silver Hammer", "length_ms": 207000, "disc_number": 1},
+                {"number": "4", "title": "Oh! Darling", "length_ms": 207000, "disc_number": 1},
+                {"number": "5", "title": "Octopus's Garden", "length_ms": 170000, "disc_number": 1},
+                {"number": "6", "title": "I Want You (She's So Heavy)", "length_ms": 469000, "disc_number": 1},
+                {"number": "7", "title": "Here Comes the Sun", "length_ms": 185000, "disc_number": 1},
+                {"number": "8", "title": "Because", "length_ms": 165000, "disc_number": 1},
+                {"number": "9", "title": "You Never Give Me Your Money", "length_ms": 242000, "disc_number": 1},
+            ],
+        },
+    )

--- a/backend/demo/http.py
+++ b/backend/demo/http.py
@@ -1,0 +1,24 @@
+"""Response helpers for demo route handlers."""
+from __future__ import annotations
+
+import datetime
+import json
+from typing import Any
+
+import httpx
+
+
+class _DatetimeEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, (datetime.datetime, datetime.date)):
+            return o.isoformat()
+        return super().default(o)
+
+
+def json_response(data: Any, status: int = 200) -> httpx.Response:
+    content = json.dumps(data, cls=_DatetimeEncoder)
+    return httpx.Response(
+        status_code=status,
+        content=content.encode(),
+        headers={"content-type": "application/json"},
+    )

--- a/backend/demo/routes_arm.py
+++ b/backend/demo/routes_arm.py
@@ -1,0 +1,275 @@
+"""ARM-neu demo route table. Paths mirror backend/services/arm_client.py."""
+from __future__ import annotations
+
+import json
+import re
+from typing import Callable
+
+import httpx
+
+from backend.demo.http import json_response
+from backend.demo.store import DemoStore
+
+RouteHandler = Callable[..., httpx.Response]
+
+
+def _jobs_paginated(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    jobs = store.jobs
+    return json_response({"jobs": jobs, "total": len(jobs), "page": 1,
+                          "per_page": max(len(jobs), 25), "pages": 1})
+
+
+def _jobs_active(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(
+        {"jobs": [j for j in store.jobs if j["status"] == "active"]})
+
+
+def _jobs_stats(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.job_stats)
+
+
+def _job_detail(request: httpx.Request, store: DemoStore,
+                job_id: str) -> httpx.Response:
+    job = store.job(int(job_id))
+    if job is None:
+        return json_response({"error": "job not found"}, status=404)
+    return json_response({"job": job, "tracks": store.tracks_for(int(job_id)),
+                          "config": store.job_config})
+
+
+def _job_track_counts(request: httpx.Request, store: DemoStore,
+                      job_id: str) -> httpx.Response:
+    job = store.job(int(job_id))
+    counts = (job or {}).get("track_counts", {"total": 0, "ripped": 0})
+    return json_response(counts)
+
+
+def _drives(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"drives": store.drives})
+
+
+def _drives_with_jobs(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    # Demo drive dicts already embed `current_job`, so the with-jobs view is
+    # the same payload as /drives (no separate join needed in demo mode).
+    return json_response({"drives": store.drives})
+
+
+def _notifications(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"notifications": store.notifications})
+
+
+def _notification_count(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    unseen = sum(1 for n in store.notifications if not n["seen"])
+    total = len(store.notifications)
+    return json_response({"total": total, "unseen": unseen,
+                          "seen": total - unseen, "cleared": 0})
+
+
+def _channels(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.channels)
+
+
+def _channel(request: httpx.Request, store: DemoStore,
+             channel_id: str) -> httpx.Response:
+    ch = store.channel(int(channel_id))
+    return json_response(ch or {}, status=200 if ch else 404)
+
+
+def _dispatches(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.dispatches)
+
+
+def _services(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"services": []})
+
+
+def _config(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"config": store.config})
+
+
+def _system_info(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.system_info)
+
+
+def _system_stats(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.system_stats)
+
+
+def _system_stats_jobs(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.job_stats)
+
+
+def _setup_status(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.setup_status)
+
+
+def _ripping_enabled(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.ripping_enabled)
+
+
+def _version(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"version": "2.8.0-demo"})
+
+
+def _dismiss_all(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    for n in store.notifications:
+        n["seen"] = True
+    return json_response({"success": True})
+
+
+def _pause_job(request: httpx.Request, store: DemoStore,
+               job_id: str) -> httpx.Response:
+    job = store.job(int(job_id))
+    if job is not None:
+        job["status"] = "waiting"
+    return json_response({"success": True})
+
+
+def _start_job(request: httpx.Request, store: DemoStore,
+               job_id: str) -> httpx.Response:
+    job = store.job(int(job_id))
+    if job is not None:
+        job["status"] = "active"
+    return json_response({"success": True})
+
+
+def _logs_list(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.log_files)
+
+
+def _log_content(request: httpx.Request, store: DemoStore,
+                 filename: str) -> httpx.Response:
+    content = "\n".join(e["raw"] for e in store.log_entries)
+    return json_response({"filename": filename, "content": content,
+                          "lines": len(store.log_entries)})
+
+
+def _log_structured(request: httpx.Request, store: DemoStore,
+                    filename: str) -> httpx.Response:
+    level = request.url.params.get("level")
+    entries = store.log_entries
+    if level:
+        entries = [e for e in entries if e["level"] == level]
+    return json_response({"filename": filename, "entries": entries,
+                          "lines": len(entries)})
+
+
+def _naming_preview(request: httpx.Request, store: DemoStore,
+                    job_id: str) -> httpx.Response:
+    job = store.job(int(job_id))
+    if job is None:
+        return json_response({"error": "job not found"}, status=404)
+    title = job.get("title", "Unknown")
+    year = job.get("year", "")
+    folder = f"{title} ({year})" if year else title
+    tracks = [
+        {"track_number": t.get("track_number", str(i + 1)),
+         "filename": t.get("filename", f"title_t0{i}.mkv"),
+         "rendered_filename": f"{title} - Track {t.get('track_number', i + 1)}.mkv"}
+        for i, t in enumerate(store.tracks_for(int(job_id)))
+    ]
+    return json_response({"success": True, "job_title": title,
+                          "job_folder": folder, "tracks": tracks})
+
+
+def _files_roots(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.file_roots)
+
+
+def _files_list(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    path = request.url.params.get("path") or "/mnt/raw"
+    entries = store.file_tree.get(path, [])
+    parent = None if path in ("/", "") else path.rsplit("/", 1)[0] or "/"
+    return json_response({"path": path, "parent": parent,
+                          "entries": entries, "readonly": False})
+
+
+def _metadata_search(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.movie_search)
+
+
+def _metadata_detail(request: httpx.Request, store: DemoStore,
+                     imdb_id: str) -> httpx.Response:
+    return json_response(store.media_detail)
+
+
+def _job_metadata(request: httpx.Request, store: DemoStore,
+                  job_id: str) -> httpx.Response:
+    job = store.job(int(job_id)) or {}
+    return json_response({
+        "title": job.get("title_auto"),
+        "year": job.get("year"),
+        "imdb_id": job.get("imdb_id"),
+        "poster_url": job.get("poster_url"),
+    })
+
+
+def _music_search(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({
+        "results": store.music_search,
+        "total": len(store.music_search),
+        "offset": 0,
+    })
+
+
+def _music_detail(request: httpx.Request, store: DemoStore,
+                  release_id: str) -> httpx.Response:
+    return json_response(store.music_detail)
+
+
+def _set_ripping_enabled(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    try:
+        body = json.loads(request.content or b"{}")
+    except (ValueError, TypeError):
+        body = {}
+    if isinstance(body, dict) and "enabled" in body:
+        store.ripping_enabled["enabled"] = bool(body["enabled"])
+    else:
+        store.ripping_enabled["enabled"] = not store.ripping_enabled.get("enabled", True)
+    return json_response({"success": True,
+                          "enabled": store.ripping_enabled["enabled"]})
+
+
+ROUTES: list[tuple[str, re.Pattern[str], RouteHandler]] = [
+    ("GET", re.compile(r"^/api/v1/jobs/paginated$"), _jobs_paginated),
+    ("GET", re.compile(r"^/api/v1/jobs/active$"), _jobs_active),
+    ("GET", re.compile(r"^/api/v1/jobs/stats$"), _jobs_stats),
+    ("GET", re.compile(r"^/api/v1/jobs/(?P<job_id>\d+)/detail$"), _job_detail),
+    ("GET", re.compile(r"^/api/v1/jobs/(?P<job_id>\d+)/track-counts$"),
+     _job_track_counts),
+    ("GET", re.compile(r"^/api/v1/drives$"), _drives),
+    ("GET", re.compile(r"^/api/v1/drives/with-jobs$"), _drives_with_jobs),
+    ("GET", re.compile(r"^/api/v1/notifications$"), _notifications),
+    ("GET", re.compile(r"^/api/v1/notifications/count$"), _notification_count),
+    ("GET", re.compile(r"^/api/v1/notifications/channels$"), _channels),
+    ("GET", re.compile(r"^/api/v1/notifications/channels/(?P<channel_id>\d+)$"),
+     _channel),
+    ("GET", re.compile(r"^/api/v1/notifications/dispatches$"), _dispatches),
+    ("GET", re.compile(r"^/api/v1/notifications/services$"), _services),
+    ("GET", re.compile(r"^/api/v1/settings/config$"), _config),
+    ("GET", re.compile(r"^/api/v1/system/info$"), _system_info),
+    ("GET", re.compile(r"^/api/v1/system/stats$"), _system_stats),
+    ("GET", re.compile(r"^/api/v1/system/stats/jobs$"), _system_stats_jobs),
+    ("GET", re.compile(r"^/api/v1/system/version$"), _version),
+    ("GET", re.compile(r"^/api/v1/setup/status$"), _setup_status),
+    ("GET", re.compile(r"^/api/v1/system/ripping-enabled$"), _ripping_enabled),
+    ("GET", re.compile(r"^/api/v1/logs$"), _logs_list),
+    ("GET", re.compile(r"^/api/v1/logs/(?P<filename>[^/]+)/structured$"), _log_structured),
+    ("GET", re.compile(r"^/api/v1/logs/(?P<filename>[^/]+)$"), _log_content),
+    ("GET", re.compile(r"^/api/v1/jobs/(?P<job_id>\d+)/naming-preview$"), _naming_preview),
+    ("GET", re.compile(r"^/api/v1/jobs/(?P<job_id>\d+)/metadata$"), _job_metadata),
+    ("GET", re.compile(r"^/api/v1/files/roots$"), _files_roots),
+    ("GET", re.compile(r"^/api/v1/files/list$"), _files_list),
+    # Metadata search/detail — specific paths before generic /{imdb_id} catch-all
+    ("GET", re.compile(r"^/api/v1/metadata/search$"), _metadata_search),
+    ("GET", re.compile(r"^/api/v1/metadata/music/search$"), _music_search),
+    ("GET", re.compile(r"^/api/v1/metadata/music/(?P<release_id>[^/]+)$"), _music_detail),
+    ("GET", re.compile(r"^/api/v1/metadata/(?P<imdb_id>[^/]+)$"), _metadata_detail),
+]
+
+ROUTES += [
+    ("POST", re.compile(r"^/api/v1/notifications/dismiss-all$"), _dismiss_all),
+    ("POST", re.compile(r"^/api/v1/jobs/(?P<job_id>\d+)/pause$"), _pause_job),
+    ("POST", re.compile(r"^/api/v1/jobs/(?P<job_id>\d+)/start$"), _start_job),
+    ("POST", re.compile(r"^/api/v1/system/ripping-enabled$"), _set_ripping_enabled),
+]

--- a/backend/demo/routes_transcoder.py
+++ b/backend/demo/routes_transcoder.py
@@ -1,0 +1,114 @@
+"""Transcoder demo route table. Paths mirror backend/services/transcoder_client.py."""
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+import httpx
+
+from backend.demo.http import json_response
+from backend.demo.store import DemoStore
+
+RouteHandler = Callable[..., httpx.Response]
+
+
+def _health(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.transcoder_health)
+
+
+def _jobs(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    jobs = store.transcode_jobs
+    job_id = request.url.params.get("job_id")
+    if job_id is not None:
+        jobs = [j for j in jobs if str(j["id"]) == str(job_id)]
+    status = request.url.params.get("status")
+    if status:
+        jobs = [j for j in jobs if j["status"] == status]
+    return json_response({"jobs": jobs, "total": len(jobs)})
+
+
+def _stats(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.transcoder_stats)
+
+
+def _system_info(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"id": 1, "name": "Transcoder Demo",
+                          "cpu": "AMD Ryzen 9", "mem_total": 64.0})
+
+
+def _system_stats(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.system_stats)
+
+
+def _config(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.transcoder_config)
+
+
+def _presets(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({"presets": store.presets})
+
+
+def _handbrake_presets(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.handbrake_presets)
+
+
+def _logs_list(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response(store.log_files)
+
+
+def _log_content(request: httpx.Request, store: DemoStore,
+                 filename: str) -> httpx.Response:
+    content = "\n".join(e["raw"] for e in store.log_entries)
+    return json_response({"filename": filename, "content": content,
+                          "lines": len(store.log_entries)})
+
+
+def _log_structured(request: httpx.Request, store: DemoStore,
+                    filename: str) -> httpx.Response:
+    level = request.url.params.get("level")
+    entries = store.log_entries
+    if level:
+        entries = [e for e in entries if e["level"] == level]
+    return json_response({"filename": filename, "entries": entries,
+                          "lines": len(entries)})
+
+
+def _workers(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({
+        "max_concurrent": 4,
+        "active_count": 1,
+        "workers": [
+            {"worker_id": 1, "status": "processing", "current_job": "1",
+             "current_job_id": 1, "started_at": "2024-01-15T10:05:00Z"},
+            {"worker_id": 2, "status": "idle", "current_job": None,
+             "current_job_id": None, "started_at": None},
+        ],
+    })
+
+
+def _scheme(request: httpx.Request, store: DemoStore) -> httpx.Response:
+    return json_response({
+        "slug": "tiered-quality",
+        "name": "Tiered Quality",
+        "supported_encoders": [],
+        "supported_audio_encoders": ["aac", "mp3", "opus"],
+        "supported_subtitle_modes": ["auto", "forced", "all"],
+        "advanced_fields": {},
+    })
+
+
+ROUTES: list[tuple[str, re.Pattern[str], RouteHandler]] = [
+    ("GET", re.compile(r"^/health$"), _health),
+    ("GET", re.compile(r"^/jobs$"), _jobs),
+    ("GET", re.compile(r"^/stats$"), _stats),
+    ("GET", re.compile(r"^/system/info$"), _system_info),
+    ("GET", re.compile(r"^/system/stats$"), _system_stats),
+    ("GET", re.compile(r"^/config$"), _config),
+    ("GET", re.compile(r"^/workers$"), _workers),
+    ("GET", re.compile(r"^/api/v1/presets$"), _presets),
+    ("GET", re.compile(r"^/api/v1/handbrake-presets$"), _handbrake_presets),
+    ("GET", re.compile(r"^/api/v1/scheme$"), _scheme),
+    ("GET", re.compile(r"^/logs$"), _logs_list),
+    ("GET", re.compile(r"^/logs/(?P<filename>[^/]+)/structured$"), _log_structured),
+    ("GET", re.compile(r"^/logs/(?P<filename>[^/]+)$"), _log_content),
+]

--- a/backend/demo/store.py
+++ b/backend/demo/store.py
@@ -1,0 +1,44 @@
+"""Mutable in-memory dataset for demo mode (per-process; resets on restart)."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DemoStore:
+    jobs: list[dict] = field(default_factory=list)
+    tracks: dict[int, list[dict]] = field(default_factory=dict)  # job_id -> tracks
+    job_config: dict = field(default_factory=dict)
+    drives: list[dict] = field(default_factory=list)
+    notifications: list[dict] = field(default_factory=list)
+    channels: list[dict] = field(default_factory=list)
+    dispatches: list[dict] = field(default_factory=list)
+    transcode_jobs: list[dict] = field(default_factory=list)
+    presets: list[dict] = field(default_factory=list)
+    config: dict = field(default_factory=dict)
+    system_info: dict = field(default_factory=dict)
+    system_stats: dict = field(default_factory=dict)
+    job_stats: dict = field(default_factory=dict)
+    setup_status: dict = field(default_factory=dict)
+    ripping_enabled: dict = field(default_factory=dict)
+    transcoder_health: dict = field(default_factory=dict)
+    transcoder_stats: dict = field(default_factory=dict)
+    transcoder_config: dict = field(default_factory=dict)
+    handbrake_presets: dict = field(default_factory=dict)
+    log_files: list[dict] = field(default_factory=list)
+    log_entries: list[dict] = field(default_factory=list)
+    file_roots: list[dict] = field(default_factory=list)
+    file_tree: dict[str, list[dict]] = field(default_factory=dict)
+    movie_search: list[dict] = field(default_factory=list)
+    media_detail: dict = field(default_factory=dict)
+    music_search: list[dict] = field(default_factory=list)
+    music_detail: dict = field(default_factory=dict)
+
+    def job(self, job_id: int) -> dict | None:
+        return next((j for j in self.jobs if j["job_id"] == job_id), None)
+
+    def tracks_for(self, job_id: int) -> list[dict]:
+        return self.tracks.get(job_id, [])
+
+    def channel(self, channel_id: int) -> dict | None:
+        return next((c for c in self.channels if c["id"] == channel_id), None)

--- a/backend/demo/transport.py
+++ b/backend/demo/transport.py
@@ -1,0 +1,73 @@
+"""Custom httpx transport that serves demo data and falls through to the
+real transport (production) for unmapped routes or handler errors.
+
+A custom AsyncBaseTransport is used rather than httpx.MockTransport because
+MockTransport's handler is synchronous and cannot await the real async
+transport for the production fallthrough.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from backend.demo import routes_arm, routes_transcoder
+from backend.demo.data import build_demo_store
+from backend.demo.store import DemoStore
+
+log = logging.getLogger(__name__)
+
+# Shared singleton so ARM and transcoder views stay consistent within a process.
+_store: DemoStore | None = None
+
+
+def get_store() -> DemoStore:
+    global _store
+    if _store is None:
+        _store = build_demo_store()
+    return _store
+
+
+class DemoTransport(httpx.AsyncBaseTransport):
+    def __init__(self, service: str, real: httpx.AsyncBaseTransport):
+        if service == "arm":
+            self._routes = routes_arm.ROUTES
+        elif service == "transcoder":
+            self._routes = routes_transcoder.ROUTES
+        else:
+            raise ValueError(f"unknown demo service: {service!r}")
+        self._real = real
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        try:
+            store = get_store()
+            for method, pattern, fn in self._routes:
+                if request.method != method:
+                    continue
+                m = pattern.match(request.url.path)
+                if m:
+                    resp = fn(request, store, **m.groupdict())
+                    if resp is not None:
+                        return resp
+        except Exception:  # never serve demo on error — fall through to real
+            log.exception("demo handler error for %s %s; forwarding to real",
+                          request.method, request.url.path)
+        else:
+            # Only a genuine no-match reaches here (a matched route returns
+            # above; an error is logged in `except`). Avoid the misleading
+            # "unmapped" message on the error path.
+            log.debug("demo: unmapped %s %s -> real transport",
+                      request.method, request.url.path)
+        return await self._real.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._real.aclose()
+
+
+def make_demo_client(service: str, **client_kwargs) -> httpx.AsyncClient:
+    """Build an AsyncClient whose transport serves demo data with a real
+    transport fallback. ``client_kwargs`` are forwarded to AsyncClient
+    (base_url, timeout, headers, limits)."""
+    real = httpx.AsyncHTTPTransport()
+    return httpx.AsyncClient(transport=DemoTransport(service, real),
+                             **client_kwargs)

--- a/backend/services/arm_client.py
+++ b/backend/services/arm_client.py
@@ -18,6 +18,16 @@ _client: httpx.AsyncClient | None = None
 def get_client() -> httpx.AsyncClient:
     global _client
     if _client is None or _client.is_closed:
+        if settings.demo_mode:
+            try:
+                from backend.demo.transport import make_demo_client
+                _client = make_demo_client(
+                    "arm", base_url=settings.arm_url, timeout=10.0,
+                    limits=httpx.Limits(keepalive_expiry=30.0),
+                )
+                return _client
+            except Exception:  # never serve demo on error — use real client
+                log.exception("demo client unavailable; using real ARM client")
         # keepalive_expiry > dashboard poll cadence (5s) so connections
         # don't sit at the keepalive boundary where one side may close
         # the socket while the other still considers it alive — that

--- a/backend/services/transcoder_client.py
+++ b/backend/services/transcoder_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -45,6 +46,8 @@ def _append_z(val: str) -> str:
         return val + "Z"
     return val
 
+log = logging.getLogger(__name__)
+
 _CONFIG_ENDPOINT = "/config"
 _client: httpx.AsyncClient | None = None
 
@@ -55,6 +58,19 @@ def get_client() -> httpx.AsyncClient:
         headers = {}
         if settings.transcoder_api_key:
             headers["X-API-Key"] = settings.transcoder_api_key
+        if settings.demo_mode:
+            try:
+                from backend.demo.transport import make_demo_client
+                _client = make_demo_client(
+                    "transcoder", base_url=settings.transcoder_url,
+                    headers=headers,
+                    timeout=httpx.Timeout(15.0, connect=5.0),
+                    limits=httpx.Limits(keepalive_expiry=30.0),
+                )
+                return _client
+            except Exception:
+                log.exception(
+                    "demo client unavailable; using real transcoder client")
         # keepalive_expiry > dashboard poll cadence (5s); see arm_client.get_client
         # for the same rationale (avoids RemoteProtocolError flicker).
         _client = httpx.AsyncClient(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
     network_mode: host
     environment:
       - ARM_UI_ARM_URL=http://localhost:8080
+      # Set to "true" to serve built-in demo data with NO ARM/Transcoder
+      # present (frontend review/handoff). Default false: normal proxying.
+      - ARM_UI_DEMO_MODE=${ARM_UI_DEMO_MODE:-false}
       - ARM_UI_TRANSCODER_URL=${ARM_UI_TRANSCODER_URL:-http://localhost:5000}
       - ARM_UI_TRANSCODER_ENABLED=${ARM_UI_TRANSCODER_ENABLED:-true}
       - ARM_UI_TRANSCODER_API_KEY=${ARM_UI_TRANSCODER_API_KEY:-}

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -1,0 +1,45 @@
+# Demo Mode
+
+Run the ARM UI **standalone, fully populated with sample data** — no ARM ripper
+and no Transcoder required. Useful for frontend review, screenshots, and handoff.
+
+When `ARM_UI_DEMO_MODE=true`, the UI backend serves a built-in, deterministic
+dataset (jobs, drives, notifications, transcodes, logs, files, posters, etc.)
+instead of proxying to the real ARM/Transcoder services. The flag defaults to
+`false`, so normal deployments are unaffected.
+
+## Clone → set → run
+
+```bash
+# 1. Clone (the contracts submodule is required for the build)
+git clone --recurse-submodules https://github.com/uprightbass360/automatic-ripping-machine-ui.git
+cd automatic-ripping-machine-ui
+# (already cloned without submodules? run: git submodule update --init)
+
+# 2. Set the flag, 3. Run
+ARM_UI_DEMO_MODE=true docker compose up --build
+```
+
+Then open <http://localhost:8888>.
+
+That's it — the dashboard, job detail, transcoder, settings, notifications,
+logs, and file browser all render with sample data and no backend services
+running.
+
+## Notes
+
+- **Default is off.** Without `ARM_UI_DEMO_MODE=true` (or with `=false`) the UI
+  behaves normally and proxies to ARM (`:8080`) and the Transcoder (`:5000`).
+  You can also set it persistently in `docker-compose.yml`
+  (`ARM_UI_DEMO_MODE=${ARM_UI_DEMO_MODE:-false}`) or a `.env` file.
+- **Port / networking.** The compose service uses `network_mode: host` and
+  serves on **8888**. Stop anything already bound to 8888 first.
+- **Posters need internet.** Demo posters come from TMDB and Cover Art Archive
+  via the UI's image proxy; with no internet the UI falls back to a placeholder.
+  Everything else works fully offline.
+- **Not hermetic on a host already running ARM/Transcoder.** Any endpoint the UI
+  calls that demo mode does not map falls through to the real service if one is
+  listening on `:8080`/`:5000`. On a clean host there is nothing to fall through
+  to, so the demo is self-contained.
+- **Data resets on restart.** Demo state lives in memory; mutations (e.g. pause a
+  job, dismiss notifications) persist only for the running session.

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,79 +1,9 @@
 """Test data factories for ripper-API-shaped dicts.
 
-The UI no longer touches the ripper DB directly, so the ORM-spec mocks that
-used to live here have been retired alongside `backend/services/arm_db.py`.
-What remains is the shared `make_job_dict()` helper that produces a Job
-columns dict matching what `/api/v1/jobs/active` and `/jobs/paginated`
-return.
+Builders now live in ``backend.demo.data`` (single source of truth shared with
+demo mode). This module re-exports them so existing test imports keep working.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
-
-_JOB_DEFAULTS: dict = {
-    "job_id": 1,
-    "arm_version": "2.8.0",
-    "crc_id": "abc123",
-    "logfile": "job_1.log",
-    "start_time": datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
-    "stop_time": None,
-    "job_length": "01:30:00",
-    "status": "active",
-    "stage": "rip",
-    "no_of_titles": 5,
-    "title": "Test Movie",
-    "title_auto": "Test Movie",
-    "title_manual": None,
-    "year": "2024",
-    "year_auto": "2024",
-    "year_manual": None,
-    "video_type": "movie",
-    "video_type_auto": "movie",
-    "video_type_manual": None,
-    "imdb_id": "tt1234567",
-    "poster_url": "https://example.com/poster.jpg",
-    "devpath": "/dev/sr0",
-    "mountpoint": "/mnt/dev/sr0",
-    "hasnicetitle": True,
-    "errors": None,
-    "disctype": "dvd",
-    "label": "TEST_MOVIE",
-    "path": "/home/arm/media/Test Movie (2024)",
-    "raw_path": "/home/arm/raw/Test Movie (2024)",
-    "transcode_path": "/home/arm/transcode",
-    "source_type": None,
-    "source_path": None,
-    "ejected": False,
-    "disc_number": None,
-    "disc_total": None,
-    "pid": 12345,
-    "artist": None,
-    "artist_auto": None,
-    "artist_manual": None,
-    "album": None,
-    "album_auto": None,
-    "album_manual": None,
-    "season": None,
-    "season_auto": None,
-    "season_manual": None,
-    "episode": None,
-    "episode_auto": None,
-    "episode_manual": None,
-}
-
-
-def make_job_dict(**overrides) -> dict:
-    """Return a plain dict matching the Job-columns dict the ripper API returns.
-
-    Used by router tests that mock ``arm_client.get_jobs_paginated`` /
-    ``get_active_jobs`` / ``get_job_detail``. Includes a default
-    ``track_counts`` so JobSchema's nested-counts field is populated.
-    """
-    defaults = {
-        **_JOB_DEFAULTS,
-        "track_counts": {"total": 5, "ripped": 0},
-    }
-    defaults.update(overrides)
-    return defaults
+from backend.demo.data import make_job_dict  # noqa: F401

--- a/tests/test_demo_mode.py
+++ b/tests/test_demo_mode.py
@@ -74,7 +74,7 @@ def test_arm_routes_serve_jobs():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "GET", "/api/v1/jobs/paginated")
-    req = _httpx.Request("GET", "http://arm/api/v1/jobs/paginated")
+    req = _httpx.Request("GET", "https://arm/api/v1/jobs/paginated")
     resp = fn(req, store, **params)
     assert resp.status_code == 200
     assert len(resp.json()["jobs"]) == len(store.jobs)
@@ -85,7 +85,7 @@ def test_arm_routes_job_detail_by_id():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "GET", "/api/v1/jobs/1/detail")
-    req = _httpx.Request("GET", "http://arm/api/v1/jobs/1/detail")
+    req = _httpx.Request("GET", "https://arm/api/v1/jobs/1/detail")
     resp = fn(req, store, **params)
     assert resp.json()["job"]["job_id"] == 1
     assert "tracks" in resp.json()
@@ -96,10 +96,10 @@ def test_transcoder_routes_serve_jobs_and_health():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "GET", "/health")
-    req = _httpx.Request("GET", "http://t/health")
+    req = _httpx.Request("GET", "https://t/health")
     assert fn(req, store, **params).json()["status"] == "online"
     fn, params = _match(ROUTES, "GET", "/jobs")
-    req = _httpx.Request("GET", "http://t/jobs?status=processing")
+    req = _httpx.Request("GET", "https://t/jobs?status=processing")
     body = fn(req, store, **params).json()
     assert all(j["status"] == "processing" for j in body["jobs"])
 
@@ -109,7 +109,7 @@ def test_transcoder_jobs_filter_by_job_id():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "GET", "/jobs")
-    req = _httpx.Request("GET", "http://t/jobs?job_id=2&limit=1")
+    req = _httpx.Request("GET", "https://t/jobs?job_id=2&limit=1")
     body = fn(req, store, **params).json()
     assert len(body["jobs"]) == 1
     assert body["jobs"][0]["id"] == 2
@@ -117,7 +117,7 @@ def test_transcoder_jobs_filter_by_job_id():
 
 async def test_demo_transport_serves_mapped_route():
     from backend.demo.transport import make_demo_client
-    client = make_demo_client("arm", base_url="http://arm-test:8080", timeout=10.0)
+    client = make_demo_client("arm", base_url="https://arm-test:8080", timeout=10.0)
     try:
         resp = await client.get("/api/v1/jobs/active")
         assert resp.status_code == 200
@@ -129,7 +129,7 @@ async def test_demo_transport_serves_mapped_route():
 async def test_demo_transport_unmapped_falls_through_to_real():
     """Unmapped path must hit the real transport (production), not demo data."""
     from backend.demo.transport import make_demo_client
-    client = make_demo_client("arm", base_url="http://127.0.0.1:1/nope", timeout=0.5)
+    client = make_demo_client("arm", base_url="https://127.0.0.1:1/nope", timeout=0.5)
     try:
         with pytest.raises(_httpx.HTTPError):
             await client.get("/api/v1/this/path/is/not/mapped")
@@ -243,7 +243,7 @@ def test_demo_mutation_dismiss_all_marks_seen():
     store = build_demo_store()
     assert any(not n["seen"] for n in store.notifications)
     fn, params = _match(ROUTES, "POST", "/api/v1/notifications/dismiss-all")
-    req = _httpx.Request("POST", "http://arm/api/v1/notifications/dismiss-all")
+    req = _httpx.Request("POST", "https://arm/api/v1/notifications/dismiss-all")
     resp = fn(req, store, **params)
     assert resp.status_code == 200
     assert all(n["seen"] for n in store.notifications)
@@ -254,11 +254,11 @@ def test_demo_mutation_pause_and_start_job():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "POST", "/api/v1/jobs/1/pause")
-    req = _httpx.Request("POST", "http://arm/api/v1/jobs/1/pause")
+    req = _httpx.Request("POST", "https://arm/api/v1/jobs/1/pause")
     assert fn(req, store, **params).json()["success"] is True
     assert store.job(1)["status"] == "waiting"
     fn, params = _match(ROUTES, "POST", "/api/v1/jobs/1/start")
-    req = _httpx.Request("POST", "http://arm/api/v1/jobs/1/start")
+    req = _httpx.Request("POST", "https://arm/api/v1/jobs/1/start")
     assert fn(req, store, **params).json()["success"] is True
     assert store.job(1)["status"] == "active"
 
@@ -268,7 +268,7 @@ def test_demo_mutation_set_ripping_enabled_honors_body():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "POST", "/api/v1/system/ripping-enabled")
-    req = _httpx.Request("POST", "http://arm/api/v1/system/ripping-enabled",
+    req = _httpx.Request("POST", "https://arm/api/v1/system/ripping-enabled",
                          json={"enabled": False})
     resp = fn(req, store, **params)
     assert resp.json()["enabled"] is False
@@ -280,13 +280,13 @@ def test_demo_log_routes_structured_and_content():
     from backend.demo.data import build_demo_store
     store = build_demo_store()
     fn, params = _match(ROUTES, "GET", "/api/v1/logs/job_1.log/structured")
-    req = _httpx.Request("GET", "http://arm/api/v1/logs/job_1.log/structured")
+    req = _httpx.Request("GET", "https://arm/api/v1/logs/job_1.log/structured")
     body = fn(req, store, **params).json()
     assert body["filename"] == "job_1.log"
     assert len(body["entries"]) >= 1
     assert {"timestamp", "level", "event", "raw"} <= set(body["entries"][0])
     fn, params = _match(ROUTES, "GET", "/api/v1/logs/job_1.log")
-    req = _httpx.Request("GET", "http://arm/api/v1/logs/job_1.log")
+    req = _httpx.Request("GET", "https://arm/api/v1/logs/job_1.log")
     c = fn(req, store, **params).json()
     assert c["filename"] == "job_1.log" and c["lines"] >= 1
     fn, params = _match(ROUTES, "GET", "/api/v1/logs")

--- a/tests/test_demo_mode.py
+++ b/tests/test_demo_mode.py
@@ -1,0 +1,419 @@
+"""Demo mode: flag, transport wiring, production fallback, and seed data."""
+from __future__ import annotations
+
+
+def test_demo_mode_defaults_false():
+    from backend.config import Settings
+    assert Settings().demo_mode is False
+
+
+def test_factories_make_job_dict_is_demo_builder():
+    """tests/factories.py must re-export the demo builder (no drift)."""
+    import tests.factories as factories
+    import backend.demo.data as demo_data
+    assert factories.make_job_dict is demo_data.make_job_dict
+
+
+def test_make_job_dict_has_core_fields():
+    from backend.demo.data import make_job_dict
+    job = make_job_dict(job_id=7, title="Demo")
+    assert job["job_id"] == 7
+    assert job["title"] == "Demo"
+    assert job["track_counts"] == {"total": 5, "ripped": 0}
+
+
+def test_entity_builders_exist():
+    from backend.demo import data
+    assert data.make_track_dict(track_id=1, job_id=1)["job_id"] == 1
+    assert data.make_drive_dict(drive_id=2)["drive_id"] == 2
+    assert data.make_notification_dict(id=3)["id"] == 3
+    assert data.make_channel_dict(id=4, type="webhook")["type"] == "webhook"
+    assert data.make_dispatch_dict(id=5, channel_id=4)["channel_id"] == 4
+    assert data.make_transcode_job_dict(id=6)["status"] == "processing"
+    assert data.make_preset_dict(slug="h264-fast")["slug"] == "h264-fast"
+
+
+def test_build_demo_store_covers_states():
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    statuses = {j["status"] for j in store.jobs}
+    assert {"active", "waiting", "success", "fail"} <= statuses
+    disctypes = {j["disctype"] for j in store.jobs}
+    assert {"dvd", "bluray", "music"} <= disctypes
+    assert any(j["status"] == "active" for j in store.jobs)
+    assert len(store.drives) >= 2
+    assert any(n["seen"] is False for n in store.notifications)
+    assert {c["type"] for c in store.channels} == {"apprise", "webhook", "bash"}
+    assert any(t["status"] == "processing" for t in store.transcode_jobs)
+    assert store.setup_status["first_run"] is False
+
+
+def test_store_job_lookup_and_tracks():
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    jid = store.jobs[0]["job_id"]
+    assert store.job(jid)["job_id"] == jid
+    assert isinstance(store.tracks_for(jid), list)
+
+
+import pytest
+import httpx as _httpx
+
+
+def _match(routes, method, path):
+    for m, pattern, fn in routes:
+        if m == method:
+            got = pattern.match(path)
+            if got:
+                return fn, got.groupdict()
+    return None, None
+
+
+def test_arm_routes_serve_jobs():
+    from backend.demo.routes_arm import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "GET", "/api/v1/jobs/paginated")
+    req = _httpx.Request("GET", "http://arm/api/v1/jobs/paginated")
+    resp = fn(req, store, **params)
+    assert resp.status_code == 200
+    assert len(resp.json()["jobs"]) == len(store.jobs)
+
+
+def test_arm_routes_job_detail_by_id():
+    from backend.demo.routes_arm import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "GET", "/api/v1/jobs/1/detail")
+    req = _httpx.Request("GET", "http://arm/api/v1/jobs/1/detail")
+    resp = fn(req, store, **params)
+    assert resp.json()["job"]["job_id"] == 1
+    assert "tracks" in resp.json()
+
+
+def test_transcoder_routes_serve_jobs_and_health():
+    from backend.demo.routes_transcoder import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "GET", "/health")
+    req = _httpx.Request("GET", "http://t/health")
+    assert fn(req, store, **params).json()["status"] == "online"
+    fn, params = _match(ROUTES, "GET", "/jobs")
+    req = _httpx.Request("GET", "http://t/jobs?status=processing")
+    body = fn(req, store, **params).json()
+    assert all(j["status"] == "processing" for j in body["jobs"])
+
+
+def test_transcoder_jobs_filter_by_job_id():
+    from backend.demo.routes_transcoder import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "GET", "/jobs")
+    req = _httpx.Request("GET", "http://t/jobs?job_id=2&limit=1")
+    body = fn(req, store, **params).json()
+    assert len(body["jobs"]) == 1
+    assert body["jobs"][0]["id"] == 2
+
+
+async def test_demo_transport_serves_mapped_route():
+    from backend.demo.transport import make_demo_client
+    client = make_demo_client("arm", base_url="http://arm-test:8080", timeout=10.0)
+    try:
+        resp = await client.get("/api/v1/jobs/active")
+        assert resp.status_code == 200
+        assert "jobs" in resp.json()
+    finally:
+        await client.aclose()
+
+
+async def test_demo_transport_unmapped_falls_through_to_real():
+    """Unmapped path must hit the real transport (production), not demo data."""
+    from backend.demo.transport import make_demo_client
+    client = make_demo_client("arm", base_url="http://127.0.0.1:1/nope", timeout=0.5)
+    try:
+        with pytest.raises(_httpx.HTTPError):
+            await client.get("/api/v1/this/path/is/not/mapped")
+    finally:
+        await client.aclose()
+
+
+def test_get_client_off_uses_real_transport(monkeypatch):
+    from backend.config import settings
+    from backend.services import arm_client
+    monkeypatch.setattr(settings, "demo_mode", False)
+    arm_client._client = None
+    client = arm_client.get_client()
+    from backend.demo.transport import DemoTransport
+    assert not isinstance(client._transport, DemoTransport)
+
+
+def test_get_client_on_uses_demo_transport(monkeypatch):
+    from backend.config import settings
+    from backend.services import arm_client, transcoder_client
+    from backend.demo.transport import DemoTransport
+    monkeypatch.setattr(settings, "demo_mode", True)
+    arm_client._client = None
+    transcoder_client._client = None
+    assert isinstance(arm_client.get_client()._transport, DemoTransport)
+    assert isinstance(transcoder_client.get_client()._transport, DemoTransport)
+
+
+def test_demo_transport_rejects_unknown_service():
+    from backend.demo.transport import DemoTransport
+    with pytest.raises(ValueError):
+        DemoTransport("bogus", _httpx.AsyncHTTPTransport())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests: real FastAPI app with demo mode ON
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def demo_on(monkeypatch):
+    """Enable demo mode and reset client singletons so get_client() returns
+    the demo transport for both ARM and transcoder."""
+    from backend.config import settings
+    from backend.services import arm_client, transcoder_client
+    monkeypatch.setattr(settings, "demo_mode", True)
+    arm_client._client = None
+    transcoder_client._client = None
+    yield
+
+
+async def test_dashboard_populated_in_demo(demo_on, app_client):
+    """GET /api/dashboard returns 200 with active jobs and a notification count."""
+    resp = await app_client.get("/api/dashboard")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # active_jobs may be None when ARM is unreachable, but in demo mode it must
+    # be a populated list (the demo store has at least one active job).
+    assert body["active_jobs"] is not None
+    assert len(body["active_jobs"]) >= 1
+    # notification_count reflects unseen demo notifications.
+    assert body["notification_count"] is not None
+    assert body["notification_count"] >= 1
+    # active_transcodes is always a list; demo has a processing transcode job.
+    assert len(body["active_transcodes"]) >= 1
+
+
+async def test_jobs_list_and_detail_in_demo(demo_on, app_client):
+    """GET /api/jobs returns >= 4 jobs; GET /api/jobs/{id} returns 200."""
+    listing = await app_client.get("/api/jobs")
+    assert listing.status_code == 200, listing.text
+    body = listing.json()
+    # Response is JobListResponse: {jobs, total, page, per_page, pages}
+    jobs = body["jobs"]
+    assert len(jobs) >= 4, f"expected >= 4 jobs, got {len(jobs)}"
+    # Pydantic serialised each job through JobSchema — spot-check required fields.
+    first = jobs[0]
+    assert "job_id" in first
+    assert "status" in first
+    assert "disctype" in first
+    # Fetch the detail for the first job.
+    detail_resp = await app_client.get(f"/api/jobs/{first['job_id']}")
+    assert detail_resp.status_code == 200, detail_resp.text
+    detail = detail_resp.json()
+    assert detail["job_id"] == first["job_id"]
+    # JobDetailSchema adds tracks and config on top of JobSchema.
+    assert "tracks" in detail
+    assert isinstance(detail["tracks"], list)
+
+
+async def test_drives_and_notification_channels_in_demo(demo_on, app_client):
+    """GET /api/drives returns >= 2 drives; GET /api/notifications/channels
+    returns all three channel types (apprise, webhook, bash)."""
+    drives_resp = await app_client.get("/api/drives")
+    assert drives_resp.status_code == 200, drives_resp.text
+    drives = drives_resp.json()
+    # Response is list[DriveSchema].
+    assert isinstance(drives, list)
+    assert len(drives) >= 2
+    assert all("drive_id" in d for d in drives)
+
+    chans_resp = await app_client.get("/api/notifications/channels")
+    assert chans_resp.status_code == 200, chans_resp.text
+    chans = chans_resp.json()
+    assert isinstance(chans, list)
+    assert {c["type"] for c in chans} == {"apprise", "webhook", "bash"}
+
+
+def test_demo_mutation_dismiss_all_marks_seen():
+    from backend.demo.routes_arm import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    assert any(not n["seen"] for n in store.notifications)
+    fn, params = _match(ROUTES, "POST", "/api/v1/notifications/dismiss-all")
+    req = _httpx.Request("POST", "http://arm/api/v1/notifications/dismiss-all")
+    resp = fn(req, store, **params)
+    assert resp.status_code == 200
+    assert all(n["seen"] for n in store.notifications)
+
+
+def test_demo_mutation_pause_and_start_job():
+    from backend.demo.routes_arm import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "POST", "/api/v1/jobs/1/pause")
+    req = _httpx.Request("POST", "http://arm/api/v1/jobs/1/pause")
+    assert fn(req, store, **params).json()["success"] is True
+    assert store.job(1)["status"] == "waiting"
+    fn, params = _match(ROUTES, "POST", "/api/v1/jobs/1/start")
+    req = _httpx.Request("POST", "http://arm/api/v1/jobs/1/start")
+    assert fn(req, store, **params).json()["success"] is True
+    assert store.job(1)["status"] == "active"
+
+
+def test_demo_mutation_set_ripping_enabled_honors_body():
+    from backend.demo.routes_arm import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "POST", "/api/v1/system/ripping-enabled")
+    req = _httpx.Request("POST", "http://arm/api/v1/system/ripping-enabled",
+                         json={"enabled": False})
+    resp = fn(req, store, **params)
+    assert resp.json()["enabled"] is False
+    assert store.ripping_enabled["enabled"] is False
+
+
+def test_demo_log_routes_structured_and_content():
+    from backend.demo.routes_arm import ROUTES
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    fn, params = _match(ROUTES, "GET", "/api/v1/logs/job_1.log/structured")
+    req = _httpx.Request("GET", "http://arm/api/v1/logs/job_1.log/structured")
+    body = fn(req, store, **params).json()
+    assert body["filename"] == "job_1.log"
+    assert len(body["entries"]) >= 1
+    assert {"timestamp", "level", "event", "raw"} <= set(body["entries"][0])
+    fn, params = _match(ROUTES, "GET", "/api/v1/logs/job_1.log")
+    req = _httpx.Request("GET", "http://arm/api/v1/logs/job_1.log")
+    c = fn(req, store, **params).json()
+    assert c["filename"] == "job_1.log" and c["lines"] >= 1
+    fn, params = _match(ROUTES, "GET", "/api/v1/logs")
+    assert _match(ROUTES, "GET", "/api/v1/logs/job_1.log/structured")[0] is not None
+
+
+async def test_demo_structured_log_through_app(demo_on, app_client):
+    resp = await app_client.get("/api/logs/job_1.log/structured")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["filename"] == "job_1.log"
+    assert len(body["entries"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: every page-level endpoint must return 200 in demo mode
+# ---------------------------------------------------------------------------
+
+DEMO_ENDPOINTS = [
+    "/api/dashboard",
+    "/api/metadata/search?q=Blade%20Runner",
+    "/api/metadata/tt1856101",
+    "/api/jobs/4/metadata",
+    "/api/metadata/music/search?q=Abbey%20Road",
+    "/api/metadata/music/abbey-road-1",
+    "/api/jobs",
+    "/api/jobs/1",
+    "/api/jobs/3",
+    "/api/jobs/3/naming-preview",
+    "/api/drives",
+    "/api/notifications",
+    "/api/notifications/channels",
+    "/api/config",
+    "/api/settings",
+    "/api/settings/transcoder/scheme",
+    "/api/settings/transcoder/presets",
+    "/api/logs",
+    "/api/logs/job_1.log/structured",
+    "/api/transcoder/jobs",
+    "/api/transcoder/stats",
+    "/api/transcoder/workers",
+    "/api/transcoder/logs",
+    "/api/transcoder/logs/transcode_1.log/structured",
+    "/api/files/roots",
+    "/api/files/list?path=/mnt/raw",
+]
+
+
+@pytest.mark.parametrize("path", DEMO_ENDPOINTS)
+async def test_demo_endpoint_returns_200(demo_on, app_client, path):
+    resp = await app_client.get(path)
+    assert resp.status_code == 200, f"{path} -> {resp.status_code}: {resp.text[:300]}"
+    # The SPA catch-all also returns 200 but with text/html; a real API
+    # response must be JSON. This catches endpoints that fall through to the
+    # SPA (e.g. a route whose path param can't match the requested value).
+    assert resp.headers["content-type"].startswith("application/json"), (
+        f"{path} returned {resp.headers['content-type']} (SPA fallthrough?)"
+    )
+
+
+async def test_demo_file_browser(demo_on, app_client):
+    roots = await app_client.get("/api/files/roots")
+    assert roots.status_code == 200
+    assert any(r["path"] == "/mnt/raw" for r in roots.json())
+    listing = await app_client.get("/api/files/list?path=/mnt/raw")
+    assert listing.status_code == 200
+    body = listing.json()
+    assert body["path"] == "/mnt/raw"
+    assert len(body["entries"]) >= 1
+    assert any(e["type"] == "directory" for e in body["entries"])
+
+
+def test_demo_transcode_logfiles_are_slash_free():
+    """Transcode-job logfiles must be bare basenames. The UI's
+    /transcoder/logs/{filename}/structured route is a single path segment;
+    an absolute path (with slashes) gets percent-encoded and never matches,
+    so the frontend's log fetch falls through to the SPA and breaks the card."""
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    for job in store.transcode_jobs:
+        assert "/" not in job["logfile"], job["logfile"]
+
+
+def test_demo_poster_hosts_are_proxy_allowed():
+    from urllib.parse import urlparse
+    from backend.routers.images import _ALLOWED_IMAGE_HOSTS
+    from backend.demo.data import build_demo_store
+    store = build_demo_store()
+    items = list(store.jobs) + list(store.transcode_jobs)
+    posters = [i["poster_url"] for i in items if i.get("poster_url")]
+    assert posters, "expected at least one real poster"
+    for url in posters:
+        assert url.startswith("https://"), url
+        assert urlparse(url).hostname in _ALLOWED_IMAGE_HOSTS, url
+
+
+async def test_demo_job_poster_survives_schema(demo_on, app_client):
+    resp = await app_client.get("/api/jobs/1")
+    assert resp.status_code == 200
+    assert resp.json()["poster_url"] == (
+        "https://image.tmdb.org/t/p/w500/gajva2L0rPYkEWjzgFlBXCAVBE5.jpg"
+    )
+
+
+async def test_demo_music_search_has_valid_covers(demo_on, app_client):
+    from urllib.parse import urlparse
+    from backend.routers.images import _ALLOWED_IMAGE_HOSTS
+    resp = await app_client.get("/api/metadata/music/search?q=Abbey%20Road")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results
+    for r in results:
+        if r.get("poster_url"):
+            assert "front-500" in r["poster_url"]  # not the 404-prone front-250
+            assert urlparse(r["poster_url"]).hostname in _ALLOWED_IMAGE_HOSTS
+
+
+def test_metadata_routes_dispatch_unambiguously():
+    from backend.demo.routes_arm import ROUTES
+
+    def match(path):
+        for m, pat, fn in ROUTES:
+            if m == "GET" and pat.match(path):
+                return fn.__name__
+        return None
+
+    assert match("/api/v1/metadata/search") == "_metadata_search"
+    assert match("/api/v1/metadata/music/search") == "_music_search"
+    assert match("/api/v1/metadata/tt123") == "_metadata_detail"
+    assert match("/api/v1/metadata/music/rel-1") == "_music_detail"


### PR DESCRIPTION
## Summary

Adds a runtime **`ARM_UI_DEMO_MODE`** flag (default `false`) that makes the stateless UI backend serve a rich, deterministic in-memory dataset with **no ARM-neu or Transcoder upstream present** — for frontend review/handoff.

When the flag is on, each service client's `get_client()` returns an `httpx.AsyncClient` wired to a custom `AsyncBaseTransport` (`DemoTransport`) that serves demo data for mapped `(method, path)` routes and **falls through to the real transport for anything unmapped or on error**. Production is always the default and the failure state — demo data is never the fallback. Responses flow through the real routers + `arm_contracts`/Pydantic validation unchanged.

## What's covered

Every page is exercised with seed data:
- Dashboard, job list, job detail (all statuses/stages/disc types, incl. episode matching)
- Drives, notifications + channels (apprise/webhook/bash)
- Transcoder (jobs/stats/workers/scheme/presets/config), settings, system, setup
- Logs (ARM + transcoder), file browser, naming preview
- Movie **Identify** + **music search** metadata
- Real posters (TMDB) and album art (Cover Art Archive) via the existing image proxy
- Stateful mutations (dismiss-all, pause/start, ripping toggle) update the in-memory store within a session

## Design guarantees

- **Production is the default & failure state** — flag-off path is byte-identical to before; unmapped routes / construction errors fall through to the real client, never fabricated data.
- **No drift** — `tests/factories.py` re-exports the job builder from `backend/demo/data.py` (single source of truth).
- **Isolation** — all demo code lives in `backend/demo/`; the import is deferred inside `get_client()`, so production import-time is untouched.

## Test plan

- [ ] `test` job (full pytest suite, 750+ tests) passes — includes flag-default inertness, production-fallthrough, per-endpoint `200 + application/json` through the app, and poster/cover host-allowlist guards.
- [ ] `test-pr-build` (Docker image builds).
- [ ] Manual: `ARM_UI_DEMO_MODE=true docker compose up --build` → every page renders populated with no ARM/transcoder running (verified locally via Playwright across all routes).
