### PR TITLE
security: confine user-controlled paths to trusted roots (path traversal)

### DIFF
--- a/backend/common/__init__.py
+++ b/backend/common/__init__.py
@@ -1,0 +1,1 @@
+# backend/common — shared utilities

--- a/backend/common/path_safety.py
+++ b/backend/common/path_safety.py
@@ -1,0 +1,22 @@
+"""Path traversal prevention utilities."""
+
+import os
+
+
+def safe_join(base: str | os.PathLike, *user_parts: str | os.PathLike) -> str:
+    """Join user-supplied parts onto a trusted base directory and guarantee
+    the result stays inside that base.
+
+    Uses os.path.realpath for both sides so symlinks are resolved before the
+    containment check — the pattern recognised by CodeQL as a path-traversal
+    sanitizer.
+
+    Returns the validated absolute path string.
+    Raises ValueError if the resolved target escapes base.
+    """
+    base_real = os.path.realpath(os.fspath(base))
+    joined = os.path.join(base_real, *[os.fspath(p) for p in user_parts])
+    target = os.path.realpath(joined)
+    if target != base_real and not target.startswith(base_real + os.sep):
+        raise ValueError(f"Path traversal: target escapes base {base_real!r}")
+    return target

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from backend.common.path_safety import safe_join
+
 from backend.routers import (
     arm_actions,
     config,
@@ -85,14 +87,17 @@ if static_dir.is_dir():
         app.mount("/img", StaticFiles(directory=str(img_dir)), name="images")
 
     # Serve root-level static files (favicon, apple-touch-icon, etc.)
-    resolved_static = static_dir.resolve()
 
     @app.get("/{filename:path}")
     async def root_static_or_spa(request: Request, filename: str):
         if filename:
-            file_path = (static_dir / filename).resolve()
-            if file_path.is_relative_to(resolved_static) and file_path.is_file():
-                return FileResponse(file_path)
+            try:
+                file_path = safe_join(static_dir, filename)
+            except ValueError:
+                pass
+            else:
+                if Path(file_path).is_file():
+                    return FileResponse(file_path)
         return FileResponse(
             static_dir / "index.html",
             headers={"Cache-Control": "no-cache"},

--- a/backend/services/themes.py
+++ b/backend/services/themes.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from backend.common.path_safety import safe_join
 from backend.config import settings
 
 # Built-in themes ship with the package
@@ -39,11 +40,12 @@ def _safe_theme_id(theme_id: str) -> str:
 
 
 def _safe_path(directory: Path, filename: str) -> Path:
-    """Build a path inside *directory* and verify it resolves within it."""
-    target = (directory / filename).resolve()
-    if not str(target).startswith(str(directory.resolve())):
-        raise ValueError(f"Path traversal detected: {filename!r}")
-    return target
+    """Build a path inside *directory* and verify it resolves within it.
+
+    Delegates to safe_join so the realpath+containment pattern is consistent
+    across the codebase and recognised by static analysis tools.
+    """
+    return Path(safe_join(directory, filename))
 
 
 def _validate_theme(data: Any) -> bool:
@@ -111,11 +113,8 @@ def save_user_theme(data: dict[str, Any], css: str = "") -> dict[str, Any]:
     data.setdefault("swatch", "#888888")
 
     user_dir = _user_themes_dir()
-    resolved_dir = user_dir.resolve()
-    json_path = (user_dir / f"{theme_id}.json").resolve()
-    css_path = (user_dir / f"{theme_id}.css").resolve()
-    if not str(json_path).startswith(str(resolved_dir)) or not str(css_path).startswith(str(resolved_dir)):
-        raise ValueError(f"Path traversal detected: {theme_id!r}")
+    json_path = Path(safe_join(user_dir, f"{theme_id}.json"))
+    css_path = Path(safe_join(user_dir, f"{theme_id}.css"))
 
     # Save JSON without css or builtin fields
     save_data = {k: v for k, v in data.items() if k not in ("builtin", "css")}
@@ -136,18 +135,13 @@ def save_user_theme(data: dict[str, Any], css: str = "") -> dict[str, Any]:
 def delete_user_theme(theme_id: str) -> bool:
     """Delete a user theme. Returns False if it's a built-in or doesn't exist."""
     theme_id = _safe_theme_id(theme_id)
-    builtin_path = (_BUILTIN_DIR / f"{theme_id}.json").resolve()
-    if not str(builtin_path).startswith(str(_BUILTIN_DIR.resolve())):
-        raise ValueError(f"Path traversal detected: {theme_id!r}")
+    builtin_path = Path(safe_join(_BUILTIN_DIR, f"{theme_id}.json"))
     if builtin_path.exists():
         return False
 
     user_dir = _user_themes_dir()
-    resolved_dir = user_dir.resolve()
-    json_path = (user_dir / f"{theme_id}.json").resolve()
-    css_path = (user_dir / f"{theme_id}.css").resolve()
-    if not str(json_path).startswith(str(resolved_dir)) or not str(css_path).startswith(str(resolved_dir)):
-        raise ValueError(f"Path traversal detected: {theme_id!r}")
+    json_path = Path(safe_join(user_dir, f"{theme_id}.json"))
+    css_path = Path(safe_join(user_dir, f"{theme_id}.css"))
     if not json_path.exists():
         return False
 


### PR DESCRIPTION
Phase 2 — clears the CodeQL "uncontrolled data used in path expression" findings.

- New `backend/common/path_safety.py` (`safe_join`) — `os.path.realpath` + containment (CodeQL-recognized sanitizer).
- `services/themes.py` — `_safe_path`, `save_user_theme`, `delete_user_theme` now route theme json/css paths through `safe_join` against the themes dir.
- `main.py` — static/SPA file serving confined to the static dir via `safe_join`.

Verified: py_compile clean; contracts tests pass (203). No theme/main-specific backend tests exist.