### PR TITLE
build: consume contracts via BuildKit named context

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -50,6 +50,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          build-contexts: |
+            contracts=components/contracts
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -63,6 +63,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          build-contexts: |
+            contracts=components/contracts
           push: true
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha

--- a/.github/workflows/test-pr-image-build.yml
+++ b/.github/workflows/test-pr-image-build.yml
@@ -27,5 +27,7 @@ jobs:
         with:
           push: false
           context: .
+          build-contexts: |
+            contracts=components/contracts
           platforms: linux/amd64,linux/arm64
           tags: arm-ui:pr${{ github.event.number }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.opencontainers.image.description="Replacement dashboard for ARM (Svelt
 WORKDIR /app
 
 COPY requirements.txt .
-COPY components/contracts components/contracts
+COPY --from=contracts . components/contracts
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY VERSION .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@
 
 services:
   arm-ui:
-    build: .
+    build:
+      context: .
+      additional_contexts:
+        contracts: ./components/contracts
     network_mode: host
     environment:
       - ARM_UI_ARM_URL=http://localhost:8080


### PR DESCRIPTION
## Summary
- Switch the `contracts` dependency in `Dockerfile` (python stage) from `COPY components/contracts components/contracts` to a BuildKit **named build context**: `COPY --from=contracts . components/contracts`.
- Expand `docker-compose.yml` `build:` to add `additional_contexts: { contracts: ./components/contracts }`.
- Add `build-contexts: contracts=components/contracts` to every image-building CI step (publish-image, publish-prerelease, test-pr-image-build).

**Why:** Makes the Dockerfile byte-identical whether built standalone (this repo, where the `components/contracts` submodule supplies the context) or inside the `automatic-ripping-machine` v3 monorepo (sibling `contracts` subtree). The node build stage is untouched; the submodule stays the content source; `requirements.txt` (`-e components/contracts`) is unchanged.

## Test Plan
- [x] `docker compose config -q` parses
- [x] `contracts` named context resolves in a real BuildKit build (verified in the monorepo umbrella)
- [x] All three workflow YAMLs parse; `requirements.txt` unchanged
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)