### PR TITLE
security: prevent open redirect in poster-proxy

### DIFF
--- a/backend/routers/folder.py
+++ b/backend/routers/folder.py
@@ -1,5 +1,6 @@
 """Folder import proxy - routes folder scan/create through the ARM backend."""
 from typing import Any
+from urllib.parse import quote, urlparse
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import RedirectResponse
@@ -38,7 +39,29 @@ async def create_folder_job(req: FolderCreateRequest) -> dict[str, Any]:
     return _check_result(await arm_client.create_folder_job(req.model_dump()))
 
 
+def _safe_proxy_redirect(url: str) -> str:
+    """Return a safe same-app redirect to the image proxy.
+
+    Poster URLs are legitimately absolute (e.g. https://image.tmdb.org/...),
+    so they are allowed — but the redirect *target* is always the hardcoded
+    same-app path ``/api/images/proxy`` and the caller-supplied URL is only
+    ever a percent-encoded query-string value. That prevents an open redirect
+    (the Location path/host is constant and the value can't break out of the
+    query string). Only http(s) poster URLs are accepted so the downstream
+    proxy can never be pointed at file://, gopher://, etc.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid url parameter: must be an http(s) URL.",
+        )
+    # percent-encode the value so it stays confined to the query string
+    safe_url = quote(url, safe="")
+    return f"/api/images/proxy?url={safe_url}"
+
+
 @router.get("/poster-proxy")
 async def poster_proxy_redirect(url: str = Query(..., description="Poster image URL")):
     """Redirect to new image proxy endpoint (backward compatibility)."""
-    return RedirectResponse(f"/api/images/proxy?url={url}", status_code=301)
+    return RedirectResponse(_safe_proxy_redirect(url), status_code=301)


### PR DESCRIPTION
Fixes the CodeQL "URL redirection from remote source" finding in `backend/routers/folder.py`.

The `poster-proxy` redirect now always targets the constant same-app path `/api/images/proxy`, with the caller-supplied poster URL percent-encoded into the query string (so it cannot alter the Location path/host), and only http(s) URLs are accepted (blocks file://, javascript:, etc.). Legitimate absolute poster URLs continue to work.