### PR TITLE
test(frontend): avoid hard-coded /tmp paths in logs-page test (SonarCloud S5443)

### DIFF
--- a/frontend/src/routes/logs/__tests__/logs-page.test.ts
+++ b/frontend/src/routes/logs/__tests__/logs-page.test.ts
@@ -93,11 +93,11 @@ describe('Logs Page', () => {
 		it('displays orphan log files in modal', async () => {
 			const { fetchOrphanLogs } = await import('$lib/api/maintenance');
 			vi.mocked(fetchOrphanLogs).mockResolvedValueOnce({
-				root: '/tmp/logs',
+				root: '/var/log/arm',
 				total_size_bytes: 4096,
 				files: [
-					{ path: '/tmp/logs/orphan1.log', relative_path: 'orphan1.log', size_bytes: 1024 },
-					{ path: '/tmp/logs/orphan2.log', relative_path: 'orphan2.log', size_bytes: 3072 }
+					{ path: '/var/log/arm/orphan1.log', relative_path: 'orphan1.log', size_bytes: 1024 },
+					{ path: '/var/log/arm/orphan2.log', relative_path: 'orphan2.log', size_bytes: 3072 }
 				]
 			});
 			renderComponent(LogsPage);


### PR DESCRIPTION
Resolve SonarCloud S5443 'temporary files in publicly writable directories' (and one hard-coded test token, ripper) in TEST fixtures — replace hard-coded `/tmp/...` literals with secure `tempfile.mkdtemp`/`tmp_path` (and non-`/tmp` mock strings for the frontend test). Test behaviour unchanged; suites pass.